### PR TITLE
Enable filtering by stock properly

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -410,7 +410,7 @@ class Block
     private function getQuantitiesBlock($filter, $selectedFilters)
     {
         $filteredSearchAdapter = $this->searchAdapter->getFilteredSearchAdapter(Search::STOCK_MANAGEMENT_FILTER);
-        $quantityArray = [
+        $availabilityOptions = [
             0 => [
                 'name' => $this->context->getTranslator()->trans(
                     'Not available',
@@ -420,6 +420,14 @@ class Block
                 'nbr' => 0,
             ],
             1 => [
+                'name' => $this->context->getTranslator()->trans(
+                    'Available',
+                    [],
+                    'Modules.Facetedsearch.Shop'
+                ),
+                'nbr' => 0,
+            ],
+            2 => [
                 'name' => $this->context->getTranslator()->trans(
                     'In stock',
                     [],
@@ -438,7 +446,7 @@ class Block
         }
 
         if ($this->psStockManagement) {
-            $results = [];
+            // Products without quantity in stock, with out-of-stock ordering disabled
             $filteredSearchAdapter->addOperationsFilter(
                 Search::STOCK_MANAGEMENT_FILTER,
                 [
@@ -448,10 +456,9 @@ class Block
                     ],
                 ]
             );
-            $results[0] = [
-                'c' => $filteredSearchAdapter->count(),
-            ];
+            $availabilityOptions[0]['nbr'] = $filteredSearchAdapter->count();
 
+            // Products in stock, or with out-of-stock ordering enabled
             $filteredSearchAdapter->addOperationsFilter(
                 Search::STOCK_MANAGEMENT_FILTER,
                 [
@@ -464,16 +471,28 @@ class Block
                     ],
                 ]
             );
-            $results[1] = [
-                'c' => $filteredSearchAdapter->count(),
-            ];
+            $availabilityOptions[1]['nbr'] = $filteredSearchAdapter->count();
 
-            foreach ($results as $key => $values) {
-                $count = $values['c'];
+            // Products in stock
+            $filteredSearchAdapter->addOperationsFilter(
+                Search::STOCK_MANAGEMENT_FILTER,
+                [
+                    [
+                        ['quantity', [0], '>'],
+                    ],
+                ]
+            );
+            $availabilityOptions[2]['nbr'] = $filteredSearchAdapter->count();
 
-                $quantityArray[$key]['nbr'] = $count;
-                if (isset($selectedFilters['quantity']) && in_array($key, $selectedFilters['quantity'], true)) {
-                    $quantityArray[$key]['checked'] = true;
+            // If some filter was selected, we want to show only this single filter, it does not make sense to show others
+            if (isset($selectedFilters['quantity'])) {
+                // We loop through selected filters and assign it to our options and remove the rest
+                foreach ($availabilityOptions as $key => $values) {
+                    if (in_array($key, $selectedFilters['quantity'], true)) {
+                        $availabilityOptions[$key]['checked'] = true;
+                    } else {
+                        unset($availabilityOptions[$key]);
+                    }
                 }
             }
         }
@@ -483,7 +502,7 @@ class Block
             'type' => 'quantity',
             'id_key' => 0,
             'name' => $this->context->getTranslator()->trans('Availability', [], 'Modules.Facetedsearch.Shop'),
-            'values' => $quantityArray,
+            'values' => $availabilityOptions,
             'filter_show_limit' => (int) $filter['filter_show_limit'],
             'filter_type' => $filter['filter_type'],
         ];

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -420,7 +420,6 @@ class Block
         // We only initialize the options if stock management is activated
         $availabilityOptions = [];
         if ($this->psStockManagement) {
-
             $availabilityOptions = [
                 0 => [
                     'name' => $this->context->getTranslator()->trans(

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -493,8 +493,6 @@ class Block
                 foreach ($availabilityOptions as $key => $values) {
                     if (in_array($key, $selectedFilters['quantity'], true)) {
                         $availabilityOptions[$key]['checked'] = true;
-                    } else {
-                        unset($availabilityOptions[$key]);
                     }
                 }
             }

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -409,34 +409,6 @@ class Block
      */
     private function getQuantitiesBlock($filter, $selectedFilters)
     {
-        $filteredSearchAdapter = $this->searchAdapter->getFilteredSearchAdapter(Search::STOCK_MANAGEMENT_FILTER);
-        $availabilityOptions = [
-            0 => [
-                'name' => $this->context->getTranslator()->trans(
-                    'Not available',
-                    [],
-                    'Modules.Facetedsearch.Shop'
-                ),
-                'nbr' => 0,
-            ],
-            1 => [
-                'name' => $this->context->getTranslator()->trans(
-                    'Available',
-                    [],
-                    'Modules.Facetedsearch.Shop'
-                ),
-                'nbr' => 0,
-            ],
-            2 => [
-                'name' => $this->context->getTranslator()->trans(
-                    'In stock',
-                    [],
-                    'Modules.Facetedsearch.Shop'
-                ),
-                'nbr' => 0,
-            ],
-        ];
-
         if ($this->psStockManagement === null) {
             $this->psStockManagement = (bool) Configuration::get('PS_STOCK_MANAGEMENT');
         }
@@ -445,7 +417,39 @@ class Block
             $this->psOrderOutOfStock = (bool) Configuration::get('PS_ORDER_OUT_OF_STOCK');
         }
 
+        // We only initialize the options if stock management is activated
+        $availabilityOptions = [];
         if ($this->psStockManagement) {
+
+            $availabilityOptions = [
+                0 => [
+                    'name' => $this->context->getTranslator()->trans(
+                        'Not available',
+                        [],
+                        'Modules.Facetedsearch.Shop'
+                    ),
+                    'nbr' => 0,
+                ],
+                1 => [
+                    'name' => $this->context->getTranslator()->trans(
+                        'Available',
+                        [],
+                        'Modules.Facetedsearch.Shop'
+                    ),
+                    'nbr' => 0,
+                ],
+                2 => [
+                    'name' => $this->context->getTranslator()->trans(
+                        'In stock',
+                        [],
+                        'Modules.Facetedsearch.Shop'
+                    ),
+                    'nbr' => 0,
+                ],
+            ];
+
+            $filteredSearchAdapter = $this->searchAdapter->getFilteredSearchAdapter(Search::STOCK_MANAGEMENT_FILTER);
+
             // Products without quantity in stock, with out-of-stock ordering disabled
             $filteredSearchAdapter->addOperationsFilter(
                 Search::STOCK_MANAGEMENT_FILTER,

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -280,10 +280,15 @@ class Converter
                             'Modules.Facetedsearch.Shop'
                         ) => 0,
                         $this->context->getTranslator()->trans(
-                            'In stock',
+                            'Available',
                             [],
                             'Modules.Facetedsearch.Shop'
                         ) => 1,
+                        $this->context->getTranslator()->trans(
+                            'In stock',
+                            [],
+                            'Modules.Facetedsearch.Shop'
+                        ) => 2,
                     ];
 
                     $searchFilters[$filter['type']] = [];

--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -89,7 +89,7 @@ class Products
 
         $this->pricePostFiltering($matchingProductList, $selectedFilters);
 
-        $nbrProducts = count($matchingProductList);
+        $nbrProducts = $this->searchAdapter->count();
 
         if (empty($nbrProducts)) {
             $matchingProductList = [];

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -204,7 +204,7 @@ class Search
                             ];
                         }
                         // Cases with 2 options selected
-                    } else if (count($filterValues) == 2) {
+                    } elseif (count($filterValues) == 2) {
                         // Not available and available, we show everything
                         if (in_array(0, $filterValues) && in_array(1, $filterValues)) {
                             break;

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -161,7 +161,7 @@ class Search
                     break;
 
                 case 'quantity':
-                    /* 
+                    /*
                     * $filterValues options can have following values:
                     * 0 - Not available - 0 or less quantity and disabled backorders
                     * 1 - Available - Positive quantity or enabled backorders
@@ -189,7 +189,7 @@ class Search
                                 ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
                             ];
                         // Available
-                        } else if ($filterValues[0] == 1) {
+                        } elseif ($filterValues[0] == 1) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '>='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
@@ -203,13 +203,13 @@ class Search
                                 ['quantity', [0], '>'],
                             ];
                         }
-                    // Cases with 2 options selected
+                        // Cases with 2 options selected
                     } else if (count($filterValues) == 2) {
                         // Not available and available, we show everything
                         if (in_array(0, $filterValues) && in_array(1, $filterValues)) {
                             break;
                         // Not available or in stock
-                        } else if (in_array(0, $filterValues) && in_array(2, $filterValues)) {
+                        } elseif (in_array(0, $filterValues) && in_array(2, $filterValues)) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '<='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
@@ -218,7 +218,7 @@ class Search
                                 ['quantity', [0], '>'],
                             ];
                         // Available or in stock
-                        } else if (in_array(1, $filterValues) && in_array(2, $filterValues)) {
+                        } elseif (in_array(1, $filterValues) && in_array(2, $filterValues)) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '>='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -161,40 +161,72 @@ class Search
                     break;
 
                 case 'quantity':
-                    // If all three are checked, we show everything
-                    if (count($selectedFilters['quantity']) == 3) {
+                    /* 
+                    * $filterValues options can have following values:
+                    * 0 - Not available - 0 or less quantity and disabled backorders
+                    * 1 - Available - Positive quantity or enabled backorders
+                    * 2 - In stock - Positive quantity
+                    */
+
+                    // If all three values are checked, we show everything
+                    if (count($filterValues) == 3) {
                         break;
                     }
 
+                    // If stock management is deactivated, we show everything
                     if (!$this->psStockManagement) {
-                        $this->getSearchAdapter()->addFilter('quantity', [0], (!$filterValues[0] ? '<=' : '>'));
                         break;
                     }
 
                     $operationsFilter = [];
 
-                    // Filter for available products
-                    // We want product with out_of_stock at 1 or 2, which mean we can buy out of stock products
-                    // Or products with positive quantity
-                    if ($filterValues[0] == 1) {
-                        $operationsFilter[] = [
-                            ['quantity', [0], '>='],
-                            ['out_of_stock', [1], $this->psOrderOutOfStock ? '>=' : '='],
-                        ];
-                        $operationsFilter[] = [
-                            ['quantity', [0], '>'],
-                        ];
-                    // Filter for products in stock, we want only products with positive quantity
-                    } elseif ($filterValues[0] == 2) {
-                        $operationsFilter[] = [
-                            ['quantity', [0], '>'],
-                        ];
-                    // Filter for products out of stock
-                    } else {
-                        $operationsFilter[] = [
-                            ['quantity', [0], '<='],
-                            ['out_of_stock', !$this->psOrderOutOfStock ? [0, 2] : [0], '='],
-                        ];
+                    // Simple cases with 1 option selected
+                    if (count($filterValues) == 1) {
+                        // Not available
+                        if ($filterValues[0] == 0) {
+                            $operationsFilter[] = [
+                                ['quantity', [0], '<='],
+                                ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
+                            ];
+                        // Available
+                        } else if ($filterValues[0] == 1) {
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>='],
+                                ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
+                            ];
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>'],
+                            ];
+                        // In stock
+                        } elseif ($filterValues[0] == 2) {
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>'],
+                            ];
+                        }
+                    // Cases with 2 options selected
+                    } else if (count($filterValues) == 2) {
+                        // Not available and available, we show everything
+                        if (in_array(0, $filterValues) && in_array(1, $filterValues)) {
+                            break;
+                        // Not available or in stock
+                        } else if (in_array(0, $filterValues) && in_array(2, $filterValues)) {
+                            $operationsFilter[] = [
+                                ['quantity', [0], '<='],
+                                ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
+                            ];
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>'],
+                            ];
+                        // Available or in stock
+                        } else if (in_array(1, $filterValues) && in_array(2, $filterValues)) {
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>='],
+                                ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
+                            ];
+                            $operationsFilter[] = [
+                                ['quantity', [0], '>'],
+                            ];
+                        }
                     }
 
                     $this->getSearchAdapter()->addOperationsFilter(

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -161,7 +161,8 @@ class Search
                     break;
 
                 case 'quantity':
-                    if (count($selectedFilters['quantity']) == 2) {
+                    // If all three are checked, we show everything
+                    if (count($selectedFilters['quantity']) == 3) {
                         break;
                     }
 
@@ -171,10 +172,11 @@ class Search
                     }
 
                     $operationsFilter = [];
-                    if ($filterValues[0]) {
-                        // Filter for available quantity, we must be able to request
-                        // product with out_of_stock at 1 or 2
-                        // which mean we can buy out of stock products
+
+                    // Filter for available products
+                    // We want product with out_of_stock at 1 or 2, which mean we can buy out of stock products
+                    // Or products with positive quantity
+                    if ($filterValues[0] == 1) {
                         $operationsFilter[] = [
                             ['quantity', [0], '>='],
                             ['out_of_stock', [1], $this->psOrderOutOfStock ? '>=' : '='],
@@ -182,6 +184,12 @@ class Search
                         $operationsFilter[] = [
                             ['quantity', [0], '>'],
                         ];
+                    // Filter for products in stock, we want only products with positive quantity
+                    } elseif ($filterValues[0] == 2) {
+                        $operationsFilter[] = [
+                            ['quantity', [0], '>'],
+                        ];
+                    // Filter for products out of stock
                     } else {
                         $operationsFilter[] = [
                             ['quantity', [0], '<='],

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -339,6 +339,7 @@ class BlockTest extends MockeryTestCase
             [['Availability', [], 'Modules.Facetedsearch.Shop'], 'Quantity'],
             [['Not available', [], 'Modules.Facetedsearch.Shop'], 'Not available'],
             [['In stock', [], 'Modules.Facetedsearch.Shop'], 'In stock'],
+            [['Available', [], 'Modules.Facetedsearch.Shop'], 'Available'],
         ]);
         $this->mockLayeredCategory([['type' => 'quantity', 'filter_show_limit' => 0, 'filter_type' => 1]]);
 

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -360,6 +360,13 @@ class BlockTest extends MockeryTestCase
                 ['c' => 100],
             ]);
 
+        $this->dbMock->shouldReceive('executeS')
+            ->once()
+            ->with('SELECT COUNT(DISTINCT p.id_product) c FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) WHERE ((sa.quantity>0))')
+            ->andReturn([
+                ['c' => 50],
+            ]);
+
         $this->adapterMock->shouldReceive('getFilteredSearchAdapter')
             ->with('quantity')
             ->andReturn($adapterInitialMock);
@@ -378,9 +385,13 @@ class BlockTest extends MockeryTestCase
                                 'nbr' => 1000,
                             ],
                             [
-                                'name' => 'In stock',
+                                'name' => 'Available',
                                 'nbr' => 100,
                                 'checked' => true,
+                            ],
+                            [
+                                'name' => 'In stock',
+                                'nbr' => 50,
                             ],
                         ],
                         'filter_show_limit' => 0,

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -603,11 +603,6 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
-                'quantity' => [
-                    '<=' => [
-                        [0],
-                    ],
-                ],
             ],
             $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
         );

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -71,6 +71,62 @@ class SearchTest extends MockeryTestCase
         );
     }
 
