### PR TITLE
Allow customization of parts of the search without total rewrite

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -310,7 +310,7 @@ class MySQL extends AbstractAdapter
      *
      * @return string
      */
-    private function computeOrderByField(array $filterToTableMapping)
+    protected function computeOrderByField(array $filterToTableMapping)
     {
         $orderField = $this->getOrderField();
 
@@ -344,7 +344,7 @@ class MySQL extends AbstractAdapter
      *
      * @return string
      */
-    private function computeShowLast($orderField, $filterToTableMapping)
+    protected function computeShowLast($orderField, $filterToTableMapping)
     {
         // allow only if feature is enabled & it is main product list query
         if ($this->getInitialPopulation() === null
@@ -396,7 +396,7 @@ class MySQL extends AbstractAdapter
      *
      * @return string Table Field name with an alias
      */
-    private function computeFieldName($fieldName, $filterToTableMapping, $sortByField = false)
+    protected function computeFieldName($fieldName, $filterToTableMapping, $sortByField = false)
     {
         if (array_key_exists($fieldName, $filterToTableMapping)
             && (
@@ -432,7 +432,7 @@ class MySQL extends AbstractAdapter
      *
      * @return array
      */
-    private function computeSelectFields(array $filterToTableMapping)
+    protected function computeSelectFields(array $filterToTableMapping)
     {
         $selectFields = [];
         foreach ($this->getSelectFields() as $key => $selectField) {
@@ -449,7 +449,7 @@ class MySQL extends AbstractAdapter
      *
      * @return array
      */
-    private function computeWhereConditions(array $filterToTableMapping)
+    protected function computeWhereConditions(array $filterToTableMapping)
     {
         $whereConditions = [];
         $operationIdx = 0;
@@ -568,7 +568,7 @@ class MySQL extends AbstractAdapter
      *
      * @return ArrayCollection
      */
-    private function computeJoinConditions(array $filterToTableMapping)
+    protected function computeJoinConditions(array $filterToTableMapping)
     {
         $joinList = new ArrayCollection();
 

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -34,22 +34,22 @@ class Search
     /**
      * @var bool
      */
-    private $psStockManagement;
+    protected $psStockManagement;
 
     /**
      * @var bool
      */
-    private $psOrderOutOfStock;
+    protected $psOrderOutOfStock;
 
     /**
      * @var AbstractAdapter
      */
-    private $searchAdapter;
+    protected $searchAdapter;
 
     /**
      * @var Context
      */
-    private $context;
+    protected $context;
 
     /**
      * Search constructor.

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Product;
+
+use Context;
+
+class SearchFactory
+{
+
+    /**
+     * Search factory. Returns an instance of Search for this context
+     *
+     * @param Context $context
+     * @return Search
+     */
+    public function getSearch(Context $context)
+    {
+        return new Search($context);
+    }
+
+}

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -32,7 +32,7 @@ class SearchFactory
      *
      * @return Search
      */
-    public function getSearch(Context $context)
+    public function build(Context $context)
     {
         return new Search($context);
     }

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -29,6 +29,7 @@ class SearchFactory
      * Returns an instance of Search for this context
      *
      * @param Context $context
+     *
      * @return Search
      */
     public function getSearch(Context $context)

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -35,5 +35,4 @@ class SearchFactory
     {
         return new Search($context);
     }
-
 }

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -26,7 +26,7 @@ class SearchFactory
 {
 
     /**
-     * Search factory. Returns an instance of Search for this context
+     * Returns an instance of Search for this context
      *
      * @param Context $context
      * @return Search

--- a/src/Product/SearchFactory.php
+++ b/src/Product/SearchFactory.php
@@ -24,7 +24,6 @@ use Context;
 
 class SearchFactory
 {
-
     /**
      * Returns an instance of Search for this context
      *

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -66,7 +66,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $this->module = $module;
         $this->filtersConverter = $converter;
         $this->facetsSerializer = $serializer;
-        $this->searchFactory = $searchFactory == null ? new SearchFactory() : $searchFactory; 
+        $this->searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory; 
     }
 
     /**

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -52,14 +52,21 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
      */
     private $facetsSerializer;
 
+    /**
+     * @var SearchFactory
+     */
+    private $searchFactory;
+
     public function __construct(
         Ps_Facetedsearch $module,
         Filters\Converter $converter,
-        URLSerializer $serializer
+        URLSerializer $serializer,
+        ?SearchFactory $searchFactory = null
     ) {
         $this->module = $module;
         $this->filtersConverter = $converter;
         $this->facetsSerializer = $serializer;
+        $this->searchFactory = $searchFactory == null ? new SearchFactory() : $searchFactory; 
     }
 
     /**
@@ -112,7 +119,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $facetedSearchFilters = $this->filtersConverter->createFacetedSearchFiltersFromQuery($query);
 
         $context = $this->module->getContext();
-        $facetedSearch = new Search($context);
+        $facetedSearch = $this->searchFactory->getSearch($context);
         // init the search with the initial population associated with the current filters
         $facetedSearch->initSearch($facetedSearchFilters);
 

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -61,7 +61,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         Ps_Facetedsearch $module,
         Filters\Converter $converter,
         URLSerializer $serializer,
-        ?SearchFactory $searchFactory = null
+        SearchFactory $searchFactory = null
     ) {
         $this->module = $module;
         $this->filtersConverter = $converter;

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -66,7 +66,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $this->module = $module;
         $this->filtersConverter = $converter;
         $this->facetsSerializer = $serializer;
-        $this-&gt;searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory;
+        $this->searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory;
     }
 
     /**

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -66,7 +66,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $this->module = $module;
         $this->filtersConverter = $converter;
         $this->facetsSerializer = $serializer;
-        $this->searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory; 
+        $this-&gt;searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory;
     }
 
     /**

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -119,7 +119,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $facetedSearchFilters = $this->filtersConverter->createFacetedSearchFiltersFromQuery($query);
 
         $context = $this->module->getContext();
-        $facetedSearch = $this->searchFactory->getSearch($context);
+        $facetedSearch = $this->searchFactory->build($context);
         // init the search with the initial population associated with the current filters
         $facetedSearch->initSearch($facetedSearchFilters);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | A module can easily provide a custom search provider but often what the ps_faceted_search module does is 90% what is needed.  At the moment, this module is difficult to reuse and customizing the search requires a completely new implementation.  This PR would allow a module to reuse ps_faceted_search implementation while allowing for some customization, in the building of the query in particular.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#20865
| How to test?  | `composer run test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/206)
<!-- Reviewable:end -->
