### PR TITLE
Check access to product on category listing

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -23,6 +23,8 @@ namespace PrestaShop\Module\FacetedSearch\Product;
 use Category;
 use Configuration;
 use Context;
+use FrontController;
+use Group;
 use PrestaShop\Module\FacetedSearch\Adapter\AbstractAdapter;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL as MySQLAdapter;
 use Tools;
@@ -112,6 +114,13 @@ class Search
 
         // Visibility of a product must be in catalog or both (search & catalog)
         $this->addFilter('visibility', ['both', 'catalog']);
+
+        // User must belong to one of the groups that can access the product
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+
+            $this->addFilter('id_group', empty($groups) ? [Group::getCurrent()->id] : $groups);
+        }
 
         $this->addSearchFilters(
             $selectedFilters,

--- a/tests/php/FacetedSearch/MockProxy.php
+++ b/tests/php/FacetedSearch/MockProxy.php
@@ -127,3 +127,9 @@ class Module extends MockProxy
     // Redeclare to use this instead MockProxy::mock
     protected static $mock;
 }
+
+class FrontController extends MockProxy
+{
+    // Redeclare to use this instead MockProxy::mock
+    protected static $mock;
+}

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -756,6 +756,136 @@ class SearchTest extends MockeryTestCase
         );
     }
 
+    public function testInitSearchWithoutGroupFeature()
+    {
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $groupMock = Mockery::mock(Group::class);
+        $groupMock->shouldReceive('isFeatureActive')
+            ->andReturn(false);
+
+        Group::setStaticExpectations($groupMock);
+
+        $this->search->initSearch(['quantity' => [2]]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'id_category_default' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_shop' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+                'visibility' => [
+                    '=' => [
+                        [
+                            'both',
+                            'catalog',
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
+        );
+    }
+
+    public function testInitSearchWithUserBelongingToGroups()
+    {
+        $toolsMock = Mockery::mock(Tools::class);
+        $toolsMock->shouldReceive('getValue')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'id_category' => 12,
+                    'id_category_layered' => 11,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Tools::setStaticExpectations($toolsMock);
+
+        $frontControllerMock = Mockery::mock(FrontController::class);
+        $frontControllerMock->shouldReceive('getCurrentCustomerGroups')
+            ->andReturn([2, 999]);
+
+        FrontController::setStaticExpectations($frontControllerMock);
+
+        $this->search->initSearch(['quantity' => [2]]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'id_category_default' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_category' => [
+                    '=' => [
+                        [
+                            null,
+                        ],
+                    ],
+                ],
+                'id_shop' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+                'visibility' => [
+                    '=' => [
+                        [
+                            'both',
+                            'catalog',
+                        ],
+                    ],
+                ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            2,
+                            999,
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
+        );
+    }
+
     public function testAddFilter()
     {
         $this->search->addFilter('weight', [10, 20]);

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -22,6 +22,8 @@ namespace PrestaShop\Module\FacetedSearch\Tests\Product;
 
 use Configuration;
 use Context;
+use FrontController;
+use Group;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
@@ -53,6 +55,25 @@ class SearchTest extends MockeryTestCase
             });
 
         Configuration::setStaticExpectations($mock);
+
+        $groupMock = Mockery::mock(Group::class);
+        $groupMock->shouldReceive('isFeatureActive')
+            ->andReturn(true);
+        $groupMock->shouldReceive('getCurrent')
+            ->andReturnUsing(function () {
+                $group = new Group();
+                $group->id = 1;
+
+                return $group;
+            });
+
+        Group::setStaticExpectations($groupMock);
+
+        $frontControllerMock = Mockery::mock(FrontController::class);
+        $frontControllerMock->shouldReceive('getCurrentCustomerGroups')
+            ->andReturn([]);
+
+        FrontController::setStaticExpectations($frontControllerMock);
 
         $contextMock = Mockery::mock(Context::class);
         $contextMock->shop = new stdClass();
@@ -121,6 +142,13 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
             ],
             $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
         );
@@ -174,6 +202,13 @@ class SearchTest extends MockeryTestCase
                         [
                             'both',
                             'catalog',
+                        ],
+                    ],
+                ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
                         ],
                     ],
                 ],
@@ -298,6 +333,13 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
             ],
             $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
         );
@@ -406,6 +448,13 @@ class SearchTest extends MockeryTestCase
                         ],
                     ],
                 ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
             ],
             $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
         );
@@ -493,6 +542,13 @@ class SearchTest extends MockeryTestCase
                     '=' => [
                         [
                             null,
+                        ],
+                    ],
+                ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
                         ],
                     ],
                 ],
@@ -600,6 +656,13 @@ class SearchTest extends MockeryTestCase
                         [
                             'both',
                             'catalog',
+                        ],
+                    ],
+                ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
                         ],
                     ],
                 ],


### PR DESCRIPTION
Products that were not accessible by the user were still visible on the listing

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Verifies that the user has the right to access the product
| Type?         | bug fix 
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27601.
| How to test?  | **On Administration**<br/>1. On category  **Clothes**, go to sub-category **Men** and set access only to groups **Customer** <br/>2. Create a product **test** with only the category **Men**<br/>**On store**<br/>1. Go to the category **Clothes**<br/>2. Sub-category **Men** isn't display and you can't see the produt **test**
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/612)
<!-- Reviewable:end -->
