### PR TITLE
Fix url validation

### DIFF
--- a/config/index.php
+++ b/config/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.module.ps_facetedsearch.constraint.url_segment_validator:
+    class: PrestaShop\Module\FacetedSearch\Constraint\UrlSegmentValidator
+    arguments:
+      - '@prestashop.adapter.tools'
+    tags:
+      - { name: validator.constraint_validator }

--- a/src/Constraint/UrlSegment.php
+++ b/src/Constraint/UrlSegment.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+class UrlSegment extends Constraint
+{
+    public $message = '%s is invalid.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return UrlSegmentValidator::class;
+    }
+}

--- a/src/Constraint/UrlSegmentValidator.php
+++ b/src/Constraint/UrlSegmentValidator.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Constraint;
+
+use PrestaShop\PrestaShop\Adapter\Tools;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Class UrlSegmentValidator responsible for validating an URL segment.
+ */
+class UrlSegmentValidator extends ConstraintValidator
+{
+    /**
+     * @var Tools
+     */
+    private $tools;
+
+    /**
+     * @param Tools $tools
+     */
+    public function __construct(Tools $tools)
+    {
+        $this->tools = $tools;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof UrlSegment) {
+            throw new UnexpectedTypeException($constraint, UrlSegment::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (strtolower($value) !== $this->tools->linkRewrite($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setTranslationDomain('Admin.Notifications.Error')
+                ->setParameter('%s', $this->formatValue($value))
+                ->addViolation()
+            ;
+        }
+    }
+}

--- a/src/Form/Feature/FormModifier.php
+++ b/src/Form/Feature/FormModifier.php
@@ -27,11 +27,11 @@
 namespace PrestaShop\Module\FacetedSearch\Form\Feature;
 
 use Context;
+use PrestaShop\Module\FacetedSearch\Constraint\UrlSegment;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Url;
 
 /**
  * Adds module specific fields to BO form
@@ -87,7 +87,7 @@ class FormModifier
                     'help' => $urlTip . ' ' . $invalidCharsHint,
                     'options' => [
                         'constraints' => [
-                            new Url([
+                            new UrlSegment([
                                 'message' => $translator->trans('%s is invalid.', [], 'Admin.Notifications.Error'),
                             ]),
                         ],

--- a/tests/php/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/php/phpstan/phpstan-1.7.1.2.neon
@@ -13,5 +13,6 @@ parameters:
     - '~Parameter #\d+ \$(.+?) of class Category constructor expects null, int given\.~'
     - '~constant NUMBERING_SYSTEM_LATIN on an unknown class~'
     - '~PrestaShopBundle\\Form\\Admin\\Type\\(TranslatableType|SwitchType) not found~'
+    - '~Call to an undefined method PrestaShop\\PrestaShop\\Adapter\\Tools::linkRewrite\(\).~'
 
   level: 5

--- a/tests/php/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/php/phpstan/phpstan-1.7.2.5.neon
@@ -13,5 +13,6 @@ parameters:
     - '~Parameter #\d+ \$(.+?) of class Category constructor expects null, int given\.~'
     - '~constant NUMBERING_SYSTEM_LATIN on an unknown class~'
     - '~PrestaShopBundle\\Form\\Admin\\Type\\(TranslatableType|SwitchType) not found~'
+    - '~Call to an undefined method PrestaShop\\PrestaShop\\Adapter\\Tools::linkRewrite\(\).~'
 
   level: 5


### PR DESCRIPTION
This module adds 2 new fields in PrestaShop's feature edit form. The validation of the URL field was incorrectly implemented in this PR: https://github.com/PrestaShop/ps_facetedsearch/pull/133

With this PR it should validate URL value the same way as it was validating prior to https://github.com/PrestaShop/ps_facetedsearch/pull/133 PR

https://prnt.sc/pebc50

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/145)
<!-- Reviewable:end -->
