### PR TITLE
Ability for module to work on all pages

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -72,7 +72,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
      *
      * @var array
      */
-    private $available_controllers = [];
+    public $available_controllers = [];
 
     /**
      * @var bool
@@ -112,13 +112,34 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
 
         $this->available_controllers = [
-            'category' => $this->trans('Category', [], 'Modules.Facetedsearch.Admin'),
-            'search' => $this->trans('Search', [], 'Modules.Facetedsearch.Admin'),
-            'manufacturer' => $this->trans('Manufacturer', [], 'Modules.Facetedsearch.Admin'),
-            'supplier' => $this->trans('Supplier', [], 'Modules.Facetedsearch.Admin'),
-            'new-products' => $this->trans('New products', [], 'Modules.Facetedsearch.Admin'),
-            'best-sales' => $this->trans('Best sales', [], 'Modules.Facetedsearch.Admin'),
-            'prices-drop' => $this->trans('Prices drop', [], 'Modules.Facetedsearch.Admin'),
+            'category' => [
+                'name' => $this->trans('Category', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => true,
+            ],
+            'search' => [
+                'name' => $this->trans('Search', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => true,
+            ],
+            'manufacturer' => [
+                'name' => $this->trans('Manufacturer', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => true,
+            ],
+            'supplier' => [
+                'name' => $this->trans('Supplier', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => true,
+            ],
+            'new-products' => [
+                'name' => $this->trans('New products', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => false,
+            ],
+            'best-sales' => [
+                'name' => $this->trans('Best sales', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => false,
+            ],
+            'prices-drop' => [
+                'name' => $this->trans('Prices drop', [], 'Modules.Facetedsearch.Admin'),
+                'cacheable' => false,
+            ],
         ];
 
         $this->hookDispatcher = new HookDispatcher($this);
@@ -827,7 +848,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $id_layered_filter = 0;
         $filters = [];
         $template_name = sprintf($this->trans('My template - %s', [], 'Modules.Facetedsearch.Admin'), date('Y-m-d'));
-        $controller_options = $this->getAvailableControllerOptions();
+        $controller_options = $this->getAvailableControllers();
         $features = $this->getAvailableFeatures();
         $attributeGroups = $this->getAvailableAttributes();
         $treeCategoriesHelper = new HelperTreeCategories('categories-treeview');
@@ -917,19 +938,9 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     /**
      * Returns array with all available controllers on the shop
      */
-    private function getAvailableControllerOptions()
+    public function getAvailableControllers()
     {
-        // Available controllers
-        $controller_options = [];
-        foreach ($this->available_controllers as $controller => $name) {
-            $controller_options[$controller] = [
-                'controller' => $controller,
-                'name' => $name,
-                'checked' => false,
-            ];
-        }
-
-        return $controller_options;
+        return $this->available_controllers;
     }
 
     /**
@@ -951,7 +962,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             foreach ($data['controllers'] as $c) {
                 // If we have a translation for the controller set in the template, we assign it
                 if (isset($this->available_controllers[$c])) {
-                    $list[] = $this->available_controllers[$c];
+                    $list[] = $this->available_controllers[$c]['name'];
                 }
             }
             $filters_templates[$k]['controllers'] = implode(', ', $list);

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -90,21 +90,28 @@ class Block
      */
     public function getFilterBlock(
         $nbProducts,
-        $selectedFilters
+        $selectedFilters,
+        $controller,
+        $idCategory
     ) {
         $idLang = (int) $this->context->language->id;
         $idShop = (int) $this->context->shop->id;
-        $idParent = (int) Tools::getValue(
-            'id_category',
-            Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'))
-        );
+        if (empty($idCategory)) {
+            $idCategory = (int) Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'));
+        }
 
-        /* Get the filters for the current category */
+        if ($controller == 'category') {
+            $where = "WHERE controller = 'category' AND id_category = " . $idCategory;
+        } else {
+            $where = "WHERE controller = '" . $controller . "' AND id_category = 0";
+        }
+
+        /* Get the filters for the current page */
         $filters = $this->database->executeS(
             'SELECT type, id_value, filter_show_limit, filter_type ' .
             'FROM ' . _DB_PREFIX_ . 'layered_category ' .
-            'WHERE id_category = ' . $idParent . ' ' .
-            'AND id_shop = ' . $idShop . ' ' .
+            $where .
+            ' AND id_shop = ' . $idShop . ' ' .
             'GROUP BY `type`, id_value ORDER BY position ASC'
         );
 
@@ -136,7 +143,7 @@ class Block
                         array_merge($filterBlocks, $this->getFeaturesBlock($filter, $selectedFilters, $idLang));
                     break;
                 case 'category':
-                    $parent = new Category($idParent, $idLang);
+                    $parent = new Category($idCategory, $idLang);
                     $filterBlocks[] = $this->getCategoriesBlock($filter, $selectedFilters, $idLang, $parent);
             }
         }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -233,18 +233,23 @@ class Converter
         $idShop = (int) $this->context->shop->id;
         $idLang = (int) $this->context->language->id;
 
