### PR TITLE
Fix facets clear button not showing on mobile 

### DIFF
--- a/_dev/front/events.js
+++ b/_dev/front/events.js
@@ -21,10 +21,10 @@ import {showOverlay, hideOverlay} from './overlay';
 
 function checkFiltersClearAll() {  
   if ($('#_desktop_search_filters_clear_all').attr('style') === 'display:none;') {
-      $('#_mobile_search_filters_clear_all').addClass('hidden-sm-down');
-  } else {	  
-	  $('#_mobile_search_filters_clear_all').removeClass('hidden-sm-down');
-  }    
+    $('#_mobile_search_filters_clear_all').addClass('hidden-sm-down');
+  } else {
+    $('#_mobile_search_filters_clear_all').removeClass('hidden-sm-down');
+  }   
 }
 
 $(document).ready(() => {

--- a/_dev/front/events.js
+++ b/_dev/front/events.js
@@ -19,12 +19,12 @@
 import refreshSliders from './slider';
 import {showOverlay, hideOverlay} from './overlay';
 
-function checkFiltersClearAll() {  
+function checkFiltersClearAll() {
   if ($('#_desktop_search_filters_clear_all').attr('style') === 'display:none;') {
     $('#_mobile_search_filters_clear_all').addClass('hidden-sm-down');
   } else {
     $('#_mobile_search_filters_clear_all').removeClass('hidden-sm-down');
-  }   
+  }
 }
 
 $(document).ready(() => {
@@ -35,9 +35,9 @@ $(document).ready(() => {
   });
 
   refreshSliders();
-  
+
   checkFiltersClearAll();
-  
+
   prestashop.on('updateFacets', () => {
     showOverlay();
   });

--- a/_dev/front/events.js
+++ b/_dev/front/events.js
@@ -19,14 +19,25 @@
 import refreshSliders from './slider';
 import {showOverlay, hideOverlay} from './overlay';
 
+function checkFiltersClearAll() {  
+  if ($('#_desktop_search_filters_clear_all').attr('style') === 'display:none;') {
+      $('#_mobile_search_filters_clear_all').addClass('hidden-sm-down');
+  } else {	  
+	  $('#_mobile_search_filters_clear_all').removeClass('hidden-sm-down');
+  }    
+}
+
 $(document).ready(() => {
   prestashop.on('updateProductList', () => {
     hideOverlay();
     refreshSliders();
+    checkFiltersClearAll();
   });
 
   refreshSliders();
-
+  
+  checkFiltersClearAll();
+  
   prestashop.on('updateFacets', () => {
     showOverlay();
   });

--- a/views/templates/front/catalog/facets.tpl
+++ b/views/templates/front/catalog/facets.tpl
@@ -30,6 +30,13 @@
             {l s='Clear all' d='Shop.Theme.Actions'}
           </button>
         </div>
+      {else}
+        <div id="_desktop_search_filters_clear_all" style="display:none;">
+          <button data-search-url="{$clear_all_link}" class="btn btn-tertiary js-search-filters-clear-all">
+            <i class="material-icons">&#xE14C;</i>
+            {l s='Clear all' d='Shop.Theme.Actions'}
+          </button>
+        </div>           
       {/if}
     {/block}
 


### PR DESCRIPTION
Problem: **Start** inner content of ps_facetedsearch **clear all** button `#_desktop_search_filters_clear_all` is defined at [modules' facets.tpl L28-L31](https://github.com/PrestaShop/ps_facetedsearch/blob/dev/views/templates/front/catalog/facets.tpl#L28-L31)<br> **Start** inner content of ps_facetedsearch **clear all** button `#_mobile_search_filters_clear_all` is defined at [themes' ps_facetedsearch.tpl L28](https://github.com/PrestaShop/classic-theme/blob/develop/modules/ps_facetedsearch/ps_facetedsearch.tpl#L28) and is **empty**<br>  Inner content of `#_desktop_search_filters_clear_all` and `#_mobile_search_filters_clear_all` will be swapped by [themes' toggleMobileStyles](https://github.com/PrestaShop/classic-theme/blob/develop/_dev/js/responsive.js#L40). <br> So, in case there is no `$activeFilters` then there is no `#_desktop_search_filters_clear_all` at all, and in turn **empty** `#_mobile_search_filters_clear_all` won't be showed in **mobile** view.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Solution: <br> 1. in modules' facets.tpl, if there is no `$activeFilters` then still add `#_desktop_search_filters_clear_all` with a special mark `style="display:none;"`. <br> 2. in modules' events.js, toggle `#_mobile_search_filters_clear_all` folllows `#_desktop_search_filters_clear_all` **style** attribute
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28677.
| How to test?  | Please follow the above issue's Steps to reproduce before PR and after PR; and do not forget to rebuild assets as well as clear web browser cache after PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/690)
<!-- Reviewable:end -->
