### PR TITLE
Add default filter functionality

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -803,13 +803,14 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $features = $this->getAvailableFeatures();
         $attributeGroups = $this->getAvailableAttributes();
 
-        // Initialize category tree
+        // Initialize category tree component
         $treeCategoriesHelper = new HelperTreeCategories('categories-treeview');
         $treeCategoriesHelper
             ->setRootCategory((Shop::getContext() == Shop::CONTEXT_SHOP ? Category::getRootCategory()->id_category : 0))
             ->setUseCheckBox(true);
 
-        // If we are editing an already existing template
+        // If we are editing an already existing template, we will load its data,
+        // check categories and add selected filters. Otherwise, we prepare empty template.
         if ($template !== null) {
             $filters = Tools::unSerialize($template['filters']);
             $id_layered_filter = $template['id_layered_filter'];
@@ -837,7 +838,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         }
 
         $this->context->smarty->assign([
-            'current_url' => $this->context->link->getAdminLink('AdminModules') . '&configure=ps_facetedsearch&tab_module=front_office_features&module_name=ps_facetedsearch',
+            'current_url' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'module_name' => $this->name]),
             'id_layered_filter' => $id_layered_filter,
             'template_name' => $template_name,
             'attribute_groups' => $attributeGroups,
@@ -879,7 +880,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     }
 
     /**
-     * Returns array with all available attributes on the shop
+     * Returns array with all available attributes on the shop. Only used in backoffice.
      */
     private function getAvailableAttributes()
     {
@@ -894,7 +895,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     }
 
     /**
-     * Returns array with all available features on the shop
+     * Returns array with all available features on the shop. Only used in backoffice.
      */
     private function getAvailableFeatures()
     {
@@ -1580,7 +1581,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
     }
 
     /**
-     * Provides data about single template.
+     * Provides data about single filter template.
      *
      * @param int $idFilterTemplate ID of filter template
      *
@@ -1591,7 +1592,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         return $this->getDatabase()->getRow(
             'SELECT *
             FROM `' . _DB_PREFIX_ . 'layered_filter`
-            WHERE id_layered_filter = ' . $idFilterTemplate
+            WHERE id_layered_filter = ' . (int) $idFilterTemplate
         );
     }
 

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -723,97 +723,53 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
         }
 
-        $categoryBox = [];
-        $attributeGroups = $this->getDatabase()->executeS(
-            'SELECT ag.id_attribute_group, ag.is_color_group, agl.name, COUNT(DISTINCT(a.id_attribute)) n
-            FROM ' . _DB_PREFIX_ . 'attribute_group ag
-            LEFT JOIN ' . _DB_PREFIX_ . 'attribute_group_lang agl ON (agl.id_attribute_group = ag.id_attribute_group)
-            LEFT JOIN ' . _DB_PREFIX_ . 'attribute a ON (a.id_attribute_group = ag.id_attribute_group)
-            WHERE agl.id_lang = ' . (int) $cookie->id_lang . '
-            GROUP BY ag.id_attribute_group'
-        );
+        // Assign general variables
+        $this->context->smarty->assign('uri', $this->getPathUri());
 
-        $features = $this->getDatabase()->executeS(
-            'SELECT fl.id_feature, fl.name, COUNT(DISTINCT(fv.id_feature_value)) n
-            FROM ' . _DB_PREFIX_ . 'feature_lang fl
-            LEFT JOIN ' . _DB_PREFIX_ . 'feature_value fv ON (fv.id_feature = fl.id_feature)
-            WHERE (fv.custom IS NULL OR fv.custom = 0) AND fl.id_lang = ' . (int) $cookie->id_lang . '
-            GROUP BY fl.id_feature'
-        );
-
-        if (Shop::isFeatureActive() && count(Shop::getShops(true, null, true)) > 1) {
-            $helper = new HelperForm();
-            $helper->id = Tools::getValue('id_layered_filter', null);
-            $helper->table = 'layered_filter';
-            $helper->identifier = 'id_layered_filter';
-            $this->context->smarty->assign('asso_shops', $helper->renderAssoShop());
-        }
-
-        $treeCategoriesHelper = new HelperTreeCategories('categories-treeview');
-        $treeCategoriesHelper->setRootCategory((Shop::getContext() == Shop::CONTEXT_SHOP ? Category::getRootCategory()->id_category : 0))
-                                                                     ->setUseCheckBox(true);
-
-        $moduleUrl = Tools::getProtocol(Tools::usingSecureMode()) . $_SERVER['HTTP_HOST'] . $this->getPathUri();
-
+        // Assign assets
         if (method_exists($this->context->controller, 'addJquery')) {
             $this->context->controller->addJS(_PS_JS_DIR_ . 'jquery/plugins/jquery.sortable.js');
         }
-
         $this->context->controller->addJS($this->_path . 'views/dist/back.js');
         $this->context->controller->addCSS($this->_path . 'views/dist/back.css');
 
+        // Render screen for adding new template
         if (Tools::getValue('add_new_filters_template')) {
-            $this->context->smarty->assign([
-                'current_url' => $this->context->link->getAdminLink('AdminModules') . '&configure=ps_facetedsearch&tab_module=front_office_features&module_name=ps_facetedsearch',
-                'uri' => $this->getPathUri(),
-                'id_layered_filter' => 0,
-                'template_name' => sprintf($this->trans('My template - %s', [], 'Modules.Facetedsearch.Admin'), date('Y-m-d')),
-                'attribute_groups' => $attributeGroups,
-                'features' => $features,
-                'total_filters' => 6 + count($attributeGroups) + count($features),
-            ]);
-
-            $this->context->smarty->assign('categories_tree', $treeCategoriesHelper->render());
-
-            return $this->display(__FILE__, 'views/templates/admin/add.tpl');
+            return $this->renderAdminTemplateEdit();
         }
 
         if (Tools::getValue('edit_filters_template')) {
+            // Try to get template to edit from database
             $idLayeredFilter = (int) Tools::getValue('id_layered_filter');
             $template = $this->getDatabase()->getRow(
                 'SELECT *
                 FROM `' . _DB_PREFIX_ . 'layered_filter`
                 WHERE id_layered_filter = ' . $idLayeredFilter
             );
-
             if (!empty($template)) {
-                $filters = Tools::unSerialize($template['filters']);
-                $treeCategoriesHelper->setSelectedCategories($filters['categories']);
-                $this->context->smarty->assign('categories_tree', $treeCategoriesHelper->render());
-
-                $selectShops = $filters['shop_list'];
-                unset($filters['categories']);
-                unset($filters['shop_list']);
-
-                $this->context->smarty->assign([
-                    'current_url' => $this->context->link->getAdminLink('AdminModules') . '&configure=ps_facetedsearch&tab_module=front_office_features&module_name=ps_facetedsearch',
-                    'uri' => $this->getPathUri(),
-                    'id_layered_filter' => $idLayeredFilter,
-                    'template_name' => $template['name'],
-                    'attribute_groups' => $attributeGroups,
-                    'features' => $features,
-                    'filters' => $filters,
-                    'total_filters' => 6 + count($attributeGroups) + count($features),
-                    'default_filters' => $this->getDefaultFilters(),
-                ]);
-
-                return $this->display(__FILE__, 'views/templates/admin/view.tpl');
+                return $this->renderAdminTemplateEdit($template);
+            } else {
+                $message = $this->displayError($this->trans('Filter template not found', [], 'Modules.Facetedsearch.Admin'));
             }
         }
 
+        $this->context->smarty->assign('message', $message);
+
+        // Render general admin screen
+        return $this->renderAdminMain();
+    }
+
+    /**
+     * Returns content for main module configuration screen
+     */
+    public function renderAdminMain()
+    {
+        // General purpose variables
+        $moduleUrl = Tools::getProtocol(Tools::usingSecureMode()) . $_SERVER['HTTP_HOST'] . $this->getPathUri();
+        $features = $this->getAvailableFeatures();
+        $attributeGroups = $this->getAvailableAttributes();
+
         $this->context->smarty->assign([
-            'message' => $message,
-            'uri' => $this->getPathUri(),
             'PS_LAYERED_INDEXED' => (int) Configuration::getGlobalValue('PS_LAYERED_INDEXED'),
             'current_url' => Tools::safeOutput(preg_replace('/&deleteFilterTemplate=[0-9]*&id_layered_filter=[0-9]*/', '', $_SERVER['REQUEST_URI'])),
             'id_lang' => $this->getContext()->cookie->id_lang,
@@ -823,7 +779,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'full_price_indexer_url' => $moduleUrl . 'ps_facetedsearch-price-indexer.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10) . '&full=1',
             'attribute_indexer_url' => $moduleUrl . 'ps_facetedsearch-attribute-indexer.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
             'clear_cache_url' => $moduleUrl . 'ps_facetedsearch-clear-cache.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
-            'filters_templates' => $this->getDatabase()->executeS('SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter ORDER BY date_add DESC'),
+            'filters_templates' => $this->getExistingFiltersOverview(),
             'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
             'cache_enabled' => Configuration::get('PS_LAYERED_CACHE_ENABLED'),
             'full_tree' => $this->psLayeredFullTree,
@@ -837,6 +793,68 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');
+    }
+
+    /**
+     * Returns content for filter template creation or editing
+     */
+    public function renderAdminTemplateEdit($template)
+    {
+        // Get general data for use in template settings
+        $features = $this->getAvailableFeatures();
+        $attributeGroups = $this->getAvailableAttributes();
+
+        // Initialize category tree
+        $treeCategoriesHelper = new HelperTreeCategories('categories-treeview');
+        $treeCategoriesHelper
+            ->setRootCategory((Shop::getContext() == Shop::CONTEXT_SHOP ? Category::getRootCategory()->id_category : 0))
+            ->setUseCheckBox(true);
+
+        // If we are editing an already existing template
+        if ($template !== null) {
+            $filters = Tools::unSerialize($template['filters']);
+            $id_layered_filter = $template['id_layered_filter'];
+            $template_name = $template['name'];
+
+            // Check categories
+            $treeCategoriesHelper->setSelectedCategories($filters['categories']);
+
+            // We need to clear all data except the filters themselves, due to JS processing them
+            unset($filters['categories']);
+            unset($filters['shop_list']);
+        } else {
+            $id_layered_filter = 0;
+            $filters = [];
+            $template_name = sprintf($this->trans('My template - %s', [], 'Modules.Facetedsearch.Admin'), date('Y-m-d'));    
+        }
+
+        // Assign multistore related data
+        if (Shop::isFeatureActive() && count(Shop::getShops(true, null, true)) > 1) {
+            $helper = new HelperForm();
+            $helper->id = Tools::getValue('id_layered_filter', null);
+            $helper->table = 'layered_filter';
+            $helper->identifier = 'id_layered_filter';
+            $this->context->smarty->assign('asso_shops', $helper->renderAssoShop());
+        }
+
+        $this->context->smarty->assign([
+            'current_url' => $this->context->link->getAdminLink('AdminModules') . '&configure=ps_facetedsearch&tab_module=front_office_features&module_name=ps_facetedsearch',
+            'id_layered_filter' => $id_layered_filter,
+            'template_name' => $template_name,
+            'attribute_groups' => $attributeGroups,
+            'features' => $features,
+            'filters' => $filters,
+            'total_filters' => 6 + count($attributeGroups) + count($features),
+            'default_filters' => $this->getDefaultFilters(),
+            'categories_tree' => $treeCategoriesHelper->render(),
+        ]);
+
+        // We are using two separate templates depending on context
+        if ($template !== null) {
+            return $this->display(__FILE__, 'views/templates/admin/view.tpl');
+        } else {
+            return $this->display(__FILE__, 'views/templates/admin/add.tpl');
+        }
     }
 
     public function displayLimitPostWarning($count)
@@ -859,6 +877,44 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     private function query($sqlQuery)
     {
         return $this->getDatabase()->query($sqlQuery);
+    }
+
+    /**
+     * Returns array with all available attributes on the shop
+     */
+    private function getAvailableAttributes()
+    {
+        return $this->getDatabase()->executeS(
+            'SELECT ag.id_attribute_group, ag.is_color_group, agl.name, COUNT(DISTINCT(a.id_attribute)) n
+            FROM ' . _DB_PREFIX_ . 'attribute_group ag
+            LEFT JOIN ' . _DB_PREFIX_ . 'attribute_group_lang agl ON (agl.id_attribute_group = ag.id_attribute_group)
+            LEFT JOIN ' . _DB_PREFIX_ . 'attribute a ON (a.id_attribute_group = ag.id_attribute_group)
+            WHERE agl.id_lang = ' . (int) $this->getContext()->cookie->id_lang . '
+            GROUP BY ag.id_attribute_group'
+        );
+    }
+
+    /**
+     * Returns array with all available features on the shop
+     */
+    private function getAvailableFeatures()
+    {
+        return $this->getDatabase()->executeS(
+            'SELECT fl.id_feature, fl.name, COUNT(DISTINCT(fv.id_feature_value)) n
+            FROM ' . _DB_PREFIX_ . 'feature_lang fl
+            LEFT JOIN ' . _DB_PREFIX_ . 'feature_value fv ON (fv.id_feature = fl.id_feature)
+            WHERE (fv.custom IS NULL OR fv.custom = 0) AND fl.id_lang = ' . (int) $this->getContext()->cookie->id_lang . '
+            GROUP BY fl.id_feature'
+        );
+    }
+
+    /**
+     * Returns array with existing filters set up in the module, for overview on a main page
+     */
+    private function getExistingFiltersOverview()
+    {
+        // Get data about current filters in database
+        return $this->getDatabase()->executeS('SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter ORDER BY date_add DESC');
     }
 
     /**
@@ -1105,43 +1161,57 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
     }
 
     /**
-     * Build layered categories
+     * This function gets serialized data of filter templates from layered_filter table and builds detailed 
+     * information, one category = one line.
      */
     public function buildLayeredCategories()
     {
-        // Get all filter template
-        $res = $this->getDatabase()->executeS('SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter ORDER BY date_add DESC');
-        $categories = [];
+        // Get data for all filter templates in the database
+        $templates = $this->getDatabase()->executeS('SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter ORDER BY date_add DESC');
+
+        // We will keep track of pages categories where filter was already set, so we don't have multiple
+        // filters for the same category and shop.
+        $alreadyAssigned = [];
+
         // Clear cache
         $this->invalidateLayeredFilterBlockCache();
-        // Remove all from layered_category
+
+        // Remove all previous data from layered_category
         $this->getDatabase()->execute('TRUNCATE ' . _DB_PREFIX_ . 'layered_category');
 
-        if (!count($res)) { // No filters templates defined, nothing else to do
+        // If no filter templates are defined, nothing else to do here
+        if (!count($templates)) {
             return true;
         }
 
+        // We will insert our queries by batches of hundred queries
         $sqlInsertPrefix = 'INSERT INTO ' . _DB_PREFIX_ . 'layered_category (id_category, id_shop, id_value, type, position, filter_show_limit, filter_type) VALUES ';
         $sqlInsert = '';
         $nbSqlValuesToInsert = 0;
 
-        foreach ($res as $filterTemplate) {
+        // Now we will loop through each filter template
+        foreach ($templates as $filterTemplate) {
+            // We will get it's data and convert it into array
             $data = Tools::unSerialize($filterTemplate['filters']);
             foreach ($data['shop_list'] as $idShop) {
-                if (!isset($categories[$idShop])) {
-                    $categories[$idShop] = [];
+                if (!isset($alreadyAssigned[$idShop])) {
+                    $alreadyAssigned[$idShop] = [];
                 }
 
                 foreach ($data['categories'] as $idCategory) {
                     $n = 0;
-                    if (in_array($idCategory, $categories[$idShop])) {
+
+                    // If we already have a filter for this category and shop, we will skip it
+                    if (in_array($idCategory, $alreadyAssigned[$idShop])) {
                         continue;
                     }
-                    // Last definition, erase previous categories defined
 
-                    $categories[$idShop][] = $idCategory;
+                    // Save information, that this category already has a filter assigned, so we skip it next time
+                    $alreadyAssigned[$idShop][] = $idCategory;
 
                     foreach ($data as $key => $value) {
+                        // The template contains some other data than filters, so we clean it up a bit
+                        // All filters begin with layered_selection
                         if (substr($key, 0, 17) == 'layered_selection') {
                             $type = $value['filter_type'];
                             $limit = $value['filter_show_limit'];
@@ -1168,6 +1238,8 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                             }
 
                             ++$nbSqlValuesToInsert;
+
+                            // If we reached the limit, we will execute it and flush our "cache"
                             if ($nbSqlValuesToInsert >= 100) {
                                 $this->getDatabase()->execute($sqlInsertPrefix . rtrim($sqlInsert, ','));
                                 $sqlInsert = '';
@@ -1179,6 +1251,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
             }
         }
 
+        // We will execute remaining queries because we almost certainly didn't reach 100 in the batch
         if ($nbSqlValuesToInsert) {
             $this->getDatabase()->execute($sqlInsertPrefix . rtrim($sqlInsert, ','));
         }

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1160,7 +1160,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
     }
 
     /**
-     * This function gets serialized data of filter templates from layered_filter table and builds detailed
+     * This method gets serialized data of filter templates from layered_filter table and builds detailed
      * information, one category = one line.
      */
     public function buildLayeredCategories()

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -797,7 +797,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     /**
      * Returns content for filter template creation or editing
      */
-    public function renderAdminTemplateEdit($template)
+    public function renderAdminTemplateEdit($template = null)
     {
         // Get general data for use in template settings
         $features = $this->getAvailableFeatures();
@@ -824,7 +824,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         } else {
             $id_layered_filter = 0;
             $filters = [];
-            $template_name = sprintf($this->trans('My template - %s', [], 'Modules.Facetedsearch.Admin'), date('Y-m-d'));    
+            $template_name = sprintf($this->trans('My template - %s', [], 'Modules.Facetedsearch.Admin'), date('Y-m-d'));
         }
 
         // Assign multistore related data
@@ -1160,7 +1160,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
     }
 
     /**
-     * This function gets serialized data of filter templates from layered_filter table and builds detailed 
+     * This function gets serialized data of filter templates from layered_filter table and builds detailed
      * information, one category = one line.
      */
     public function buildLayeredCategories()
@@ -1583,24 +1583,26 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
      * Provides data about single template.
      *
      * @param int $idFilterTemplate ID of filter template
-     * 
+     *
      * @return array Filter data
      */
-    public function getFilterTemplate($idFilterTemplate) {
+    public function getFilterTemplate($idFilterTemplate)
+    {
         return $this->getDatabase()->getRow(
             'SELECT *
             FROM `' . _DB_PREFIX_ . 'layered_filter`
             WHERE id_layered_filter = ' . $idFilterTemplate
         );
     }
+
     /**
      * Checks if module is configured to automatically add some filter to new categories.
      * If so, it adds the new category.
      *
      * @param int $idCategory ID of category being created
      */
-    public function addCategoryToDefaultFilter($idCategory) {
-
+    public function addCategoryToDefaultFilter($idCategory)
+    {
         // Get default template
         $defaultFilterTemplateId = (int) Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE');
         if (empty($defaultFilterTemplateId)) {
@@ -1612,7 +1614,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         if (empty($template)) {
             return;
         }
- 
+
         // Unserialize filters, add our category
         $filters = Tools::unSerialize($template['filters']);
         $filters['categories'][] = $idCategory;

--- a/src/Hook/Category.php
+++ b/src/Hook/Category.php
@@ -86,7 +86,8 @@ class Category extends AbstractHook
                 unset($data['categories'][array_search((int) $params['category']->id, $data['categories'])]);
                 $this->database->execute(
                     'UPDATE `' . _DB_PREFIX_ . 'layered_filter`
-                    SET `filters` = \'' . pSQL(serialize($data)) . '\'
+                    SET `filters` = \'' . pSQL(serialize($data)) . '\',
+                    n_categories = ' . (int) count($data['categories']) . ' 
                     WHERE `id_layered_filter` = ' . (int) $layeredFilter['id_layered_filter']
                 );
             }

--- a/src/Hook/Category.php
+++ b/src/Hook/Category.php
@@ -37,6 +37,7 @@ class Category extends AbstractHook
      */
     public function actionCategoryAdd(array $params)
     {
+        $this->module->addCategoryToDefaultFilter((int) $params['category']->id);
         $this->module->rebuildLayeredCache([], [(int) $params['category']->id]);
         $this->module->invalidateLayeredFilterBlockCache();
     }

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -261,6 +261,21 @@
     </div>
   </div>
 
+	<div class="form-group">
+		<label class="control-label col-lg-3">{l s='Default filter template for new categories' d='Modules.Facetedsearch.Admin'}</label>				
+		<div class="col-lg-9">
+			<select class="form-control fixed-width-xxl" name="ps_layered_default_category_template" id="ps_layered_default_category_template">
+				<option value="0" {if empty($default_category_template)} selected="selected" {/if}>{l s='None' d='Admin.Global'}</option>
+				{foreach $filters_templates as $template}
+					<option value="{$template['id_layered_filter']}" {if $default_category_template == $template['id_layered_filter']} selected="selected" {/if}>{$template['name']}</option>
+				{/foreach}
+			</select>
+		</div>
+		<div class="col-lg-9 col-lg-offset-3">
+			<div class="help-block">{l s='If you want to automatically assign a filter template to new categories, select it here.' d='Modules.Facetedsearch.Admin'}</div>
+		</div>
+	</div>
+
 	<div class="panel-footer">
 	  <button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 	</div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below. I tried to provide clear description of the feature with context and how it looks like. Please ask me if some things are not clear.
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28687
| How to test?  | Read below. I tried to provide clear 'how to test' items please ask me if some things are not clear.

### Description
- Half of merchants have no idea about any filter settings and you must non-stop keep checking, if you didn't forget to assign a template to new category after creating it. Merchants don't want to think about it.
- So, this PR adds a new function where you can select a default filter that you want to assign to new categories. After creating a new category, if this function is enabled, the category will be added to this filter.
- It also refactors the admin a tiny bit, adds some comments, extracts some logic to separate functions and fixes a tiny bug.

### How does it look
![template](https://user-images.githubusercontent.com/6097524/198348567-c865e2ef-3cd8-4ff4-bdd5-27927ba5e737.jpg)

### How to test and what to test
Firstly, this PR modifies a behavior that happens when adding a new category. Then some parts of the code were extracted to separate functions to make it SOMEHOW cleaner. It concerns only the backend part, there cannot be any effect on filtering in front office.

**So, to test default filter functionality:**
- Set up a filter in faceted search for some categories. 
- Set up another filter for another categories.
- Select one of the filters as your default one.
- Then go to Catalog > Categories and create a new category.
- Go back to faceted search and see that this category should be automatically added to your default filter. The other filter should stay exactly as it was.
- Check that nothing else was changed in that filter other than the 1 new category.

**A tiny bug fixed**
- If you delete a category, faceted search goes through each filter template and deletes the category from the filter template. But, it forgots to update the category count in the filter. Although maybe used only for BO, it's good if everything is correct.
- Setup a filter template for some categories. Then go to Catalog > Categories and delete one of the categories.
- See that on dev branch, category count in filter template list stayed the same. With my PR, it gets correctly updated.

**General test**
- Click through all the settings in the module settings, see that everything works.
- Try adding a new filter template, try editing some template, try deleting some template.
- Check that you are offered all your features and attributes for filtering.

You can briefly check FO, but there is no effect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/728)
<!-- Reviewable:end -->
