### PR TITLE
Fix availability filter for products with negative quantities.

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -466,8 +466,7 @@ class Block
                 Search::STOCK_MANAGEMENT_FILTER,
                 [
                     [
-                        ['quantity', [0], '>='],
-                        ['out_of_stock', [1], $this->psOrderOutOfStock ? '>=' : '='],
+                        ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
                     ],
                     [
                         ['quantity', [0], '>'],

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -191,7 +191,6 @@ class Search
                         // Available
                         } elseif ($filterValues[0] == 1) {
                             $operationsFilter[] = [
-                                ['quantity', [0], '>='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
                             ];
                             $operationsFilter[] = [
@@ -220,7 +219,6 @@ class Search
                         // Available or in stock
                         } elseif (in_array(1, $filterValues) && in_array(2, $filterValues)) {
                             $operationsFilter[] = [
-                                ['quantity', [0], '>='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
                             ];
                             $operationsFilter[] = [

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -355,7 +355,7 @@ class BlockTest extends MockeryTestCase
 
         $this->dbMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT COUNT(DISTINCT p.id_product) c FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_stock_available sa_1 ON (p.id_product = sa_1.id_product AND IFNULL(pac.id_product_attribute, 0) = sa_1.id_product_attribute) WHERE ((sa.quantity>=0 AND sa_1.out_of_stock>=1) OR (sa.quantity>0))')
+            ->with('SELECT COUNT(DISTINCT p.id_product) c FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) WHERE ((sa.out_of_stock IN (1, 2)) OR (sa.quantity>0))')
             ->andReturn([
                 ['c' => 100],
             ]);

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -633,13 +633,6 @@ class SearchTest extends MockeryTestCase
                 'with_stock_management' => [
                     [
                         [
-                            'quantity',
-                            [
-                                0,
-                            ],
-                            '>=',
-                        ],
-                        [
                             'out_of_stock',
                             [
                                 1,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I made a logical mistake and left a legacy code which ignored products with negative quantities, when filtering for Available products. I also changed one line to improve clarity.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes bug in my previous PR - https://github.com/PrestaShop/ps_facetedsearch/pull/479
| How to test?  | Make a product with Backorders allowed and quantity -1. It did not appear if you selected in "Available" in stock filter. Now it does.

Ping @rdy4ever and @hibatallahAouadni for quick QA 😄

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/586)
<!-- Reviewable:end -->
