### PR TITLE
Fixed order brands case sensitive

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -538,8 +538,6 @@ class Block
             }
         }
 
-        $this->sortByKey($manufacturers, $manufacturersArray);
-
         $manufacturerBlock = [
             'type_lite' => 'manufacturer',
             'type' => 'manufacturer',
@@ -874,8 +872,6 @@ class Block
                 $categoryArray[$idCategory]['checked'] = true;
             }
         }
-
-        $categoryArray = $this->sortByKey($categories, $categoryArray);
 
         $categoryBlock = [
             'type_lite' => 'category',

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -507,6 +507,6 @@ class Converter
      */
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
-        return strnatcmp(strtoupper($a->getLabel()), strtoupper($b->getLabel()));
+        return strnatcasecmp($a->getLabel(), $b->getLabel());
     }
 }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -507,6 +507,6 @@ class Converter
      */
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
-        return strnatcmp($a->getLabel(), $b->getLabel());
+        return strnatcmp(strtoupper($a->getLabel()), strtoupper($b->getLabel()));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The alphabetical order seems to be case-sensitive, as it takes into account possible capital letters when it should not. <br/>So I change function `strnatcmp` by case-insentitive alternative `strnatcasecmp`. <br/>I also remove useless call function `sortbykey` because categories and manufacturers are sort by `sortFiltersByLabel` function with `strnatcasecmp` in all cases.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#26444.
| How to test?  | See how to test section on issue.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/548)
<!-- Reviewable:end -->
