### PR TITLE
Fix notices of PHP 7.2

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -2372,7 +2372,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
     private static function getQuantityFilterSubQuery($filter_value, $ignore_join = false)
     {
-        if (count($filter_value) == 2 || empty($filter_value)) {
+        if (empty($filter_value) || count($filter_value) == 2) {
             return array();
         }
 
@@ -2401,7 +2401,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
     private static function getConditionFilterSubQuery($filter_value, $ignore_join = false)
     {
-        if (count($filter_value) == 3 || empty($filter_value)) {
+        if (empty($filter_value) || count($filter_value) == 3) {
             return array();
         }
 


### PR DESCRIPTION
Fixes notices about `count()` must be used on a value which implements Countable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/30)
<!-- Reviewable:end -->