-        $idParent = $query->getIdCategory();
-        if (empty($idParent)) {
-            $idParent = (int) Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'));
+        $idCategory = $query->getIdCategory();
+        if (empty($idCategory)) {
+            $idCategory = (int) Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'));
         }
 
         $searchFilters = [];
 
-        /* Get the filters for the current category */
+        if ($query->getQueryType() == 'category') {
+            $where = " WHERE controller = 'category' AND id_category = " . $idCategory . ' ';
+        } else {
+            $where = " WHERE controller = '" . $query->getQueryType() . "' AND id_category = 0 ";
+        }
+
+        /* Get the filters for the current page */
         $filters = $this->database->executeS(
-            'SELECT type, id_value, filter_show_limit, filter_type FROM ' . _DB_PREFIX_ . 'layered_category
-            WHERE id_category = ' . (int) $idParent . '
-            AND id_shop = ' . (int) $idShop . '
+            'SELECT type, id_value, filter_show_limit, filter_type FROM ' . _DB_PREFIX_ . 'layered_category ' .
+            $where . ' AND id_shop = ' . (int) $idShop . '
             GROUP BY `type`, id_value ORDER BY position ASC'
         );
 
@@ -389,7 +394,8 @@ class Converter
                 case self::TYPE_CATEGORY:
                     if (isset($facetAndFiltersLabels[$filterLabel])) {
                         foreach ($facetAndFiltersLabels[$filterLabel] as $queryFilter) {
-                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $query->getIdCategory());
+                            $id_category = empty($query->getIdCategory()) ? (int) Configuration::get('PS_HOME_CATEGORY') : (int) $query->getIdCategory();
+                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, $id_category);
                             if ($categories) {
                                 $searchFilters[$filter['type']][] = $categories['id_category'];
                             }

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -40,40 +40,30 @@ class ProductSearch extends AbstractHook
      */
     public function productSearchProvider(array $params)
     {
-        $query = $params['query'];
-        // do something with query,
-        // e.g. use $query->getIdCategory()
-        // to choose a template for filters.
-        // Query is an instance of:
-        // PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery
-        if ($query->getIdCategory()) {
-            $this->context->controller->addJqueryUi('slider');
-            $this->context->controller->registerStylesheet(
-                'facetedsearch_front',
-                '/modules/ps_facetedsearch/views/dist/front.css'
-            );
-            $this->context->controller->registerJavascript(
-                'facetedsearch_front',
-                '/modules/ps_facetedsearch/views/dist/front.js',
-                ['position' => 'bottom', 'priority' => 100]
-            );
+        $this->context->controller->addJqueryUi('slider');
+        $this->context->controller->registerStylesheet(
+            'facetedsearch_front',
+            '/modules/ps_facetedsearch/views/dist/front.css'
+        );
+        $this->context->controller->registerJavascript(
+            'facetedsearch_front',
+            '/modules/ps_facetedsearch/views/dist/front.js',
+            ['position' => 'bottom', 'priority' => 100]
+        );
 
-            $urlSerializer = new URLSerializer();
-            $dataAccessor = new DataAccessor($this->module->getDatabase());
+        $urlSerializer = new URLSerializer();
+        $dataAccessor = new DataAccessor($this->module->getDatabase());
 
-            return new SearchProvider(
-                $this->module,
-                new Converter(
-                    $this->module->getContext(),
-                    $this->module->getDatabase(),
-                    $urlSerializer,
-                    $dataAccessor
-                ),
+        return new SearchProvider(
+            $this->module,
+            new Converter(
+                $this->module->getContext(),
+                $this->module->getDatabase(),
                 $urlSerializer,
                 $dataAccessor
-            );
-        }
-
-        return null;
+            ),
+            $urlSerializer,
+            $dataAccessor
+        );
     }
 }

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -89,7 +89,7 @@ class Search
      *
      * @param array $selectedFilters
      */
