### PR TITLE
Optimize price search

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -279,7 +279,7 @@ class Search
      */
     private function addPriceFilter($minPrice, $maxPrice)
     {
-        $this->getSearchAdapter()->addFilter('price_min', [$minPrice], '>=');
-        $this->getSearchAdapter()->addFilter('price_max', [$maxPrice], '<=');
+        $this->getSearchAdapter()->addFilter('price_min', [$maxPrice], '<=');
+        $this->getSearchAdapter()->addFilter('price_max', [$minPrice], '>=');
     }
 }

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -190,16 +190,16 @@ class SearchTest extends MockeryTestCase
                     ],
                 ],
                 'price_min' => [
-                    '>=' => [
+                    '<=' => [
                         [
-                            50.0,
+                            200.0,
                         ],
                     ],
                 ],
                 'price_max' => [
-                    '<=' => [
+                    '>=' => [
                         [
-                            200.0,
+                            50.0,
                         ],
                     ],
                 ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Make sure the minPrice is lower than the price_max, and maxPrice higher than price_min in layered_price_index table
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#16822
| How to test?  | See ticket.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/300)
<!-- Reviewable:end -->
