### PR TITLE
Remove use of `$_GET`, refacto, simplify

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -31,8 +31,8 @@ use PrestaShop\Module\FacetedSearch\Adapter\InterfaceAdapter;
 use PrestaShop\Module\FacetedSearch\Product\Search;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberSymbolList;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShopDatabaseException;
-use Tools;
 
 /**
  * Display filters block on navigation
@@ -74,12 +74,23 @@ class Block
      */
     private $dataAccessor;
 
-    public function __construct(InterfaceAdapter $searchAdapter, Context $context, Db $database, DataAccessor $dataAccessor)
-    {
+    /**
+     * @var ProductSearchQuery
+     */
+    private $query;
+
+    public function __construct(
+        InterfaceAdapter $searchAdapter,
+        Context $context,
+        Db $database,
+        DataAccessor $dataAccessor,
+        ProductSearchQuery $query
+        ) {
         $this->searchAdapter = $searchAdapter;
         $this->context = $context;
         $this->database = $database;
         $this->dataAccessor = $dataAccessor;
+        $this->query = $query;
     }
 
     /**
@@ -94,16 +105,18 @@ class Block
     ) {
         $idLang = (int) $this->context->language->id;
         $idShop = (int) $this->context->shop->id;
-        $idParent = (int) Tools::getValue(
-            'id_category',
-            Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'))
-        );
+
+        // Get category ID from the query or home category as a fallback
+        $idCategory = (int) $this->query->getIdCategory();
+        if (empty($idCategory)) {
+            $idCategory = (int) Configuration::get('PS_HOME_CATEGORY');
+        }
 
         /* Get the filters for the current category */
         $filters = $this->database->executeS(
             'SELECT type, id_value, filter_show_limit, filter_type ' .
             'FROM ' . _DB_PREFIX_ . 'layered_category ' .
-            'WHERE id_category = ' . $idParent . ' ' .
+            'WHERE id_category = ' . $idCategory . ' ' .
             'AND id_shop = ' . $idShop . ' ' .
             'GROUP BY `type`, id_value ORDER BY position ASC'
         );
@@ -136,7 +149,7 @@ class Block
                         array_merge($filterBlocks, $this->getFeaturesBlock($filter, $selectedFilters, $idLang));
                     break;
                 case 'category':
-                    $parent = new Category($idParent, $idLang);
+                    $parent = new Category($idCategory, $idLang);
                     $filterBlocks[] = $this->getCategoriesBlock($filter, $selectedFilters, $idLang, $parent);
             }
         }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -21,7 +21,6 @@
 namespace PrestaShop\Module\FacetedSearch\Filters;
 
 use Category;
-use Configuration;
 use Context;
 use Db;
 use Manufacturer;
