### PR TITLE
Faceted search 2.2.1 doesn't show results with color/ patterns of Attributes 0 Stock

### DIFF
--- a/src/Ps_FacetedsearchProductSearchProvider.php
+++ b/src/Ps_FacetedsearchProductSearchProvider.php
@@ -285,7 +285,7 @@ class Ps_FacetedsearchProductSearchProvider implements ProductSearchProviderInte
                 }
             }
             $facet->setDisplayed(
-                $usefulFiltersCount > 1
+                $usefulFiltersCount >= 1
             );
         }
     }


### PR DESCRIPTION
Fix: [https://github.com/PrestaShop/PrestaShop/issues/12143](url)  
Faceted search 2.2.1 doesn't show results with color/ patterns of Attributes 0 Stock

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/49)
<!-- Reviewable:end -->
