### PR TITLE
Fix for texture added to not color groups

### DIFF
--- a/src/Ps_FacetedsearchFiltersConverter.php
+++ b/src/Ps_FacetedsearchFiltersConverter.php
@@ -40,7 +40,7 @@ class Ps_FacetedsearchFiltersConverter
                             ->setMagnitude($filterArray['nbr'])
                             ->setValue($id)
                         ;
-                        
+
                         if (isset($facetArray['is_color_group']) && $facetArray['is_color_group']){
                             if (isset($filterArray['color']) && $filterArray['color'] != '') {
                                 $filter->setProperty('color', $filterArray['color']);
@@ -49,7 +49,7 @@ class Ps_FacetedsearchFiltersConverter
                                 $filter->setProperty('texture', _THEME_COL_DIR_.$id.'.jpg');
                             }
                         }
-                        
+
                         $facet->addFilter($filter);
                     }
                     break;

--- a/src/Ps_FacetedsearchFiltersConverter.php
+++ b/src/Ps_FacetedsearchFiltersConverter.php
@@ -40,13 +40,16 @@ class Ps_FacetedsearchFiltersConverter
                             ->setMagnitude($filterArray['nbr'])
                             ->setValue($id)
                         ;
-                        if (isset($filterArray['color']) && $filterArray['color'] != '') {
-                            $filter->setProperty('color', $filterArray['color']);
+                        
+                        if (isset($facetArray['is_color_group']) && $facetArray['is_color_group']){
+                            if (isset($filterArray['color']) && $filterArray['color'] != '') {
+                                $filter->setProperty('color', $filterArray['color']);
+                            }
+                            if (isset($filterArray['url_name']) && $filterArray['url_name'] != '') {
+                                $filter->setProperty('texture', _THEME_COL_DIR_.$id.'.jpg');
+                            }
                         }
-
-                        if (isset($filterArray['url_name']) && $filterArray['url_name'] != '') {
-                            $filter->setProperty('texture', _THEME_COL_DIR_.$id.'.jpg');
-                        }
+                        
                         $facet->addFilter($filter);
                     }
                     break;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | allow to setProperty('color') only for color or textures factets
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | yes or no ?
| Deprecations? | yes or no ?
| Fixed ticket? | [BOOM-3454](http://forge.prestashop.com/browse/BOOM-3454)
| How to test?  | before fix attributes in facated search are treated as color options so they design is bad

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/26)
<!-- Reviewable:end -->
