### PR TITLE
Dev

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1442,7 +1442,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
                 case 'manufacturer':
                     $selected_filters['manufacturer'] = array_map('intval', $selected_filters['manufacturer']);
-                    $query_filters_where .= ' AND p.id_manufacturer IN (' . implode($selected_filters['manufacturer'], ',') . ')';
+                    $query_filters_where .= ' AND p.id_manufacturer IN (' . implode(',', $selected_filters['manufacturer']) . ')';
                     break;
 
                 case 'condition':
@@ -2452,7 +2452,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             $query_filters = '';
         } else {
             array_walk($filter_value, create_function('&$id_manufacturer', '$id_manufacturer = (int)$id_manufacturer;'));
-            $query_filters = ' AND p.id_manufacturer IN ('.implode($filter_value, ',').')';
+            $query_filters = ' AND p.id_manufacturer IN ('.implode(',', $filter_value).')';
         }
         if ($ignore_join) {
             return array('where' => $query_filters);


### PR DESCRIPTION
Product weight filter
Hi,
he repeats it twice and it's because of the range he takes
example of a product that weighs 100
correct would be
0 - 100 (1)
101 - 200
etc..

now shows
0 - 100 (1)
100 - 200 (1)

Could it be fixed?
Thank you

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/39)
<!-- Reviewable:end -->
