### PR TITLE
Creation of better ranges

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -960,14 +960,23 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 $values[] = '('.(int) $id_product.',
 					'.(int) $currency['id_currency'].',
 					'.$id_shop.',
-					'.(int) $min_price[$currency['id_currency']].',
-					'.(int) Tools::ps_round($max_price[$currency['id_currency']] * (100 + $max_tax_rate) / 100, 0).')';
+					'.(int) Ps_Facetedsearch::taxPrice($min_price[$currency['id_currency']], $max_tax_rate).',
+					'.(int) Ps_Facetedsearch::taxPrice($max_price[$currency['id_currency']], $max_tax_rate).')';
             }
 
             Db::getInstance()->execute('
 				INSERT INTO `'._DB_PREFIX_.'layered_price_index` (id_product, id_currency, id_shop, price_min, price_max)
 				VALUES '.implode(',', $values).'
 				ON DUPLICATE KEY UPDATE id_product = id_product # avoid duplicate keys');
+        }
+    }
+
+    private static function taxPrice($price, $tax)
+    {
+        if ($tax > 0) {
+            return Tools::ps_round(($price * (100 + $tax)) / 100, 0);
+        } else {
+            return $price;
         }
     }
 

--- a/src/Ps_FacetedsearchRangeAggregator.php
+++ b/src/Ps_FacetedsearchRangeAggregator.php
@@ -6,10 +6,6 @@ class Ps_FacetedsearchRangeAggregator
     {
         $min = $range[$minColumnIndex];
         $max = $range[$maxColumnIndex];
-        if ($min === $max) {
-            $min = $range[$minColumnIndex] > 0 ? $range[$minColumnIndex] - 1 : 0;
-            $max = $max + 1;
-        }
 
         return [
             'min' => $min,


### PR DESCRIPTION
* the artificial creation of ranges in case of an equal min and max has been dropped.
* the function mergeRanges now merges records first for entries with an equal min and max, so the user doesn't get confronted with weird ranges (previously a record [min=400, max=400] caused a range of 399..401 which is not only weird, it's confusing too as it doesn't resemble the data)
* the function mergeRanges didn't reduce the number of ranges so if the number of ranges exceeded the $outputLength it still had the same length after going through the original implementation.

Please be aware that I'm not a PHP developer, so there might be better ways to do things. Nevertheless I finally got proper ranges with these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/29)
<!-- Reviewable:end -->
