### PR TITLE
Fixed facet filters disappear and won’t come back after filter reset

### DIFF
--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -17,7 +17,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <div id="search_filters">
-{if $displayedFacets|count}
+  {if $displayedFacets|count}
     {block name='facets_title'}
       <p class="text-uppercase h6 hidden-sm-down">{l s='Filter By' d='Shop.Theme.Actions'}</p>
     {/block}
@@ -176,5 +176,5 @@
         {/if}
       </section>
     {/foreach}
-{/if}
+  {/if}
 </div>

--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -16,8 +16,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
+<div id="search_filters">
 {if $displayedFacets|count}
-  <div id="search_filters">
     {block name='facets_title'}
       <p class="text-uppercase h6 hidden-sm-down">{l s='Filter By' d='Shop.Theme.Actions'}</p>
     {/block}
@@ -176,5 +176,5 @@
         {/if}
       </section>
     {/foreach}
-  </div>
 {/if}
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Before fix, facet filters could disappear on filtering and not come back on reset.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#22488.
| How to test?  | See ticket.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/293)
<!-- Reviewable:end -->
