### PR TITLE
Fix Drop-down Facets being Cleared by other Drop-down Facets [BOOM-5484]

### DIFF
--- a/src/Ps_FacetedsearchFiltersConverter.php
+++ b/src/Ps_FacetedsearchFiltersConverter.php
@@ -90,7 +90,7 @@ class Ps_FacetedsearchFiltersConverter
                     $facet->setWidgetType('radio-buttons');
                     break;
                 case 2: // drop down
-                    $facet->setMultipleSelectionAllowed(false);
+                    $facet->setMultipleSelectionAllowed(true);
                     $facet->setWidgetType('dropdown');
                     break;
             }


### PR DESCRIPTION
Workaround: Set MultipleSelectionAllowed to 'true' for drop down in 'ps_facetedsearch/src/Ps_FacetedsearchFiltersConverter.php' and  disable actual end-user Multi-Select on drop downs in 'themes/classic/templates/catalog/_partials/facet.tpl'
 
Fix Requires Pulls from Prestahop AND ps_facetedsearch development repos 

This is my first Pull Request (suggested in [BOOM-5484]) and I was not able to combine the 2 PRs into 1 PR (if it is possible from 2 different repos).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/34)
<!-- Reviewable:end -->
