### PR TITLE
Fix for filter on subcategories with the same name

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -389,7 +389,7 @@ class Converter
                 case self::TYPE_CATEGORY:
                     if (isset($facetAndFiltersLabels[$filterLabel])) {
                         foreach ($facetAndFiltersLabels[$filterLabel] as $queryFilter) {
-                            $categories = Category::searchByName($idLang, $queryFilter, true);
+                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $query->getIdCategory());
                             if ($categories) {
                                 $searchFilters[$filter['type']][] = $categories['id_category'];
                             }


### PR DESCRIPTION
This pull request fix the issue with the ps_faceted search modules sub category filter. It is mixing what category it should fetch products from when there are several categories with the same name.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This pull request fix the issue with the sub category filter mixing what category it should fetch products from.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#24764.
| How to test?  | Follow instructions in Ticket.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/449)
<!-- Reviewable:end -->
