### PR TITLE
Use the same version as it is defined in the composer.lock

### DIFF
--- a/tests/php/phpstan.sh
+++ b/tests/php/phpstan.sh
@@ -23,6 +23,6 @@ echo "Run PHPStan using phpstan-${PS_VERSION}.neon file"
 docker run --rm --volumes-from temp-ps \
        -v $PWD:/var/www/html/modules/ps_facetedsearch \
        -e _PS_ROOT_DIR_=/var/www/html \
-       --workdir=/var/www/html/modules/ps_facetedsearch phpstan/phpstan:0.12 \
+       --workdir=/var/www/html/modules/ps_facetedsearch phpstan/phpstan:0.12.54 \
        analyse \
        --configuration=/var/www/html/modules/ps_facetedsearch/tests/php/phpstan/phpstan-$PS_VERSION.neon


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use the same version as it is defined un the composer.lock instead of using the latest 0.12 version
| Type?         | bug fix

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/420)
<!-- Reviewable:end -->
