### PR TITLE
Cache features in DataAccessor

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -698,7 +698,7 @@ class Block
      */
     private function getFeaturesBlock($filter, $selectedFilters, $idLang)
     {
-        $features = $featureBlock = [];
+        $featureBlock = [];
         $idFeature = $filter['id_value'];
         $filteredSearchAdapter = null;
 
@@ -716,13 +716,9 @@ class Block
             $filteredSearchAdapter = $this->searchAdapter->getFilteredSearchAdapter();
         }
 
-        $tempFeatures = $this->dataAccessor->getFeatures($idLang);
-        if (empty($tempFeatures)) {
+        $features = $this->dataAccessor->getFeatures($idLang);
+        if (empty($features)) {
             return [];
-        }
-
-        foreach ($tempFeatures as $key => $feature) {
-            $features[$feature['id_feature']] = $feature;
         }
 
         $filteredSearchAdapter->addOperationsFilter(
@@ -740,10 +736,7 @@ class Block
             $feature = $features[$idFeature];
 
             if (!isset($featureBlock[$idFeature])) {
-                $tempFeatureValues = $this->dataAccessor->getFeatureValues($idFeature, $idLang);
-                foreach ($tempFeatureValues as $featureValueKey => $featureValue) {
-                    $features[$idFeature]['featureValues'][$featureValue['id_feature_value']] = $featureValue;
-                }
+                $features[$idFeature]['featureValues'] = $this->dataAccessor->getFeatureValues($idFeature, $idLang);
 
                 $featureBlock[$idFeature] = [
                     'type_lite' => 'id_feature',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Compare installs with and without this PR, they will provide the same results.

### Description
- There is no need to load a list of features or their values 30 times.
- There was already a mechanism to store loaded attributes, I implemented the same for features.

### Stats
- I tried on my shop with a category that has 2592 products, 28 features and about 800 feature values.
- Average load time from 8 attempts 507 ms ➡️ 492 ms
- Database queries 386 ➡️ 359
- Peak memory usage 15,4 MB ➡️ 15,3 MB

### How to test
- I think this can be tested by a dev. There is no difference to the returned data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/727)
<!-- Reviewable:end -->
