### PR TITLE
Fix price indexing for products with specific prices only for some currencies

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -428,12 +428,6 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
                 // Get price by currency & country, without reduction!
                 foreach ($currencyList as $currency) {
-                    if (!empty($productMinPrices)) {
-                        $minPrice[$idCountry][$currency['id_currency']] = null;
-                        $maxPrice[$idCountry][$currency['id_currency']] = null;
-                        continue;
-                    }
-
                     $price = Product::priceCalculation(
                         $idShop,
                         (int) $idProduct,


### PR DESCRIPTION
Hi, I think the condition to skip default prices is too wide here.
I have a shop where I define base prices in default currency.
Prices for other currencies are defined using specific prices, in order to avoid rounding issues due to exchange rates.

The price calculation for such a product then is:
default currency: default price
other currencies: specific price.

The logic for indexing a products price in this file looks for ANY specific price rule, regardless of id_currency/id_country for the product, and if it finds one, the default price is never used.

As a result in my price index, for default currency (no specific rule) all products are indexed with zero price.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/159)
<!-- Reviewable:end -->
