### PR TITLE
MySQL query fix for unreliable product ordering by position

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -31,6 +31,7 @@ use Product;
 use Context;
 use Configuration;
 use StockAvailable;
+use Tools;
 use Doctrine\Common\Collections\ArrayCollection;
 
 class MySQL extends AbstractAdapter
@@ -156,6 +157,12 @@ class MySQL extends AbstractAdapter
             'sa'
         );
 
+        $homeCategory = Configuration::get('PS_HOME_CATEGORY');
+        $idCategory = (int) Tools::getValue(
+            'id_category',
+            Tools::getValue('id_category_layered', $homeCategory)
+        );
+
         $filterToTableMapping = [
             'id_product_attribute' => [
                 'tableName' => 'product_attribute',
@@ -205,7 +212,7 @@ class MySQL extends AbstractAdapter
             'position' => [
                 'tableName' => 'category_product',
                 'tableAlias' => 'cp',
-                'joinCondition' => '(p.id_product = cp.id_product)',
+                'joinCondition' => '(p.id_product = cp.id_product AND cp.id_category = ' . $idCategory . ')',
                 'joinType' => self::INNER_JOIN,
             ],
             'manufacturer_name' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | included id_category join condition for the $filterToTableMapping['position'] to make the position value reliably taken from the current category.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Products positions on category pages with position ordering should always be the same as their position values in the products page of the back office.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