-    public function initSearch($selectedFilters)
+    public function initSearch($selectedFilters, $queryType = 'category')
     {
         $homeCategory = Configuration::get('PS_HOME_CATEGORY');
         /* If the current category isn't defined or if it's homepage, we have nothing to display */
@@ -101,12 +101,12 @@ class Search
         $parent = new Category((int) $idParent);
 
         $psLayeredFullTree = Configuration::get('PS_LAYERED_FULL_TREE');
-        if (!$psLayeredFullTree) {
+        if (!$psLayeredFullTree && $queryType == 'category') {
             $this->addFilter('id_category', [$parent->id]);
         }
 
         $psLayeredFilterByDefaultCategory = Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
-        if ($psLayeredFilterByDefaultCategory) {
+        if ($psLayeredFilterByDefaultCategory && $queryType == 'category') {
             $this->addFilter('id_category_default', [$parent->id]);
         }
 

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -178,7 +178,12 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         );
 
         // Try to get filter block from the cache by using unique hash
-        $filterBlock = $filterBlockSearch->getFromCache($filterHash);
+        // Only if the current controller supports caching
+        if ($this->module->getAvailableControllers()[$query->getQueryType()]['cacheable'] === true) {
+            $filterBlock = $filterBlockSearch->getFromCache($filterHash);
+        } else {
+            $filterBlock = null;
+        }
 
         // If not found in cache, we re-generate it and save it in the cache
         if (empty($filterBlock)) {
@@ -188,7 +193,11 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 $query->getQueryType(),
                 $query->getIdCategory()
             );
-            $filterBlockSearch->insertIntoCache($filterHash, $filterBlock);
+
+            // If we should cache this controller, we save it
+            if ($this->module->available_controllers[$query->getQueryType()]['cacheable'] === true) {
+                $filterBlockSearch->insertIntoCache($filterHash, $filterBlock);
+            }
         }
 
         $facets = $this->filtersConverter->getFacetsFromFilterBlocks(

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -1190,7 +1190,7 @@ class BlockTest extends MockeryTestCase
     {
         $this->dbMock->shouldReceive('executeS')
             ->once()
-            ->with("SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category  WHERE controller = 'category' AND id_category = 12 AND id_shop = 1 GROUP BY `type`, id_value ORDER BY position ASC")
+            ->with("SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category WHERE controller = 'category' AND id_category = 12 AND id_shop = 1 GROUP BY `type`, id_value ORDER BY position ASC")
             ->andReturn($result);
     }
 }

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -135,7 +135,9 @@ class BlockTest extends MockeryTestCase
             ['filters' => []],
             $this->block->getFilterBlock(
                 10,
-                []
+                [],
+                'category',
+                12
             )
         );
     }