+    public function testInitSearchWithoutCorrectSelectedFilters()
+    {
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $this->search->initSearch(['quantity' => []]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'id_category_default' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_shop' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+                'visibility' => [
+                    '=' => [
+                        [
+                            'both',
+                            'catalog',
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
+        );
+        $this->assertEquals([], $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray());
+    }
+
     public function testInitSearchWithEmptyFilters()
     {
         $toolsMock = Mockery::mock(Tools::class);
@@ -465,6 +521,181 @@ class SearchTest extends MockeryTestCase
                                 3,
                                 4,
                             ],
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray()
+        );
+    }
+
+    public function testInitSearchWithQuantityFiltersWithoutStockManagement()
+    {
+        $mock = Mockery::mock(Configuration::class);
+        $mock->shouldReceive('get')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'PS_STOCK_MANAGEMENT' => false,
+                    'PS_ORDER_OUT_OF_STOCK' => true,
+                    'PS_HOME_CATEGORY' => true,
+                    'PS_LAYERED_FULL_TREE' => false,
+                    'PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY' => true,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Configuration::setStaticExpectations($mock);
+
+        $contextMock = Mockery::mock(Context::class);
+        $contextMock->shop = new stdClass();
+        $contextMock->shop->id = 1;
+
+        Context::setStaticExpectations($contextMock);
+
+        $this->search = new Search($contextMock);
+
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $this->search->initSearch(['quantity' => [0]]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'id_category_default' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_shop' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+                'visibility' => [
+                    '=' => [
+                        [
+                            'both',
+                            'catalog',
+                        ],
+                    ],
+                ],
+                'quantity' => [
+                    '<=' => [
+                        [0],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
+        );
+        $this->assertEquals([], $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray());
+    }
+
+    public function testInitSearchWithFirstQuantityFilters()
+    {
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $this->search->initSearch(['quantity' => [1]]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'with_stock_management' => [
+                    [
+                        [
+                            'quantity',
+                            [
+                                0,
+                            ],
+                            '>=',
+                        ],
+                        [
+                            'out_of_stock',
+                            [
+                                1,
+                            ],
+                            '>=',
+                        ],
+                    ],
+                    [
+                        [
+                            'quantity',
+                            [
+                                0,
+                            ],
+                            '>',
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray()
+        );
+    }
+
+    public function testInitSearchWithSecondQuantityFilters()
+    {
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $this->search->initSearch(['quantity' => [2]]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'with_stock_management' => [
+                    [
+                        [
+                            'quantity',
+                            [
+                                0,
+                            ],
+                            '>',
                         ],
                     ],
                 ],

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -643,8 +643,9 @@ class SearchTest extends MockeryTestCase
                             'out_of_stock',
                             [
                                 1,
+                                2,
                             ],
-                            '>=',
+                            '=',
                         ],
                     ],
                     [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Type?         | bug fix / improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#14518
| How to test?  | See below

### Description
- This PR enables to filter products by quantity in stock, like it was in PrestaShop 1.6. You now have three options:
  - Not available - shows product with zero quantity and disabled out-of-stock ordering. (not very useful but kept it - users can remove it in their TPL)
  - Available - shows products in stock or with enabled out-of-stock ordering
  - In stock - shows products in stock (new option I added)

### How to test
1. Make 4 products
  A. Quantity 0, disabled backorder.
  B. Quantity 0, enabled backorder.
  C. Quantity 1.
  D. Product with 2 combinations, one combination quantity 1, one combination quantity 0, backorder disabled.
2. Setup filter, clear cache if needed
3. Go try the filter and see that it works properly.

You should get
- In stock - 2 - C, D
- Available - 1 - B
- Not available - 2 - A, D

### Screenshot
![in stock](https://user-images.githubusercontent.com/6097524/127305117-13decdff-822e-415b-9541-99e61e55edfd.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/479)
<!-- Reviewable:end -->

ping @kpodemski @PierreRambaud 