### PR TITLE
Use public_name instead of name for attribute group

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -678,7 +678,7 @@ class Block
         if (!isset($this->attributesGroup[$idLang])) {
             $this->attributesGroup[$idLang] = [];
             $tempAttributesGroup = $this->database->executeS(
-                'SELECT ag.id_attribute_group, agl.name as attribute_group_name, is_color_group ' .
+                'SELECT ag.id_attribute_group, agl.public_name as attribute_group_name, is_color_group ' .
                 'FROM `' . _DB_PREFIX_ . 'attribute_group` ag ' .
                 Shop::addSqlAssociation('attribute_group', 'ag') . ' ' .
                 'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ' .

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -323,9 +323,9 @@ class Converter
                     $attributesGroup = AttributeGroup::getAttributesGroups($idLang);
                     foreach ($attributesGroup as $attributeGroup) {
                         if ($filter['id_value'] == $attributeGroup['id_attribute_group']
-                            && isset($facetAndFiltersLabels[$attributeGroup['name']])
+                            && isset($facetAndFiltersLabels[$attributeGroup['public_name']])
                         ) {
-                            $attributeLabels = $facetAndFiltersLabels[$attributeGroup['name']];
+                            $attributeLabels = $facetAndFiltersLabels[$attributeGroup['public_name']];
                             $attributes = AttributeGroup::getAttributes($idLang, $attributeGroup['id_attribute_group']);
                             foreach ($attributes as $attribute) {
                                 if (in_array($attribute['name'], $attributeLabels)) {

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -1017,7 +1017,7 @@ class BlockTest extends MockeryTestCase
             $this->dbMock->shouldReceive('executeS')
                 ->once()
                 ->with(
-                    'SELECT ag.id_attribute_group, agl.name as attribute_group_name, is_color_group ' .
+                    'SELECT ag.id_attribute_group, agl.public_name as attribute_group_name, is_color_group ' .
                     'FROM `ps_attribute_group` ag INNER JOIN ps_attribute_group_shop attribute_group_shop ' .
                     'ON (attribute_group_shop.id_attribute_group = ag.id_attribute_group AND ' .
                     'attribute_group_shop.id_shop = 1) LEFT JOIN `ps_attribute_group_lang` agl ON ' .


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/15688

It should use the Public name instead of Name property for attributes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/144)
<!-- Reviewable:end -->
