### PR TITLE
Hide or display others filters

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -198,6 +198,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
+            Configuration::updateValue('PS_LAYERED_HIDE_OTHERS_FILTERS', 1);
 
             $this->psLayeredFullTree = 1;
 
@@ -235,6 +236,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
+        Configuration::deleteByName('PS_LAYERED_HIDE_OTHERS_FILTERS');
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_category');
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_filter');
@@ -697,6 +699,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
+            Configuration::updateValue('PS_LAYERED_HIDE_OTHERS_FILTERS', (int) Tools::getValue('ps_layered_hide_others_filters'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -831,6 +834,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
+            'hide_others_filters' => (bool) Configuration::get('PS_LAYERED_HIDE_OTHERS_FILTERS'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -448,7 +448,8 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         foreach ($facets as $facet) {
             if ($facet->getWidgetType() === 'slider') {
                 $facet->setDisplayed(
-                    $facet->getProperty('min') != $facet->getProperty('max')
+                    !(int) Configuration::get('PS_LAYERED_HIDE_OTHERS_FILTERS')
+                    || $facet->getProperty('min') != $facet->getProperty('max')
                 );
                 continue;
             }

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -464,7 +464,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
             $facet->setDisplayed(
                 // There are two filters displayed
-                $usefulFiltersCount > Configuration::get('PS_LAYERED_HIDE_OTHERS_FILTERS') ? 1 : 0
+                $usefulFiltersCount > (int) Configuration::get('PS_LAYERED_HIDE_OTHERS_FILTERS')
                 ||
                 /*
                  * There is only one fitler and the

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -186,7 +186,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
         $this->labelRangeFilters($facets);
         $this->addEncodedFacetsToFilters($facets);
-        $this->hideUselessFacets($facets, (int)$result->getTotalProductsCount());
+        $this->hideUselessFacets($facets, (int) $result->getTotalProductsCount());
 
         $facetCollection = new FacetCollection();
         $nextMenu = $facetCollection->setFacets($facets);

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -186,7 +186,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
         $this->labelRangeFilters($facets);
         $this->addEncodedFacetsToFilters($facets);
-        $this->hideUselessFacets($facets, (int) $result->getTotalProductsCount());
+        $this->hideUselessFacets($facets, (int)$result->getTotalProductsCount());
 
         $facetCollection = new FacetCollection();
         $nextMenu = $facetCollection->setFacets($facets);
@@ -464,7 +464,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
             $facet->setDisplayed(
                 // There are two filters displayed
-                $usefulFiltersCount > 1
+                $usefulFiltersCount > Configuration::get('PS_LAYERED_HIDE_OTHERS_FILTERS') ? 1 : 0
                 ||
                 /*
                  * There is only one fitler and the

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -182,6 +182,23 @@
 	</div>
 
 	<div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='Hide the others filters when no results with active filter' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_hide_others_filters" id="ps_layered_hide_others_filters_on" value="1"{if $hide_others_filters} checked="checked"{/if}>
+		  <label for="ps_layered_hide_others_filters_on" class="radioCheck">
+			<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_hide_others_filters" id="ps_layered_hide_others_filters_off" value="0"{if !$hide_others_filters} checked="checked"{/if}>
+		  <label for="ps_layered_hide_others_filters_off" class="radioCheck">
+			<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+	  </div>
+	</div>
+
+	<div class="form-group">
 	  <label class="col-lg-3 control-label">{l s='Category filter depth (0 for no limits, 1 by default)' d='Modules.Facetedsearch.Admin'}</label>
 	  <div class="col-lg-9">
 		<input type="text" name="ps_layered_filter_category_depth" value="{if $category_depth !== false}{$category_depth}{else}1{/if}" class="fixed-width-sm" />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Possibility to display or hide others filters when only one result with active filter
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially PrestaShop/Prestashop#10018
| How to test?  | Hiding (by default) does not change the previous behaviour.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/315)
<!-- Reviewable:end -->
