### PR TITLE
Fixed Price And URL When Filtering With Combinations

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -198,6 +198,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
+            Configuration::updateValue('PS_LAYERED_FILTER_CATALOG_LIST_COMBINATIONS_AS_PRODUCTS', 0);
 
             $this->psLayeredFullTree = 1;
 
@@ -235,6 +236,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
+        Configuration::deleteByName('PS_LAYERED_FILTER_CATALOG_LIST_COMBINATIONS_AS_PRODUCTS');
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_category');
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_filter');
@@ -697,6 +699,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
+            Configuration::updateValue('PS_LAYERED_FILTER_CATALOG_LIST_COMBINATIONS_AS_PRODUCTS', (int) Tools::getValue('ps_layered_filter_list_combinations_as_products'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -831,6 +834,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
+            'list_combinations_as_products' => (bool) Configuration::get('PS_LAYERED_FILTER_CATALOG_LIST_COMBINATIONS_AS_PRODUCTS'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -764,6 +764,7 @@ class MySQL extends AbstractAdapter
         $this->setSelectFields(
             [
                 'id_product',
+                'id_product_attribute',
                 'id_manufacturer',
                 'quantity',
                 'condition',

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -255,8 +255,6 @@ class MySQL extends AbstractAdapter
                 $stockCondition . ')',
                 'joinType' => self::LEFT_JOIN,
                 'dependencyField' => 'id_attribute',
-                'aggregateFunction' => 'SUM',
-                'aggregateFieldName' => 'quantity',
             ],
             'price_min' => [
                 'tableName' => 'layered_price_index',
@@ -760,7 +758,8 @@ class MySQL extends AbstractAdapter
     public function useFiltersAsInitialPopulation()
     {
         $this->setLimit(null);
-        $this->setOrderField('');
+        $this->addGroupBy('p.id_product, pa.id_product_attribute');
+        $this->setOrderField('p.id_product, pa.id_product_attribute, pa.default_on');
         $this->setSelectFields(
             [
                 'id_product',

--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -85,7 +85,9 @@ class Products
             $this->searchAdapter->addSelectField('price_max');
         }
 
-        $this->searchAdapter->addSelectField('id_product_attribute');
+        if (isset($selectedFilters['id_attribute_group'])) {
+            $this->searchAdapter->addSelectField('id_product_attribute');
+        }
 
         $matchingProductList = $this->searchAdapter->execute();
 

--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -85,6 +85,8 @@ class Products
             $this->searchAdapter->addSelectField('price_max');
         }
 
+        $this->searchAdapter->addSelectField('id_product_attribute');
+
         $matchingProductList = $this->searchAdapter->execute();
 
         $this->pricePostFiltering($matchingProductList, $selectedFilters);

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -239,6 +239,23 @@
 	  </div>
 	</div>
 
+	<div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='List combinations as individual products' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_filter_list_combinations_as_products" id="ps_layered_filter_list_combinations_as_products_on" value="1"{if $list_combinations_as_products} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_list_combinations_as_products_on" class="radioCheck">
+			<i></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_filter_list_combinations_as_products" id="ps_layered_filter_list_combinations_as_products_off" value="0"{if !$list_combinations_as_products} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_list_combinations_as_products_off" class="radioCheck">
+			<i></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+	  </div>
+	</div>
+
 	<div class="panel-footer">
 	  <button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 	</div>


### PR DESCRIPTION
- Added `id_product_attribute` To Select-Fields

Edit: I just noticed the product default combination gets ignored if a filter based on attribute groups is active.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When filtering products with combinations, only the default combination was used to determine price and url of the results.
| Type?         | bug fix / improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#15738 and PrestaShop/Prestashop#15164
| How to test?  | Filter for products with multiple combinations and different prices. Click on a product to navigate to the correct combination.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/718)
<!-- Reviewable:end -->
