### PR TITLE
Remove unreported error and fix tests

### DIFF
--- a/tests/php/phpstan/phpstan-latest.neon
+++ b/tests/php/phpstan/phpstan-latest.neon
@@ -7,4 +7,3 @@ parameters:
     - '~^Parameter #2 \$active of static method CurrencyCore::getCurrencies\(\) expects bool, int given\.$~'
     - '~^Parameter #3 \$groupBy of static method CurrencyCore::getCurrencies\(\) expects bool, Shop given\.$~'
     - '~^Parameter #\d+ \$\w+ of static method ProductCore::priceCalculation\(\) expects \w+, \w+ given\.$~'
-    - '~^Access to an undefined property Cookie::\$id_lang\.$~'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Tests were reporting `Ignored error pattern ~^Access to an undefined property Cookie::\$id_lang\.$~ was not matched in reported errors.`, and "fail". This will fix it.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | See tests are green.

Example of failing tests on different PRs:
- https://github.com/PrestaShop/ps_facetedsearch/actions/runs/3338143641/jobs/5906764102
- https://github.com/PrestaShop/ps_facetedsearch/actions/runs/3331877803/jobs/5838854200

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/746)
<!-- Reviewable:end -->
