### PR TITLE
Allows filtering products on manufacturer pages

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -107,6 +107,13 @@ class Block
             'AND id_shop = ' . $idShop . ' ' .
             'GROUP BY `type`, id_value ORDER BY position ASC'
         );
+        
+        // Unset some filters for the manufacturer pages
+        if (\Tools::getValue('controller') == 'manufacturer') {
+          foreach($filters as $key => $filter) {
+            if (in_array($filter['type'], ['manufacturer', 'category'])) unset($filters[$key]);
+          }
+        }
 
         $filterBlocks = [];
         // iterate through each filter, and the get corresponding filter block

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -46,7 +46,7 @@ class ProductSearch extends AbstractHook
         // to choose a template for filters.
         // Query is an instance of:
         // PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery
-        if ($query->getIdCategory()) {
+        if ($query->getIdCategory() || \Tools::getValue('controller') == 'manufacturer') {
             $this->context->controller->addJqueryUi('slider');
             $this->context->controller->registerStylesheet(
                 'facetedsearch_front',

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -91,27 +91,36 @@ class Search
      */
     public function initSearch($selectedFilters)
     {
-        $homeCategory = Configuration::get('PS_HOME_CATEGORY');
-        /* If the current category isn't defined or if it's homepage, we have nothing to display */
-        $idParent = (int) Tools::getValue(
-            'id_category',
-            Tools::getValue('id_category_layered', $homeCategory)
-        );
-
-        $parent = new Category((int) $idParent);
-
-        $psLayeredFullTree = Configuration::get('PS_LAYERED_FULL_TREE');
-        if (!$psLayeredFullTree) {
-            $this->addFilter('id_category', [$parent->id]);
+        if (\Tools::getValue('controller') == 'manufacturer') {
+          
+          $manufacturerID = (int)$_GET['id_manufacturer'];
+          $this->addFilter('id_manufacturer', [$manufacturerID]);
+          
+        } else {  
+          
+          $homeCategory = Configuration::get('PS_HOME_CATEGORY');
+          /* If the current category isn't defined or if it's homepage, we have nothing to display */
+          $idParent = (int) Tools::getValue(
+              'id_category',
+              Tools::getValue('id_category_layered', $homeCategory)
+          );
+  
+          $parent = new Category((int) $idParent);
+  
+          $psLayeredFullTree = Configuration::get('PS_LAYERED_FULL_TREE');
+          if (!$psLayeredFullTree) {
+              $this->addFilter('id_category', [$parent->id]);
+          }
+  
+          $psLayeredFilterByDefaultCategory = Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
+          if ($psLayeredFilterByDefaultCategory) {
+              $this->addFilter('id_category_default', [$parent->id]);
+          }
+  
+          // Visibility of a product must be in catalog or both (search & catalog)
+          $this->addFilter('visibility', ['both', 'catalog']);
+          
         }
-
-        $psLayeredFilterByDefaultCategory = Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
-        if ($psLayeredFilterByDefaultCategory) {
-            $this->addFilter('id_category_default', [$parent->id]);
-        }
-
-        // Visibility of a product must be in catalog or both (search & catalog)
-        $this->addFilter('visibility', ['both', 'catalog']);
 
         $this->addSearchFilters(
             $selectedFilters,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allows filtering products on manufacturer pages.<br>Tested on PrestaShop 1.7.8.3, "classic" theme, PHP 7.4
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/15137
| How to test?  | Set two columns layout for brands and clear the filters cache, the filters should appears on the manufacturers pages now.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/615)
<!-- Reviewable:end -->
