### PR TITLE
By default put "indexable" option to No in add/edit attributes & features pages

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1294,8 +1294,8 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;'
         );
         $this->getDatabase()->execute(
-            'INSERT INTO `' . _DB_PREFIX_ . 'layered_indexable_attribute_group`
-            SELECT id_attribute_group, 1 FROM `' . _DB_PREFIX_ . 'attribute_group`'
+            'INSERT INTO `' . _DB_PREFIX_ . 'layered_indexable_attribute_group` (id_attribute_group)
+            SELECT id_attribute_group FROM `' . _DB_PREFIX_ . 'attribute_group`'
         );
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'layered_indexable_attribute_group_lang_value`');
@@ -1332,8 +1332,8 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         );
 
         $this->getDatabase()->execute(
-            'INSERT INTO `' . _DB_PREFIX_ . 'layered_indexable_feature`
-            SELECT id_feature, 1 FROM `' . _DB_PREFIX_ . 'feature`'
+            'INSERT INTO `' . _DB_PREFIX_ . 'layered_indexable_feature` (id_feature)
+            SELECT id_feature FROM `' . _DB_PREFIX_ . 'feature`'
         );
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'layered_indexable_feature_lang_value`');

--- a/src/Form/Feature/FormDataProvider.php
+++ b/src/Form/Feature/FormDataProvider.php
@@ -51,7 +51,7 @@ class FormDataProvider
     {
         $defaultUrl = [];
         $defaultMetaTitle = [];
-        $isIndexable = true;
+        $isIndexable = false;
 
         // if params contains id, gets data for edit form
         if (!empty($params['id'])) {

--- a/src/Hook/AttributeGroup.php
+++ b/src/Hook/AttributeGroup.php
@@ -124,11 +124,6 @@ VALUES (' . (int) $params['id_attribute_group'] . ', ' . (int) Tools::getValue('
             WHERE `id_attribute_group` = ' . (int) $params['id_attribute_group']
         );
 
-        // Request failed, force $isIndexable
-        if ($isIndexable === false) {
-            $isIndexable = true;
-        }
-
         if ($result = $this->database->executeS(
             'SELECT `url_name`, `meta_title`, `id_lang` FROM ' . _DB_PREFIX_ . 'layered_indexable_attribute_group_lang_value
             WHERE `id_attribute_group` = ' . (int) $params['id_attribute_group']

--- a/src/Hook/Feature.php
+++ b/src/Hook/Feature.php
@@ -146,10 +146,6 @@ class Feature extends AbstractHook
             'WHERE `id_feature` = ' . (int) $params['id_feature']
         );
 
-        // Request failed, force $isIndexable
-        if ($isIndexable === false) {
-            $isIndexable = true;
-        }
         $result = $this->database->executeS(
             'SELECT `url_name`, `meta_title`, `id_lang` ' .
             'FROM ' . _DB_PREFIX_ . 'layered_indexable_feature_lang_value ' .


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | By default put "indexable" option to No (instead of Yes) in add/edit attributes & features pages
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#15170.
| How to test?  | Add an attribute group in **Catalog > Attributes & Features > Attributes** or a feature in **Catalog > Attributes & Features > Features**.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/550)
<!-- Reviewable:end -->
