### PR TITLE
Fix facet display when there is only one filter

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -47,6 +47,15 @@ class Converter
     const WIDGET_TYPE_DROPDOWN = 2;
     const WIDGET_TYPE_SLIDER = 3;
 
+    const TYPE_ATTRIBUTE_GROUP = 'attribute_group';
+    const TYPE_AVAILABILITY = 'availability';
+    const TYPE_CATEGORY = 'category';
+    const TYPE_CONDITION = 'condition';
+    const TYPE_FEATURE = 'feature';
+    const TYPE_MANUFACTURER = 'manufacturer';
+    const TYPE_PRICE = 'price';
+    const TYPE_WEIGHT = 'weight';
+
     /**
      * @var Context
      */
@@ -79,20 +88,20 @@ class Converter
                 ->setMultipleSelectionAllowed(true);
 
             switch ($filterBlock['type']) {
-                case 'category':
+                case self::TYPE_CATEGORY:
+                case self::TYPE_CONDITION:
+                case self::TYPE_MANUFACTURER:
                 case 'quantity':
-                case 'condition':
-                case 'manufacturer':
                 case 'id_attribute_group':
                 case 'id_feature':
                     $type = $filterBlock['type'];
                     if ($filterBlock['type'] == 'quantity') {
-                        $type = 'availability';
+                        $type = self::TYPE_AVAILABILITY;
                     } elseif ($filterBlock['type'] == 'id_attribute_group') {
-                        $type = 'attribute_group';
+                        $type = self::TYPE_ATTRIBUTE_GROUP;
                         $facet->setProperty('id_attribute_group', $filterBlock['id_key']);
                     } elseif ($filterBlock['type'] == 'id_feature') {
-                        $type = 'feature';
+                        $type = self::TYPE_FEATURE;
                         $facet->setProperty('id_feature', $filterBlock['id_key']);
                     }
 
@@ -118,8 +127,8 @@ class Converter
                         $facet->addFilter($filter);
                     }
                     break;
-                case 'weight':
-                case 'price':
+                case self::TYPE_WEIGHT:
+                case self::TYPE_PRICE:
                     $facet
                         ->setType($filterBlock['type'])
                         ->setProperty('min', $filterBlock['min'])

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -441,7 +441,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
      * Keep facet status when it's a slider
      *
      * @param array $facets
-     * @param integer $totalProducts
+     * @param int $totalProducts
      */
     private function hideUselessFacets(array $facets, $totalProducts)
     {
@@ -467,7 +467,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 $usefulFiltersCount > 1
                 ||
                 (
-                    /**
+                    /*
                      * There is only one fitler and the
                      * magnitude is different than the
                      * total products

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -466,12 +466,12 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 // There are two filters displayed
                 $usefulFiltersCount > 1
                 ||
+                /*
+                 * There is only one fitler and the
+                 * magnitude is different than the
+                 * total products
+                 */
                 (
-                    /*
-                     * There is only one fitler and the
-                     * magnitude is different than the
-                     * total products
-                     */
                     count($facet->getFilters()) === 1
                     && $totalFacetProducts != $totalProducts
                     && $usefulFiltersCount > 0

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -176,7 +176,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $this->labelRangeFilters($facets);
         $this->addEncodedFacetsToFilters($facets);
         $this->hideZeroValues($facets);
-        $this->hideUselessFacets($facets);
+        $this->hideUselessFacets($facets, (int) $result->getTotalProductsCount());
 
         $facetCollection = new FacetCollection();
         $nextMenu = $facetCollection->setFacets($facets);
@@ -441,8 +441,9 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
      * Keep facet status when it's a slider
      *
      * @param array $facets
+     * @param integer $totalProducts
      */
-    private function hideUselessFacets(array $facets)
+    private function hideUselessFacets(array $facets, $totalProducts)
     {
         foreach ($facets as $facet) {
             if ($facet->getWidgetType() === 'slider') {
@@ -452,15 +453,29 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 continue;
             }
 
+            $totalFacetProducts = 0;
             $usefulFiltersCount = 0;
             foreach ($facet->getFilters() as $filter) {
                 if ($filter->getMagnitude() > 0) {
+                    $totalFacetProducts += $filter->getMagnitude();
                     ++$usefulFiltersCount;
                 }
             }
 
             $facet->setDisplayed(
+                // There are two filters displayed
                 $usefulFiltersCount > 1
+                ||
+                (
+                    /**
+                     * There is only one fitler and the
+                     * magnitude is different than the
+                     * total products
+                     */
+                    count($facet->getFilters()) === 1
+                    && $totalFacetProducts != $totalProducts
+                    && $usefulFiltersCount > 0
+                )
             );
         }
     }


### PR DESCRIPTION
You should be able to see a facet even if you have only one filter.
See https://github.com/PrestaShop/PrestaShop/issues/9647 for more explanation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/103)
<!-- Reviewable:end -->
