### PR TITLE
fix bug indexed prices

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -355,7 +355,9 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
 
             if (!Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $taxRatesByCountry = [['rate' => 0, 'id_country' => 0, 'iso_code' => '']];
+                $idCountry = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+                $isoCode = Country::getIsoById($idCountry);
+                $taxRatesByCountry = [['rate' => 0, 'id_country' => $idCountry, 'iso_code' => $isoCode]];
             } else {
                 $taxRatesByCountry = $this->getDatabase()->executeS(
                     'SELECT t.rate rate, tr.id_country, c.iso_code


### PR DESCRIPTION
Failure to index prices in case of tax inactivity

If the "Use tax to filter price" setting is disabled, the price index will not be executed correctly and the price slider will not be displayed.

![disabel_use_tax_filter_price](https://user-images.githubusercontent.com/10551562/59268682-8191a400-8c62-11e9-8465-b41e8ed2e975.png)
![table_indexed_prices](https://user-images.githubusercontent.com/10551562/59268683-8191a400-8c62-11e9-88fd-b720b352b64d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/89)
<!-- Reviewable:end -->
