### PR TITLE
Products are displayed in wrong order when sorted by "position" and "Show products from subcategories" is disabled 

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -107,6 +107,7 @@ class Search
         $psLayeredFullTree = Configuration::get('PS_LAYERED_FULL_TREE');
         if (!$psLayeredFullTree) {
             $this->addFilter('id_category_default', [$parent->id]);
+            $this->addFilter('id_category', [$parent->id]);
         }
 
         // Visibility of a product must be in catalog or both (search & catalog)

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -104,6 +104,13 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
                 'id_shop' => [
                     '=' => [
                         [
@@ -233,6 +240,9 @@ class SearchTest extends MockeryTestCase
                 'id_category' => [
                     '=' => [
                         [
+                            null,
+                        ],
+                        [
                             6,
                         ],
                     ],
@@ -337,6 +347,13 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
             ],
             $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
         );
@@ -408,6 +425,13 @@ class SearchTest extends MockeryTestCase
                     ],
                 ],
                 'id_category_default' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_category' => [
                     '=' => [
                         [
                             null,


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/15062

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/125)
<!-- Reviewable:end -->