@@ -30,7 +29,6 @@ use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
-use Tools;
 
 class Converter
 {
@@ -233,22 +231,27 @@ class Converter
         $idShop = (int) $this->context->shop->id;
         $idLang = (int) $this->context->language->id;
 
-        $idParent = $query->getIdCategory();
-        if (empty($idParent)) {
-            $idParent = (int) Tools::getValue('id_category_layered', Configuration::get('PS_HOME_CATEGORY'));
+        // Get category ID from the query or home category as a fallback
+        $idCategory = (int) $query->getIdCategory();
+        if (empty($idCategory)) {
+            $idCategory = (int) Configuration::get('PS_HOME_CATEGORY');
         }
 
         $searchFilters = [];
 
-        /* Get the filters for the current category */
+        // Get filters configured for the current category
         $filters = $this->database->executeS(
             'SELECT type, id_value, filter_show_limit, filter_type FROM ' . _DB_PREFIX_ . 'layered_category
-            WHERE id_category = ' . (int) $idParent . '
-            AND id_shop = ' . (int) $idShop . '
+            WHERE id_category = ' . $idCategory . '
+            AND id_shop = ' . $idShop . '
             GROUP BY `type`, id_value ORDER BY position ASC'
         );
 
+        // Parse currently selected filters from URL into a nice array
         $facetAndFiltersLabels = $this->urlSerializer->unserialize($query->getEncodedFacets());
+
+        // Go through filters that are configured and find out which should be activated,
+        // depending on what was provided in the URL
         foreach ($filters as $filter) {
             $filterLabel = $this->convertFilterTypeToLabel($filter['type']);
 

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\FacetedSearch\Filters;
 
 use Category;
+use Configuration;
 use Context;
 use Db;
 use Manufacturer;

--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\FacetedSearch\Filters;
 use Configuration;
 use PrestaShop\Module\FacetedSearch\Adapter\AbstractAdapter;
 use PrestaShop\Module\FacetedSearch\Product\Search;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use Product;
 use Validate;
 
@@ -53,27 +54,28 @@ class Products
     }
 
     /**
-     * Get the products associated with the current filters
+     * Get the products associated with the current filters.
      *
-     * @param int $productsPerPage
-     * @param int $page
-     * @param string $orderBy
-     * @param string $orderWay
+     * @param ProductSearchQuery $query
      * @param array $selectedFilters
      *
      * @return array
      */
     public function getProductByFilters(
-        $productsPerPage,
-        $page,
-        $orderBy,
-        $orderWay,
-        $selectedFilters = []
+        ProductSearchQuery $query,
+        array $selectedFilters = []
     ) {
+        // Get pagination
+        $productsPerPage = (int) $query->getResultsPerPage();
+        $page = (int) $query->getPage();
+
+        // Load sorting type and direction, validate it and apply fallback if needed
+        $orderBy = $query->getSortOrder()->toLegacyOrderBy(false);
+        $orderWay = $query->getSortOrder()->toLegacyOrderWay();
         $orderWay = Validate::isOrderWay($orderWay) ? $orderWay : 'ASC';
         $orderBy = Validate::isOrderBy($orderBy) ? $orderBy : 'position';
 
-        $this->searchAdapter->setLimit((int) $productsPerPage, ((int) $page - 1) * $productsPerPage);
+        $this->searchAdapter->setLimit($productsPerPage, ($page - 1) * $productsPerPage);
         $this->searchAdapter->setOrderField($orderBy);
         $this->searchAdapter->setOrderDirection($orderWay);
 

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -33,7 +33,7 @@ class ProductSearch extends AbstractHook
     ];
 
     /**
-     * This function returns the search provider to the controller who requested it.
+     * This method returns the search provider to the controller who requested it.
      * Module currently only supports filtering in categories, so in other cases,
      * we don't return anything.
      *

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -33,7 +33,9 @@ class ProductSearch extends AbstractHook
     ];
 
     /**
-     * Hook project search provider
+     * This function returns the search provider to the controller who requested it.
+     * Module currently only supports filtering in categories, so in other cases,
+     * we don't return anything.
      *
      * @param array $params
      *
@@ -41,42 +43,38 @@ class ProductSearch extends AbstractHook
      */
     public function productSearchProvider(array $params)
     {
-        $query = $params['query'];
-        // do something with query,
-        // e.g. use $query->getIdCategory()
-        // to choose a template for filters.
-        // Query is an instance of:
-        // PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery
-        if ($query->getIdCategory()) {
-            if ((bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER')) {
-                $this->context->controller->addJqueryUi('slider');
-            }
-            $this->context->controller->registerStylesheet(
-                'facetedsearch_front',
-                '/modules/ps_facetedsearch/views/dist/front.css'
-            );
-            $this->context->controller->registerJavascript(
-                'facetedsearch_front',
-                '/modules/ps_facetedsearch/views/dist/front.js',
-                ['position' => 'bottom', 'priority' => 100]
-            );
-
-            $urlSerializer = new URLSerializer();
-            $dataAccessor = new DataAccessor($this->module->getDatabase());
-
-            return new SearchProvider(
-                $this->module,
-                new Converter(
-                    $this->module->getContext(),
-                    $this->module->getDatabase(),
-                    $urlSerializer,
-                    $dataAccessor
-                ),
-                $urlSerializer,
-                $dataAccessor
-            );
+        if (!$params['query']->getIdCategory()) {
+            return null;
         }
 
-        return null;
+        // Assign assets
+        if ((bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER')) {
+            $this->context->controller->addJqueryUi('slider');
+        }
+        $this->context->controller->registerStylesheet(
+            'facetedsearch_front',
+            '/modules/ps_facetedsearch/views/dist/front.css'
+        );
+        $this->context->controller->registerJavascript(
+            'facetedsearch_front',
+            '/modules/ps_facetedsearch/views/dist/front.js',
+            ['position' => 'bottom', 'priority' => 100]
+        );
+
+        $urlSerializer = new URLSerializer();
+        $dataAccessor = new DataAccessor($this->module->getDatabase());
+
+        // Return an instance of our searcher, ready to accept requests
+        return new SearchProvider(
+            $this->module,
+            new Converter(
+                $this->module->getContext(),
+                $this->module->getDatabase(),
+                $urlSerializer,
+                $dataAccessor
+            ),
+            $urlSerializer,
+            $dataAccessor
+        );
     }
 }

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -111,6 +111,10 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
     }
 
     /**
+     * Instance of this class was previously passed to frontend controller, so we are now
+     * ready to accept runQuery requests. The query object contains all the important information
+     * about what we should get.
+     *
      * @param ProductSearchContext $context
      * @param ProductSearchQuery $query
      *
@@ -121,25 +125,29 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         ProductSearchQuery $query
     ) {
         $result = new ProductSearchResult();
-        // extract the filter array from the Search query
+
+        /**
+         * Get currently selected filters. In the query, it's passed as encoded URL string,
+         * we make it an array. All filters in the URL that are no longer valid are removed.
+         */
         $facetedSearchFilters = $this->filtersConverter->createFacetedSearchFiltersFromQuery($query);
 
+        // Initialize the search mechanism
         $context = $this->module->getContext();
         $facetedSearch = $this->searchFactory->build($context);
-        // init the search with the initial population associated with the current filters
+
+        // Add query information into Search
+        $facetedSearch->setQuery($query);
+
+        // Init the search with the initial population associated with the current filters
         $facetedSearch->initSearch($facetedSearchFilters);
 
-        $orderBy = $query->getSortOrder()->toLegacyOrderBy(false);
-        $orderWay = $query->getSortOrder()->toLegacyOrderWay();
-
+        // Load the product searcher, it gets the Adapter through Search object
         $filterProductSearch = new Filters\Products($facetedSearch);
 
-        // get the product associated with the current filter
+        // Get the product associated with the current filter
         $productsAndCount = $filterProductSearch->getProductByFilters(
-            $query->getResultsPerPage(),
-            $query->getPage(),
-            $orderBy,
-            $orderWay,
+            $query,
             $facetedSearchFilters
         );
 
@@ -148,14 +156,17 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             ->setTotalProductsCount($productsAndCount['count'])
             ->setAvailableSortOrders($this->getAvailableSortOrders());
 
-        // now get the filter blocks associated with the current search
+        // Now let's get the filter blocks associated with the current search.
+        // This will allow user to further filter this list we found.
         $filterBlockSearch = new Filters\Block(
             $facetedSearch->getSearchAdapter(),
             $context,
             $this->module->getDatabase(),
-            $this->dataAccessor
+            $this->dataAccessor,
+            $query
         );
 
+        // Get basic information about the context and see if we have these filters cached
         $idShop = (int) $context->shop->id;
         $idLang = (int) $context->language->id;
         $idCurrency = (int) $context->currency->id;
@@ -174,6 +185,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             )
         );
 
+        // If not, we regenerate it and cache it
         $filterBlock = $filterBlockSearch->getFromCache($filterHash);
         if (empty($filterBlock)) {
             $filterBlock = $filterBlockSearch->getFilterBlock($productsAndCount['count'], $facetedSearchFilters);

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -31,11 +31,11 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
 use PrestaShop\Module\FacetedSearch\Filters\Block;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Shop;
 use stdClass;
 use StockAvailable;
-use Tools;
 
 class BlockTest extends MockeryTestCase
 {
@@ -102,29 +102,23 @@ class BlockTest extends MockeryTestCase
 
         StockAvailable::setStaticExpectations($mock);
 
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-        Tools::setStaticExpectations($toolsMock);
-
         $this->shopMock = Mockery::mock(Shop::class);
         Shop::setStaticExpectations($this->shopMock);
 
         $this->adapterMock = Mockery::mock(MySQL::class)->makePartial();
         $this->adapterMock->resetAll();
 
+        // Initialize fake query
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')
+            ->andReturn(12);
+
         $this->block = new Block(
             $this->adapterMock,
             $this->contextMock,
             $this->dbMock,
-            new DataAccessor($this->dbMock)
+            new DataAccessor($this->dbMock),
+            $query
         );
     }
 

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
 use Shop;
 use stdClass;
-use Tools;
 
 class ConverterTest extends MockeryTestCase
 {
@@ -72,17 +71,6 @@ class ConverterTest extends MockeryTestCase
         $this->contextMock->language->id = 2;
 
         $this->dbMock = Mockery::mock(Db::class);
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-        Tools::setStaticExpectations($toolsMock);
 
         $this->shopMock = Mockery::mock(Shop::class);
         Shop::setStaticExpectations($this->shopMock);

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -28,8 +28,8 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
 use PrestaShop\Module\FacetedSearch\Product\Search;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use stdClass;
-use Tools;
 
 class SearchTest extends MockeryTestCase
 {
@@ -81,7 +81,14 @@ class SearchTest extends MockeryTestCase
 
         Context::setStaticExpectations($contextMock);
 
+        // Initialize the search engine
         $this->search = new Search($contextMock);
+
+        // Initialize fake query
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')
+            ->andReturn(12);
+        $this->search->setQuery($query);
     }
 
     public function testGetFacetedSearchTypeAdapter()
@@ -94,19 +101,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithoutCorrectSelectedFilters()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(['quantity' => []]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
@@ -116,14 +110,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -157,19 +151,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithEmptyFilters()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch([]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
@@ -179,14 +160,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -220,19 +201,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithAllFilters()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(
             [
                 'id_feature' => [
@@ -326,7 +294,7 @@ class SearchTest extends MockeryTestCase
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                         [
                             6,
@@ -393,19 +361,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithManyFeatures()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(
             [
                 'id_feature' => [
@@ -437,14 +392,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -490,19 +445,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithManyAttributes()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(
             [
                 'id_attribute_group' => [
@@ -534,14 +476,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -611,18 +553,11 @@ class SearchTest extends MockeryTestCase
 
         $this->search = new Search($contextMock);
 
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
+        // Initialize fake query
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')
+            ->andReturn(12);
+        $this->search->setQuery($query);
 
         $this->search->initSearch(['quantity' => [0]]);
 
@@ -633,14 +568,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -674,19 +609,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithFirstQuantityFilters()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(['quantity' => [1]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
@@ -721,19 +643,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithSecondQuantityFilters()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $this->search->initSearch(['quantity' => [2]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
@@ -758,19 +667,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithoutGroupFeature()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $groupMock = Mockery::mock(Group::class);
         $groupMock->shouldReceive('isFeatureActive')
             ->andReturn(false);
@@ -786,14 +682,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
@@ -819,19 +715,6 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithUserBelongingToGroups()
     {
-        $toolsMock = Mockery::mock(Tools::class);
-        $toolsMock->shouldReceive('getValue')
-            ->andReturnUsing(function ($arg) {
-                $valueMap = [
-                    'id_category' => 12,
-                    'id_category_layered' => 11,
-                ];
-
-                return $valueMap[$arg];
-            });
-
-        Tools::setStaticExpectations($toolsMock);
-
         $frontControllerMock = Mockery::mock(FrontController::class);
         $frontControllerMock->shouldReceive('getCurrentCustomerGroups')
             ->andReturn([2, 999]);
@@ -847,14 +730,14 @@ class SearchTest extends MockeryTestCase
                 'id_category_default' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],
                 'id_category' => [
                     '=' => [
                         [
-                            null,
+                            12,
                         ],
                     ],
                 ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Type?         | improvement / refacto
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | This Pull Request refactors the code, but does not modify the behavior. You should be able to compare the module behavior with and without this PR : they should be identical

### Intro for reviewers on how this works
- When you open a category or other page, the controller first asks on a hook, if there is somebody who would like to search products for him. This module is hooked there and if it's category controller, it says "Hey I can do this filtering for you" and return it's instance.
- Then, category controller calls `runQuery()` function in this module and passes `ProductSearchQuery` object. This object contains all the information about category ID, selected filters, query type, page, sorting etc. 
- This basically means = "Hey `ps_facetedsearch`, you agreed to search products for me, so get me the products then. Use these instructions."

It looks like this:
![test](https://user-images.githubusercontent.com/6097524/198016330-f5e06df5-937f-4f70-b936-a6675a3165c2.jpg)

### What was wrong
- Even though all the required information is provided in the `ProductSearchQuery`, ps_facetedsearch was using it only partially and in some places in the code, it was doing `Tools::getValue('id_category');` which is not very reliable.
- This is a problem when you want to fetch those products from a different custom controller, you then need to do weird stuff like 
`$_POST['id_category'] = 471;`
- So I changed this and now it takes the category ID from `ProductSearchQuery` properly everywhere.
- It also make implementing https://github.com/PrestaShop/ps_facetedsearch/pull/531 much easier, because I will have all the query data available everywhere properly.

### What I changed 
- src/Filters/Block - Added `$query` to constructor and using `$this->query->getIdCategory()`.
- src/Filters/Converter - Query already provided, so I just used `$query->getIdCategory()``.
- src/Filters/Products - Instead of passing the query data in 4 variables (`$productsPerPage`, `$page`, `$orderBy`, `$orderWay`) I passed only `$query` like in `src/Filters/Block`.
- src/Hook/ProductSearch - Just some comments and early return to avoid big `if` block.
- src/Product/Search - Added `$query` property, getter, setter. So I can use `$this->query->getIdCategory();`. Initialize the Category object only if psLayeredFullTree is true, no need to do it in the beginning if it's not used eventually.
- src/Product/SearchProvider - Mostly comments, adding setQuery call and changing two calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/726)
<!-- Reviewable:end -->
