### PR TITLE
Fix order by price indexation without tax rate

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -411,7 +411,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             );
 
             if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $idCountry = (int) Configuration::get('PS_COUNTRY_DEFAULT');
+                $idCountry = (int) Configuration::get('PS_COUNTRY_DEFAULT', null, null, $idShop);
                 $isoCode = Country::getIsoById($idCountry);
                 $taxRatesByCountry = [['rate' => 0, 'id_country' => $idCountry, 'iso_code' => $isoCode]];
             }


### PR DESCRIPTION
If you have several shop with different default country, indexation of price are base only on the default country of the default shop.
For instance, you can create a shop in France and a shop in USA with only one currency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/157)
<!-- Reviewable:end -->