@@ -166,7 +168,9 @@ class BlockTest extends MockeryTestCase
                         '24',
                         '42',
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -248,7 +252,9 @@ class BlockTest extends MockeryTestCase
                         '24',
                         '42',
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -298,7 +304,9 @@ class BlockTest extends MockeryTestCase
                         '24',
                         '42',
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -328,7 +336,9 @@ class BlockTest extends MockeryTestCase
                         '14',
                         '40',
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -393,7 +403,9 @@ class BlockTest extends MockeryTestCase
                     'quantity' => [
                         1,
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -451,7 +463,9 @@ class BlockTest extends MockeryTestCase
                     'condition' => [
                         'new',
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -479,7 +493,9 @@ class BlockTest extends MockeryTestCase
                 10,
                 [
                     'manufacturer' => [1],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -553,7 +569,9 @@ class BlockTest extends MockeryTestCase
                 10,
                 [
                     'manufacturer' => [1],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -580,7 +598,9 @@ class BlockTest extends MockeryTestCase
                 10,
                 [
                     'id_attribute_group' => [1 => 'Something'],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -603,7 +623,9 @@ class BlockTest extends MockeryTestCase
             $this->block->getFilterBlock(
                 10,
                 [
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -633,7 +655,9 @@ class BlockTest extends MockeryTestCase
             $this->block->getFilterBlock(
                 10,
                 [
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -779,7 +803,9 @@ class BlockTest extends MockeryTestCase
                     'id_attribute_group' => [
                         [2],
                     ],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -805,7 +831,9 @@ class BlockTest extends MockeryTestCase
                 10,
                 [
                     'id_feature' => [1 => 'Something'],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -829,7 +857,9 @@ class BlockTest extends MockeryTestCase
             $this->block->getFilterBlock(
                 10,
                 [
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -1018,7 +1048,9 @@ class BlockTest extends MockeryTestCase
                 10,
                 [
                     'id_feature' => [[4]],
-                ]
+                ],
+                'category',
+                12
             )
         );
     }
@@ -1158,7 +1190,7 @@ class BlockTest extends MockeryTestCase
     {
         $this->dbMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category WHERE id_category = 12 AND id_shop = 1 GROUP BY `type`, id_value ORDER BY position ASC')
+            ->with("SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category  WHERE controller = 'category' AND id_category = 12 AND id_shop = 1 GROUP BY `type`, id_value ORDER BY position ASC")
             ->andReturn($result);
     }
 }

--- a/views/templates/admin/_partials/controllers.tpl
+++ b/views/templates/admin/_partials/controllers.tpl
@@ -1,5 +1,4 @@
-<?php
-/**
+{**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -16,25 +15,15 @@
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- */
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
-function upgrade_module_3_8_0($module)
-{
-    Db::getInstance()->execute(
-      'ALTER TABLE `' . _DB_PREFIX_ . 'layered_price_index` 
-      CHANGE `price_min` `price_min` decimal(20,6) NOT NULL,
-      CHANGE `price_max` `price_max` decimal(20,6) NOT NULL;');
-
-    Db::getInstance()->execute(
-    'ALTER TABLE `' . _DB_PREFIX_ . 'layered_category` 
-    ADD `controller` VARCHAR(64) NOT NULL AFTER `id_shop`;');
-
-    Db::getInstance()->execute(
-        'UPDATE `' . _DB_PREFIX_ . "layered_category` 
-        SET `controller`= 'category';");
-
-    return true;
-}
+ *}
+<div class="form-group">
+  <label class="control-label col-lg-3">{l s='Pages using this template:' d='Modules.Facetedsearch.Admin'}</label>
+  <div class="col-lg-9">
+    {foreach from=$controller_options item=option}
+      <div class="checkbox">
+        <label for="{$option.controller}"><input type="checkbox" name="controllers[]" value="{$option.controller}"
+        {if $option.checked == true} checked {/if}>{$option.name}</label>
+      </div>
+    {/foreach}
+  </div>
+</div>

--- a/views/templates/admin/_partials/controllers.tpl
+++ b/views/templates/admin/_partials/controllers.tpl
@@ -19,10 +19,10 @@
 <div class="form-group">
   <label class="control-label col-lg-3">{l s='Pages using this template:' d='Modules.Facetedsearch.Admin'}</label>
   <div class="col-lg-9">
-    {foreach from=$controller_options item=option}
+    {foreach $controller_options as $controller => $data}
       <div class="checkbox">
-        <label for="{$option.controller}"><input type="checkbox" name="controllers[]" value="{$option.controller}"
-        {if $option.checked == true} checked {/if}>{$option.name}</label>
+        <label for="{$controller}"><input type="checkbox" name="controllers[]" value="{$controller}"
+        {if isset($data.checked) && $data.checked == true} checked {/if}>{$data.name}</label>
       </div>
     {/foreach}
   </div>

--- a/views/templates/admin/add.tpl
+++ b/views/templates/admin/add.tpl
@@ -26,6 +26,7 @@
     <input type="hidden" name="id_layered_filter" id="id_layered_filter" value="{$id_layered_filter}" />
 
     {include file='./_partials/header.tpl'}
+    {include file='./_partials/controllers.tpl'}
     {include file='./_partials/categories-tree.tpl'}
     {include file='./_partials/shops.tpl'}
 

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -56,6 +56,7 @@
 		  <tr>
 			<th class="fixed-width-xs center"><span class="title_box">{l s='ID' d='Admin.Global'}</span></th>
 			<th><span class="title_box text-left">{l s='Name' d='Admin.Global'}</span></th>
+			<th><span class="title_box">{l s='Pages' d='Admin.Global'}</span></th>
 			<th class="fixed-width-sm center"><span class="title_box">{l s='Categories' d='Admin.Global'}</span></th>
 			<th class="fixed-width-lg"><span class="title_box">{l s='Created on' d='Modules.Facetedsearch.Admin'}</span></th>
 			<th class="fixed-width-sm"><span class="title_box text-right">{l s='Actions' d='Modules.Facetedsearch.Admin'}</span></th>
@@ -66,6 +67,7 @@
 			<tr>
 			  <td class="center">{(int)$template['id_layered_filter']}</td>
 			  <td class="text-left">{$template['name']}</td>
+				<td>{$template['controllers']}</td>
 			  <td class="center">{(int)$template['n_categories']}</td>
 			  <td>{Tools::displayDate($template['date_add'],null , true)}</td>
 			  <td>

--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -26,6 +26,7 @@
     <input type="hidden" name="id_layered_filter" id="id_layered_filter" value="{$id_layered_filter}" />
 
     {include file='./_partials/header.tpl'}
+    {include file='./_partials/controllers.tpl'}
     {include file='./_partials/categories-tree.tpl'}
     {include file='./_partials/shops.tpl'}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows the module to work on all controllers.
| Type?         | improvement
| BC breaks?    | ?
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#15137
| How to test?  | Install module and see that filter works on all pages.

## Functionality
- In every template, user will select controllers where he wants to use this filter template. Category checkboxes are needed only if using the template on category page.
- In the filter overview, merchant can nicely see which pages use the filter template he created.
- On special pages
  - If using category filter, it always sets the home category as the root.
  - Settings **Show products from subcategories** and **Show products only from default category are ignored** 

## Details
- I added a controller column to filter table.
- Supports all default product listing controllers. 
- Supports any custom controller specified in the list. We can make some hook for this possibly. ;-)
- Technically, the biggest change is `WHERE id_category = " . $idCategory` to `WHERE controller = 'category' AND id_category = " . $idCategory` when getting filters. The other stuff was mainly to adjust admin and some conditions here and there.
- I separated the rendering of admin screen to separate functions at least. It would be good to move everything related to Admin and Indexing to separate pages, but that is not the scope of this PR.
- Cache
  - If the page should be cached or not is determined by 'cacheable' property in controller list.
  - We are currently caching category, manufacturer, supplier and search pages. We could omit search, because it could grow big.
  - We can't cache new product page because we don't know if the product expired from the page. The same with best-sales and price-drop.
  - Module does not need https://github.com/PrestaShop/PrestaShop/pull/26285 to work, I added backward compatibility function which can be later removed.

## Screenshots
![fo](https://user-images.githubusercontent.com/6097524/137899713-99c7759e-07e6-4687-bf51-d012767047a2.JPG)
![bo1](https://user-images.githubusercontent.com/6097524/137899716-8d864bea-0e0b-4509-920e-f9b45b8f5bfb.JPG)
![bo2](https://user-images.githubusercontent.com/6097524/137899717-b751204b-272c-43fc-b2b3-2cc8670abdb1.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/531)
<!-- Reviewable:end -->
