### PR TITLE
Fix Wrong count of products with price search

### DIFF
--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -89,7 +89,7 @@ class Products
 
         $this->pricePostFiltering($matchingProductList, $selectedFilters);
 
-        $nbrProducts = $this->searchAdapter->count();
+        $nbrProducts = count($matchingProductList);
 
         if (empty($nbrProducts)) {
             $matchingProductList = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The price range slider does not update correctly the counter of products with specific prices. But Ask in issue before : https://github.com/PrestaShop/PrestaShop/issues/25819#issuecomment-950121389
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#25819.
| How to test?  | See **Steps to Reproduce** section of PrestaShop/Prestashop#25819

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/537)
<!-- Reviewable:end -->
