### PR TITLE
Fix order by price indexation without tax rate (default country fix)

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -413,13 +413,13 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
                 $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
                 $taxCountries = array_filter($shopCountries, function ($country) {
-                    return $country['active'] == 1;
+                    return $country['active'];
                 });
                 $taxRatesByCountry = array_map(function ($country) {
                     return [
                         'rate' => 0,
                         'id_country' => $country['id_country'],
-                        'iso_code' => $country['iso_code']
+                        'iso_code' => $country['iso_code'],
                     ];
                 }, $taxCountries);
             }

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -411,9 +411,17 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             );
 
             if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $idCountry = (int) Configuration::get('PS_COUNTRY_DEFAULT', null, null, $idShop);
-                $isoCode = Country::getIsoById($idCountry);
-                $taxRatesByCountry = [['rate' => 0, 'id_country' => $idCountry, 'iso_code' => $isoCode]];
+                $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+                $taxCountries = array_filter($shopCountries, function ($country) {
+                    return $country['active'] == 1;
+                });
+                $taxRatesByCountry = array_map(function ($country) {
+                    return [
+                        'rate' => 0,
+                        'id_country' => $country['id_country'],
+                        'iso_code' => $country['iso_code']
+                    ];
+                }, $taxCountries);
             }
 
             $productMinPrices = $this->getDatabase()->executeS(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you configure default sort by for category page with value `sort by price` and products in category don't have a tax configured (without tax) or an option `use taxes` is disabled in the module and you have more than one country configured for current shop, so in this case you will not see products in category. It happens only when you access FO using customer that country is different from the default country. The module tries to make joins by current country id, but price index use only default country for each shop/product (the line is not present in DB, because we made indexes only for default country). To fix this problem i propose to fetch activated countries for each shop and add them all to the table of price indexes (not only default country).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #157.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/189)
<!-- Reviewable:end -->
