### PR TITLE
Fix Drop-down Facets being Cleared by other Drop-down Facets [BOOM-5484]

### DIFF
--- a/src/Ps_FacetedsearchProductSearchProvider.php
+++ b/src/Ps_FacetedsearchProductSearchProvider.php
@@ -231,6 +231,7 @@ class Ps_FacetedsearchProductSearchProvider implements ProductSearchProviderInte
         $urlSerializer = new URLFragmentSerializer();
 
         foreach ($facets as $facet) {
+            $facetFiltersToAdd = $activeFacetFilters;
             // If only one filter can be selected, we keep track of
             // the current active filter to disable it before generating the url stub
             // and not select two filters in a facet that can have only one active filter.
@@ -238,14 +239,14 @@ class Ps_FacetedsearchProductSearchProvider implements ProductSearchProviderInte
                 foreach ($facet->getFilters() as $filter) {
                     if ($filter->isActive()) {
                         // we have a currently active filter is the facet, remove it from the facetFilter array
-                        $activeFacetFilters = $this->facetsSerializer->removeFilterFromFacetFilters($activeFacetFilters, $filter, $facet);
+                        $facetFiltersToAdd = $this->facetsSerializer->removeFilterFromFacetFilters($facetFiltersToAdd, $filter, $facet);
                         break;
                     }
                 }
             }
 
             foreach ($facet->getFilters() as $filter) {
-                $facetFilters = $activeFacetFilters;
+                $facetFilters = $facetFiltersToAdd;
 
                 // toggle the current filter
                 if ($filter->isActive()) {


### PR DESCRIPTION
Using multiple dropdown facets result in random clearing of active filters, depending on order in which are filters activated.

The bug is actually in `addEncodedFacetsToFilters` method. When you have two facets(ie. Size and Brand), both as dropdown (`multipleSelectionAllowed=false`) and you select one of the filters (ie. Size), it depends in which order they are processed. When Size is processed first, it's detected as active and removed from `$activeFacetFilters`. Then Brand is processed and now it seems there is no active filter (even though there should be Size active) and it sets `setNextEncodedFacets` to wrong value.
When the facets are processed in different order (Brand before Size), Brand's `setNextEncodedFacets` is set correctly because activeFacetFilter gets deleted after (when processing Size facet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/53)
<!-- Reviewable:end -->
