### PR TITLE
Set default check on filter by stock if "only show available" active

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -359,6 +359,9 @@ class Converter
                     }
             }
         }
+        if (0 == Configuration::get('PS_DISP_UNAVAILABLE_ATTR') && !isset($searchFilters[self::TYPE_QUANTITY])) {
+            $searchFilters[self::TYPE_QUANTITY] = [1];
+        }
 
         // Remove all empty selected filters
         foreach ($searchFilters as $key => $value) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If filter by stock is not set and only show available at the shop is set, then apply a default to filter only content with stock at the search results
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially PrestaShop/PrestaShop#10018
| How to test?  | At BO: At the facetedsearch config, set "Show unavailable, out of stock last" to NO; setup a few products with combinations; add stock only to some of those combinations in one product and add stock to the rest of combinations in other products   At FO: use the faceted search to filter by a particular combination that only one of the products has stock --- You should see only the products wirh stock on that filtered combination.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
