### PR TITLE
Fix `strip_tags` error messages during value escaping.

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -316,11 +316,17 @@ class MySQL extends AbstractAdapter
      */
     protected function getJoinedEscapedValue($separator, array $values)
     {
-        return implode($separator, array_map(function ($value) use ($separator) {
-            return is_array($value) ?
-                $this->getJoinedEscapedValue($separator, $value) :
-                (is_numeric($value) ? pSQL($value) : "'" . pSQL($value) . "'");
-        }, $values));
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = $this->getJoinedEscapedValue($separator, $value);
+            } elseif (is_numeric($value)) {
+                $values[$key] = pSQL($value);
+            } else {
+                $values[$key] = "'" . pSQL($value) . "'";
+            }
+        }
+
+        return implode($separator, $values);
     }
 
     /**

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -307,6 +307,23 @@ class MySQL extends AbstractAdapter
     }
 
     /**
+     * Get the joined and escaped value from an multi-dimensional array
+     *
+     * @param string $separator
+     * @param array $values
+     *
+     * @return string Escaped string value
+     */
+    protected function getJoinedEscapedValue($separator, array $values)
+    {
+        return implode($separator, array_map(function ($value) use ($separator) {
+            return is_array($value) ?
+                $this->getJoinedEscapedValue($separator, $value) :
+                (is_numeric($value) ? pSQL($value) : "'" . pSQL($value) . "'");
+        }, $values));
+    }
+
+    /**
      * Compute the orderby fields, adding the proper alias that will be added to the final query
      *
      * @param array $filterToTableMapping
@@ -477,9 +494,7 @@ class MySQL extends AbstractAdapter
                         $operator = !empty($operation[2]) ? $operation[2] : '=';
                         $conditions[] = $selectAlias . '.' . $operation[0] . $operator . current($values);
                     } else {
-                        $conditions[] = $selectAlias . '.' . $operation[0] . ' IN (' . implode(', ', array_map(function ($value) {
-                            return is_numeric($value) ? pSQL($value) : "'" . pSQL($value) . "'";
-                        }, $values)) . ')';
+                        $conditions[] = $selectAlias . '.' . $operation[0] . ' IN (' . $this->getJoinedEscapedValue(', ', $values) . ')';
                     }
                 }
 
@@ -510,9 +525,7 @@ class MySQL extends AbstractAdapter
                                 $selectAlias . '.' . $filterName . $operator . "'" . current($values) . "'";
                         } else {
                             $whereConditions[] =
-                                $selectAlias . '.' . $filterName . ' IN (' . implode(', ', array_map(function ($value) {
-                                    return is_numeric($value) ? pSQL($value) : "'" . pSQL($value) . "'";
-                                }, $values)) . ')';
+                                $selectAlias . '.' . $filterName . ' IN (' . $this->getJoinedEscapedValue(', ', $values) . ')';
                         }
                     } else {
                         $orConditions = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR fixes the issue when an array-type value is given to the `pSQL` function, since the `$values` variable could be a multi-dimensional array.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27357.
| How to test?  | Please see PrestaShop/Prestashop#27357.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/593)
<!-- Reviewable:end -->
