### PR TITLE
Fix migration from blocklayered

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -186,8 +186,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
             $this->rebuildPriceIndexTable();
 
-            $this->getDatabase()->execute('TRUNCATE TABLE ' . _DB_PREFIX_ . 'layered_filter CHANGE `filters` `filters` LONGTEXT NULL');
-            $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'friendly_url');
+            $this->getDatabase()->execute('ALTER TABLE ' . _DB_PREFIX_ . 'layered_filter CHANGE `filters` `filters` LONGTEXT NULL');
+            $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_friendly_url');
         } else {
             Configuration::updateValue('PS_LAYERED_CACHE_ENABLED', 1);
             Configuration::updateValue('PS_LAYERED_SHOW_QTIES', 1);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Because of wrong SQL queries, installing this module over the old blocklayered one in the BO fails. Also, when deleting it, the table `ps_layered_friendly_url` is still in the DB.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially PrestaShop/Prestashop#22668
| How to test?  | 1. On PS 1.7.x.x, uninstall any existing ps_facetedsearch or blocklayered module.<br>2. Check that your DB doesn't have any table starting with `ps_layered_*`.<br>3. Install [this **modified** version of blocklayered](https://github.com/PrestaShop/ps_facetedsearch/files/5787806/blocklayered.zip) (only the compatibility range has been changed so we can install it manually on a 1.7.x.x shop).<br>4. Install ps_facetedsearch with this PR, the install should not cause any problem.<br>5. Check that blocklayered is uninstalled and that the table `ps_layered_friendly_url` is **not** present in the DB.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/302)
<!-- Reviewable:end -->
