### PR TITLE
Column type size

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -885,7 +885,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $this->getDatabase()->execute(
             'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'layered_filter_block` (
             `hash` CHAR(32) NOT NULL DEFAULT "" PRIMARY KEY,
-            `data` TEXT NULL
+            `data` MEDIUMTEXT NULL
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;'
         );
 

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -90,7 +90,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '3.2.0';
+        $this->version = '3.2.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;

--- a/upgrade/upgrade-3.2.1.php
+++ b/upgrade/upgrade-3.2.1.php
@@ -29,6 +29,6 @@ if (!defined('_PS_VERSION_')) {
 
 function upgrade_module_3_2_1(Ps_Facetedsearch $module)
 {
-    $sql = 'ALTER TABLE `'._DB_PREFIX_.'layered_filter_block` CHANGE `data` `data` MEDIUMTEXT NULL DEFAULT NULL;';
+    $sql = 'ALTER TABLE `'._DB_PREFIX_.'layered_filter_block` CHANGE COLUMN `data` `data` MEDIUMTEXT NULL DEFAULT NULL;';
     return Db::getInstance()->execute($sql);
 }

--- a/upgrade/upgrade-3.2.1.php
+++ b/upgrade/upgrade-3.2.1.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_2_1(Ps_Facetedsearch $module)
+{
+    $sql = 'ALTER TABLE `'._DB_PREFIX_.'layered_filter_block` CHANGE `data` `data` MEDIUMTEXT NULL DEFAULT NULL;';
+    return Db::getInstance()->execute($sql);
+}


### PR DESCRIPTION
The TEXT type column for `layered_filter_block.data` has a size limit that is too small for customers with a lot of products. I have a client that has a data size of 150kB which throws an exception since the text type is too small.

![ps_facetedsearch_error](https://user-images.githubusercontent.com/43071597/62923543-46206c80-bdae-11e9-8b26-0e32eb9fb7f5.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/122)
<!-- Reviewable:end -->
