### PR TITLE
Refactoring values sorting

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -142,7 +142,7 @@ class Converter
 
                     $this->hideZeroValuesAndShowLimit($filters, (int) $filterBlock['filter_show_limit']);
 
-                    if ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP) {
+                    if ((int) $filterBlock['filter_show_limit'] !== 0 || $filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP) {
                         usort($filters, array($this, 'sortFiltersByLabel'));
                     }
 
@@ -451,7 +451,8 @@ class Converter
         $aMagnitude = $a->getMagnitude();
         $bMagnitude = $b->getMagnitude();
         if ($aMagnitude == $bMagnitude) {
-            return 0;
+            // Same magnitude, sort by label
+            return $this->sortFiltersByLabel($a, $b);
         }
 
         return $aMagnitude > $bMagnitude ? -1 : +1;
@@ -467,6 +468,10 @@ class Converter
      */
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
+        if (is_numeric($a->getLabel()) && is_numeric($b->getLabel())) {
+            return $a->getLabel() - $b->getLabel();
+        }
+
         return strcmp($a->getLabel(), $b->getLabel());
     }
 }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -136,9 +136,15 @@ class Converter
                         $filters[] = $filter;
                     }
 
-                    usort($filters, array($this, 'sortFiltersByMagnitude'));
+                    if ((int) $filterBlock['filter_show_limit'] !== 0) {
+                        usort($filters, array($this, 'sortFiltersByMagnitude'));
+                    }
+
                     $this->hideZeroValuesAndShowLimit($filters, (int) $filterBlock['filter_show_limit']);
-                    usort($filters, array($this, 'sortFiltersByLabel'));
+
+                    if ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP) {
+                        usort($filters, array($this, 'sortFiltersByLabel'));
+                    }
 
                     // No method available to add all filters
                     foreach ($filters as $filter) {

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -469,7 +469,7 @@ class Converter
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
         if (is_numeric($a->getLabel()) && is_numeric($b->getLabel())) {
-            return (float) $a->getLabel() - (float) $b->getLabel();
+            return ceil($a->getLabel()) - ceil($b->getLabel());
         }
 
         return strcmp($a->getLabel(), $b->getLabel());

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -469,7 +469,7 @@ class Converter
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
         if (is_numeric($a->getLabel()) && is_numeric($b->getLabel())) {
-            return $a->getLabel() - $b->getLabel();
+            return (float) $a->getLabel() - (float) $b->getLabel();
         }
 
         return strcmp($a->getLabel(), $b->getLabel());

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -468,10 +468,6 @@ class Converter
      */
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
-        if (is_numeric($a->getLabel()) && is_numeric($b->getLabel())) {
-            return ceil($a->getLabel()) - ceil($b->getLabel());
-        }
-
-        return strcmp($a->getLabel(), $b->getLabel());
+        return strnatcmp($a->getLabel(), $b->getLabel());
     }
 }

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -239,6 +239,20 @@ class ConverterTest extends MockeryTestCase
                             'filters' => [
                                 Filter::__set_state(
                                     [
+                                        'label' => 'White',
+                                        'type' => 'attribute_group',
+                                        'active' => false,
+                                        'displayed' => true,
+                                        'properties' => [
+                                            'color' => '#ffffff',
+                                        ],
+                                        'magnitude' => 3,
+                                        'value' => 8,
+                                        'nextEncodedFacets' => [],
+                                    ]
+                                ),
+                                Filter::__set_state(
+                                    [
                                         'label' => 'Black',
                                         'type' => 'attribute_group',
                                         'active' => false,
@@ -262,20 +276,6 @@ class ConverterTest extends MockeryTestCase
                                         ],
                                         'magnitude' => 3,
                                         'value' => 12,
-                                        'nextEncodedFacets' => [],
-                                    ]
-                                ),
-                                Filter::__set_state(
-                                    [
-                                        'label' => 'White',
-                                        'type' => 'attribute_group',
-                                        'active' => false,
-                                        'displayed' => true,
-                                        'properties' => [
-                                            'color' => '#ffffff',
-                                        ],
-                                        'magnitude' => 3,
-                                        'value' => 8,
                                         'nextEncodedFacets' => [],
                                     ]
                                 ),

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -294,15 +294,39 @@ class ConverterTest extends MockeryTestCase
                     'type' => 'id_feature',
                     'id_key' => '2',
                     'values' => [
-                        10 => [
-                            'nbr' => '3',
-                            'name' => '120 pages',
+                        5 => [
+                            'nbr' => '2',
+                            'name' => '2',
+                            'url_name' => null,
+                            'meta_title' => null,
+                        ],
+                        6 => [
+                            'nbr' => '2',
+                            'name' => '1',
+                            'url_name' => null,
+                            'meta_title' => null,
+                        ],
+                        7 => [
+                            'nbr' => '2',
+                            'name' => '2.2',
+                            'url_name' => null,
+                            'meta_title' => null,
+                        ],
+                        8 => [
+                            'nbr' => '2',
+                            'name' => '2.1',
                             'url_name' => null,
                             'meta_title' => null,
                         ],
                         9 => [
                             'nbr' => '3',
                             'name' => 'Removable cover',
+                            'url_name' => null,
+                            'meta_title' => null,
+                        ],
+                        10 => [
+                            'nbr' => '3',
+                            'name' => '120 pages',
                             'url_name' => null,
                             'meta_title' => null,
                         ],
@@ -324,6 +348,54 @@ class ConverterTest extends MockeryTestCase
                                 'id_feature' => '2',
                             ],
                             'filters' => [
+                                Filter::__set_state(
+                                    [
+                                        'label' => '1',
+                                        'type' => 'feature',
+                                        'active' => false,
+                                        'displayed' => true,
+                                        'properties' => [],
+                                        'magnitude' => 2,
+                                        'value' => 6,
+                                        'nextEncodedFacets' => [],
+                                    ]
+                                ),
+                                Filter::__set_state(
+                                    [
+                                        'label' => '2',
+                                        'type' => 'feature',
+                                        'active' => false,
+                                        'displayed' => true,
+                                        'properties' => [],
+                                        'magnitude' => 2,
+                                        'value' => 5,
+                                        'nextEncodedFacets' => [],
+                                    ]
+                                ),
+                                Filter::__set_state(
+                                    [
+                                        'label' => '2.1',
+                                        'type' => 'feature',
+                                        'active' => false,
+                                        'displayed' => true,
+                                        'properties' => [],
+                                        'magnitude' => 2,
+                                        'value' => 8,
+                                        'nextEncodedFacets' => [],
+                                    ]
+                                ),
+                                Filter::__set_state(
+                                    [
+                                        'label' => '2.2',
+                                        'type' => 'feature',
+                                        'active' => false,
+                                        'displayed' => true,
+                                        'properties' => [],
+                                        'magnitude' => 2,
+                                        'value' => 7,
+                                        'nextEncodedFacets' => [],
+                                    ]
+                                ),
                                 Filter::__set_state(
                                     [
                                         'label' => '120 pages',


### PR DESCRIPTION
- Only sort by magnitude if there is a filters show limitations
- Do not sort attributes by label

Fixes: https://github.com/PrestaShop/PrestaShop/issues/15065
https://github.com/PrestaShop/PrestaShop/issues/14989

Specs: 
[https://github.com/PrestaShop/prestashop-specs/blob/master/ps_facetedsearch.md#sorting](https://github.com/PrestaShop/prestashop-specs/blob/master/ps_facetedsearch.md#sorting) 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/124)
<!-- Reviewable:end -->
