### PR TITLE
Add configuration to use jquery ui slider

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[3.8.0]]></version>
+    <version><![CDATA[3.9.0]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -91,7 +91,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '3.8.0';
+        $this->version = '3.9.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -198,6 +198,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
+            Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
 
             $this->psLayeredFullTree = 1;
 
@@ -697,6 +698,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
+            Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -831,6 +833,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
+            'use_jquery_ui_sloder' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -833,7 +833,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
-            'use_jquery_ui_sloder' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
+            'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -24,6 +24,7 @@ use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\Product\SearchProvider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
+use Configuration;
 
 class ProductSearch extends AbstractHook
 {

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -20,11 +20,11 @@
 
 namespace PrestaShop\Module\FacetedSearch\Hook;
 
+use Configuration;
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\Product\SearchProvider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
-use Configuration;
 
 class ProductSearch extends AbstractHook
 {

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -47,7 +47,9 @@ class ProductSearch extends AbstractHook
         // Query is an instance of:
         // PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery
         if ($query->getIdCategory()) {
-            $this->context->controller->addJqueryUi('slider');
+            if ((bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER')) {
+                $this->context->controller->addJqueryUi('slider');
+            }
             $this->context->controller->registerStylesheet(
                 'facetedsearch_front',
                 '/modules/ps_facetedsearch/views/dist/front.css'

--- a/upgrade/upgrade-3.9.0.php
+++ b/upgrade/upgrade-3.9.0.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_9_0($module)
+{
+    Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
+
+    return true;
+}

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -239,6 +239,28 @@
 	  </div>
 	</div>
 
+  <div class="form-group">
+    <label class="col-lg-3 control-label">{l s='Use Jquery UI slider' d='Modules.Facetedsearch.Admin'}</label>
+    <div class="col-lg-9">
+    <span class="switch prestashop-switch fixed-width-lg">
+      <input type="radio" name="ps_use_jquery_ui_slider" id="ps_use_jquery_ui_slider_on" value="1"{if $use_jquery_ui_slider} checked="checked"{/if}>
+      <label for="ps_use_jquery_ui_slider_on" class="radioCheck">
+      <i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+      </label>
+      <input type="radio" name="ps_use_jquery_ui_slider" id="ps_use_jquery_ui_slider_off" value="0"{if !$use_jquery_ui_slider} checked="checked"{/if}>
+      <label for="ps_use_jquery_ui_slider_off" class="radioCheck">
+      <i class="color_danger"></i> {l s='No' d='Admin.Global'}
+      </label>
+      <a class="slide-button btn"></a>
+    </span>
+    </div>
+    <div class="col-lg-9 col-lg-offset-3">
+      <div class="help-block">
+        {l s='Switch this setting if your theme uses the Jquery UI slider. It is recommended to keep it ON when using classic theme.' d='Modules.Facetedsearch.Admin'}
+      </div>
+    </div>
+  </div>
+
 	<div class="panel-footer">
 	  <button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 	</div>

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -256,7 +256,7 @@
     </div>
     <div class="col-lg-9 col-lg-offset-3">
       <div class="help-block">
-        {l s='Switch this setting if your theme uses the Jquery UI slider. It is recommended to keep it ON when using classic theme.' d='Modules.Facetedsearch.Admin'}
+        {l s='Switch this OFF only if your theme does not use Jquery UI slider. It is recommended to keep it ON when using classic theme.' d='Modules.Facetedsearch.Admin'}
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | https://github.com/PrestaShop/PrestaShop/issues/27186
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/27186
| How to test?  | :warning: there are more modules loading jquery.ui.  So before testing please disable the following modules: **ps_searchbar**, **ps_blockreassurance** and **ps_imageslider** :warning:  . Install this module your prestashop, (go to Modules management page and upgrade if you manually reuploaded it on top of older version - actually recommeded to do so to test the upgrade). Now you should be able to see additional option in module confuguration "Use Jquery UI slider". Disable JS CCC function in BO > Performance.See that jquery-ui javascript file is not loaded in front office if the new option is not enabled. If you disable it, you should break price slider on classic theme, but not on hummingbird

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/691)
<!-- Reviewable:end -->
