### PR TITLE
Only show products that the user has access to

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1666,8 +1666,18 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Tools::orderbyPrice($products, $order_way);
         }
 
+	$productsWithAccess = [];
+        $customerId = isset($this->context->customer->id) && $this->context->customer->id 
+            ? (int) $this->context->customer->id 
+            : 0;
+        foreach ($products as $p) {
+            if (Product::checkAccessStatic($p['id_product'], $customerId)) {
+                $productsWithAccess[] = $p;
+            }
+        }
+
         return array(
-            'products' => $products,
+            'products' => $productsWithAccess,	   
             'count' => $this->nbr_products,
         );
     }


### PR DESCRIPTION
Before, ps_facetedsearach showed also products that the user did not have access to, e.g. because his user group was not in the product's categories. 

This filters records to be only shown when the user has access to the detail page, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/48)
<!-- Reviewable:end -->
