### PR TITLE
Faceted filter doesn't shows attribute selection if category have only one product with same attribute or feature.

### DIFF
--- a/src/Ps_FacetedsearchProductSearchProvider.php
+++ b/src/Ps_FacetedsearchProductSearchProvider.php
@@ -285,7 +285,7 @@ class Ps_FacetedsearchProductSearchProvider implements ProductSearchProviderInte
                 }
             }
             $facet->setDisplayed(
-                $usefulFiltersCount > 1
+                $usefulFiltersCount >= 1
             );
         }
     }


### PR DESCRIPTION
When Category have only one product with same attribute or feature, It doesn't shows filter option with that attribute or feature on left-column. It's necessary to show filter option if at least one product have same attribute or feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/47)
<!-- Reviewable:end -->
