### PR TITLE
Fix issue with out of stock

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1420,7 +1420,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                         ON (pa.`id_product_attribute` = pac.`id_product_attribute`)' .
                         Shop::addSqlAssociation('product_attribute', 'pa') .
                         ' JOIN `'._DB_PREFIX_.'stock_available` sa
-                        ON (sa.`id_product_attribute` = pac.`id_product_attribute` AND sa.`quantity` > 0)
+                        ON (sa.`id_product_attribute` = pac.`id_product_attribute` AND sa.`quantity` >= 0)
                         WHERE ' . implode(' OR ', $sub_query) . ') ';
                     }
                     break;


### PR DESCRIPTION
When you filter color/pattern attributes, the module doesn't show results of combinations out of stock.
Fix: https://github.com/PrestaShop/PrestaShop/issues/12143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/50)
<!-- Reviewable:end -->
