### PR TITLE
Add flag to change the page is migrated

### DIFF
--- a/src/Hook/Feature.php
+++ b/src/Hook/Feature.php
@@ -79,7 +79,7 @@ class Feature extends AbstractHook
     /**
      * Hook after create feature.
      *
-     * @since PrestaShop 1.7.7.0
+     * @since PrestaShop 1.7.8.0
      *
      * @param array $params
      */
@@ -91,7 +91,7 @@ class Feature extends AbstractHook
     /**
      * Hook after update feature.
      *
-     * @since PrestaShop 1.7.7.0
+     * @since PrestaShop 1.7.8.0
      *
      * @param array $params
      */
@@ -212,7 +212,7 @@ class Feature extends AbstractHook
      * @param int $featureId
      * @param array $formData
      *
-     * @since PrestaShop 1.7.7
+     * @since PrestaShop 1.7.8.0
      */
     private function save($featureId, array $formData)
     {

--- a/src/Hook/Feature.php
+++ b/src/Hook/Feature.php
@@ -40,6 +40,11 @@ class Feature extends AbstractHook
      */
     private $dataProvider;
 
+    /**
+     * @var bool
+     */
+    private $isMigratedPage = false;
+
     public function __construct(Ps_Facetedsearch $module)
     {
         parent::__construct($module);
@@ -67,6 +72,7 @@ class Feature extends AbstractHook
      */
     public function actionFeatureFormBuilderModifier(array $params)
     {
+        $this->isMigratedPage = true;
         $this->formModifier->modify($params['form_builder'], $this->dataProvider->getData($params));
     }
 
@@ -129,7 +135,7 @@ class Feature extends AbstractHook
      */
     public function displayFeatureForm(array $params)
     {
-        if (version_compare(_PS_VERSION_, '1.7.7.0') >= 0) {
+        if ($this->isMigratedPage === true) {
             return;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The version condition is not enough, we should display the hook only if the migrated page is loaded.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#21546
| How to test?  | Load feature form in 1.7.7.x and on develop branch.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/239)
<!-- Reviewable:end -->
