### PR TITLE
FO: New Feature - Sort products: InStock,OOPS with qty 0, OutOfStock

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1710,13 +1710,13 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
         foreach($array as $subKey => $subArray){
             // SPLIT out_of_stock OOPS products
-            if(Product::isAvailableWhenOutOfStock($subArray['out_of_stock']) == 1 && $subArray['quantity'] == 0) {
+            if(Product::isAvailableWhenOutOfStock($subArray['out_of_stock']) == 1 && $subArray['quantity'] <= 0) {
                 $outOfStockOOPSProducts[] = $array[$subKey];
                 unset($array[$subKey]);
             }
 
             // SPLIT out_of_stock products
-            if(Product::isAvailableWhenOutOfStock($subArray['out_of_stock']) == 0 && $subArray['quantity'] == 0) {
+            if(Product::isAvailableWhenOutOfStock($subArray['out_of_stock']) == 0 && $subArray['quantity'] <= 0) {
                 $outOfStockProducts[] = $array[$subKey];
                 unset($array[$subKey]);
             }

--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -180,6 +180,26 @@
 				</span>
 			</div>
 		</div>
+		{* show_out_of_stock_last *}
+		<div class="form-group">
+			<label class="col-lg-3 control-label">{l s='Show out-of-stock products last' d='Modules.Facetedsearch.Admin'}</label>
+			<div class="col-lg-9">
+				<span class="switch prestashop-switch fixed-width-lg">
+					<input type="radio" name="ps_layered_filter_show_out_of_stock_last" id="ps_layered_filter_show_out_of_stock_last_on" value="1"{if $show_out_of_stock_last} checked="checked"{/if}/>
+					<label for="ps_layered_filter_show_out_of_stock_last_on" class="radioCheck">
+						<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+					</label>
+					<input type="radio" name="ps_layered_filter_show_out_of_stock_last" id="ps_layered_filter_show_out_of_stock_last_off" value="0"{if !$show_out_of_stock_last} checked="checked"{/if}/>
+					<label for="ps_layered_filter_show_out_of_stock_last_off" class="radioCheck">
+						<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+					</label>
+					<a class="slide-button btn"></a>
+				</span>
+				<p class="help-block">
+					Sorts products like this: In Stock, Back-order available, Out Of Stock.
+				</p>
+			</div>
+		</div>
 		<div class="panel-footer">
 			<button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 		</div>

--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -196,7 +196,7 @@
 					<a class="slide-button btn"></a>
 				</span>
 				<p class="help-block">
-					Sorts products like this: In Stock, Back-order available, Out Of Stock.
+					{l s='Sorts products like this: In Stock, Back-order available, Out Of Stock.' d='Modules.Facetedsearch.Admin'}
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Adding new FO feature. 

I added an option "Show out-of-stock products last" in BO module preferences tab. If it is active, product array is rearanged in this way:
1. Products in stock
2. Products out of stock but back-order available
3. Products out of stock - quantity = 0

All available filters is compatible with this feature.

Screenshoots:
![screen shot 2019-02-04 at 12 34 41](https://user-images.githubusercontent.com/10948341/52211726-5ef61580-2893-11e9-93c5-1caf0ba83e63.png)
![screen shot 2019-02-04 at 13 33 13](https://user-images.githubusercontent.com/10948341/52211727-5ef61580-2893-11e9-9937-639d1eb33aba.png)
![screen shot 2019-02-04 at 13 33 00](https://user-images.githubusercontent.com/10948341/52211728-5f8eac00-2893-11e9-810e-2f5762dca2e5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/51)
<!-- Reviewable:end -->

Fixes https://github.com/PrestaShop/PrestaShop/issues/12143
