### PR TITLE
Flush cache if changing configuration related to stock

### DIFF
--- a/src/Hook/Configuration.php
+++ b/src/Hook/Configuration.php
@@ -17,16 +17,22 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 
-function upgrade_module_3_8_0($module)
+namespace PrestaShop\Module\FacetedSearch\Hook;
+
+class Configuration extends AbstractHook
 {
-    $module->registerHook('actionProductPreferencesPageStockSave');
+    const AVAILABLE_HOOKS = [
+        'actionProductPreferencesPageStockSave',
+    ];
 
-    return Db::getInstance()->execute(
-      'ALTER TABLE `' . _DB_PREFIX_ . 'layered_price_index` 
-      CHANGE `price_min` `price_min` decimal(20,6) NOT NULL,
-      CHANGE `price_max` `price_max` decimal(20,6) NOT NULL;');
+    /**
+     * After save of product stock preferences form
+     *
+     * @param array $params
+     */
+    public function actionProductPreferencesPageStockSave(array $params)
+    {
+        $this->module->invalidateLayeredFilterBlockCache();
+    }
 }

--- a/src/HookDispatcher.php
+++ b/src/HookDispatcher.php
@@ -33,6 +33,7 @@ class HookDispatcher
         Hook\Attribute::class,
         Hook\AttributeGroup::class,
         Hook\Category::class,
+        Hook\Configuration::class,
         Hook\Design::class,
         Hook\Feature::class,
         Hook\FeatureValue::class,

--- a/tests/php/FacetedSearch/HookDispatcherTest.php
+++ b/tests/php/FacetedSearch/HookDispatcherTest.php
@@ -77,6 +77,7 @@ class HookDispatcherTest extends MockeryTestCase
                 'productSearchProvider',
                 'actionObjectSpecificPriceRuleUpdateBefore',
                 'actionAdminSpecificPriceRuleControllerSaveAfter',
+                'actionProductPreferencesPageStockSave',
             ],
             $this->dispatcher->getAvailableHooks()
         );

--- a/tests/php/FacetedSearch/HookDispatcherTest.php
+++ b/tests/php/FacetedSearch/HookDispatcherTest.php
@@ -61,6 +61,7 @@ class HookDispatcherTest extends MockeryTestCase
                 'actionCategoryAdd',
                 'actionCategoryDelete',
                 'actionCategoryUpdate',
+                'actionProductPreferencesPageStockSave',
                 'displayLeftColumn',
                 'actionFeatureSave',
                 'actionFeatureDelete',
@@ -77,7 +78,6 @@ class HookDispatcherTest extends MockeryTestCase
                 'productSearchProvider',
                 'actionObjectSpecificPriceRuleUpdateBefore',
                 'actionAdminSpecificPriceRuleControllerSaveAfter',
-                'actionProductPreferencesPageStockSave',
             ],
             $this->dispatcher->getAvailableHooks()
         );

--- a/tests/php/FacetedSearch/HookDispatcherTest.php
+++ b/tests/php/FacetedSearch/HookDispatcherTest.php
@@ -47,7 +47,7 @@ class HookDispatcherTest extends MockeryTestCase
 
     public function testGetAvailableHooks()
     {
-        $this->assertCount(27, $this->dispatcher->getAvailableHooks());
+        $this->assertCount(28, $this->dispatcher->getAvailableHooks());
         $this->assertEquals(
             [
                 'actionAttributeGroupDelete',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If caching option is enabled in faceted search, it caches the rendered blocks into database for faster loading. However, we must reload them if changing **Allow ordering of out-of-stock products** or **Enable stock management** in **Shop parameters > Product settings**. This PR does it automatically.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#25587
| How to test?  | See below.

**How to test**
- Install module, set it up, enable cache in it. Go any category in FO to load the cache up.
- Open your phpMyAdmin or Adminer and open table `ps_layered_filter_block`. There should be some data.
- Go to **Shop parameters > Product settings** and click **Save** on **Products stock** form.
- Go back to your DB admin and see the table is flushed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/585)
<!-- Reviewable:end -->
