### PR TITLE
fix FacetFilters widget disappears after a no facet filter

### DIFF
--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -178,6 +178,6 @@
     {/foreach}
   </div>
 {else}
-  <div id="search_filters" class="d-none">
+  <div id="search_filters" style="display:none;">
   </div>  
 {/if}

--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -177,4 +177,7 @@
       </section>
     {/foreach}
   </div>
+{else}
+  <div id="search_filters" class="d-none">
+  </div>  
 {/if}


### PR DESCRIPTION
module **ps_facetedsearch**'s [facets.tpl](https://github.com/PrestaShop/ps_facetedsearch/blob/dde4153afad3b9ed5bebfcc6a326dc75b24ba43f/views/templates/front/catalog/facets.tpl#L19-L20) return `null` when there is no facet in FacetFilters widget
In turn, theme **classic-theme**'s [listing.js](https://github.com/PrestaShop/classic-theme/blob/0c1ecfaa3308d75bedb603c689a5300c7bc3dc56/_dev/js/listing.js#L177-L179) `replaceWith` replaces the whole `#search_filters` div (both inner content and the div itself) by
```
<!-- begin module:ps_facetedsearch/views/templates/front/catalog/facets.tpl -->
<!-- end module:ps_facetedsearch/views/templates/front/catalog/facets.tpl -->
```
so the next **ajax render** can not finds `#search_filters` then can not renders its inner content as desired in next filters till the **whole page refresh**.
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The bug happens in a very specific case as described in the related issue 22488: add a filter with a custom feature that has only one value. <br> The solution is return a **hidden** `#search_filters` div with empty inner content in that case instead of `null`.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop/issues/22488
| How to test?  | Follow steps to procedure of the above issue before PR and after PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/679)
<!-- Reviewable:end -->
