### PR TITLE
Fix facets not showing after empty facet is cleared

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -211,9 +211,9 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         list($activeFilters, $displayedFacets, $facetsVar) = $this->prepareActiveFiltersForRender($context, $result);
 
         // If there are no facets, initialize empty array.
-        if (empty($facetsVar))
+        if (empty($facetsVar)) {
             $this->module->getContext()->smarty->assign('displayedFacets', []);
-        else 
+        } else {
             $this->module->getContext()->smarty->assign(
                 [
                     'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
@@ -230,6 +230,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                     ),
                 ]
             );
+        }
 
         // Always render facets even when they are empty.
         return $this->module->fetch(

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -210,28 +210,28 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
     {
         list($activeFilters, $displayedFacets, $facetsVar) = $this->prepareActiveFiltersForRender($context, $result);
 
-        // No need to render without facets
-        if (empty($facetsVar)) {
-            return '';
-        }
+        // If there are no facets, initialize empty array.
+        if (empty($facetsVar))
+            $this->module->getContext()->smarty->assign('displayedFacets', []);
+        else 
+            $this->module->getContext()->smarty->assign(
+                [
+                    'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
+                    'facets' => $facetsVar,
+                    'js_enabled' => $this->module->isAjax(),
+                    'displayedFacets' => $displayedFacets,
+                    'activeFilters' => $activeFilters,
+                    'sort_order' => $result->getCurrentSortOrder()->toString(),
+                    'clear_all_link' => $this->updateQueryString(
+                        [
+                            'q' => null,
+                            'page' => null,
+                        ]
+                    ),
+                ]
+            );
 
-        $this->module->getContext()->smarty->assign(
-            [
-                'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
-                'facets' => $facetsVar,
-                'js_enabled' => $this->module->isAjax(),
-                'displayedFacets' => $displayedFacets,
-                'activeFilters' => $activeFilters,
-                'sort_order' => $result->getCurrentSortOrder()->toString(),
-                'clear_all_link' => $this->updateQueryString(
-                    [
-                        'q' => null,
-                        'page' => null,
-                    ]
-                ),
-            ]
-        );
-
+        // Always render facets even when they are empty.
         return $this->module->fetch(
             'module:ps_facetedsearch/views/templates/front/catalog/facets.tpl'
         );

--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -16,8 +16,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-{if $displayedFacets|count}
-  <div id="search_filters">
+<div id="search_filters">
+  {if $displayedFacets|count}
     {block name='facets_title'}
       <p class="text-uppercase h6 hidden-sm-down">{l s='Filter By' d='Shop.Theme.Actions'}</p>
     {/block}
@@ -176,5 +176,5 @@
         {/if}
       </section>
     {/foreach}
-  </div>
-{/if}
+  {/if}
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes an issue where the facets will disappear and won't re-appear after removing the active filters. This issue occurs when clearing an empty facet (i.e. there are no available facet to display due to the current active filters)
| Type?         | bug fix
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes PrestaShop/Prestashop#22488
| How to test?  | Follow reproduction steps in above ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/448)
<!-- Reviewable:end -->
