### PR TITLE
Simplify type casting (CI)

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1129,11 +1129,13 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         foreach ($res as $filterTemplate) {
             $data = Tools::unSerialize($filterTemplate['filters']);
             foreach ($data['shop_list'] as $idShop) {
+                $idShop = (int) $idShop;
                 if (!isset($categories[$idShop])) {
                     $categories[$idShop] = [];
                 }
 
                 foreach ($data['categories'] as $idCategory) {
+                    $idCategory = (int) $idCategory;
                     $n = 0;
                     if (in_array($idCategory, $categories[$idShop])) {
                         continue;
@@ -1149,23 +1151,23 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                             ++$n;
 
                             if ($key == 'layered_selection_stock') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'quantity\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'quantity\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_subcategories') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'category\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'category\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_condition') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'condition\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'condition\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_weight_slider') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'weight\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'weight\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_price_slider') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'price\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'price\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_manufacturer') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', NULL,\'manufacturer\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', NULL,\'manufacturer\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif (substr($key, 0, 21) == 'layered_selection_ag_') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', ' . (int) str_replace('layered_selection_ag_', '', $key) . ',
-\'id_attribute_group\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', ' . (int) str_replace('layered_selection_ag_', '', $key) . ',
+\'id_attribute_group\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif (substr($key, 0, 23) == 'layered_selection_feat_') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', ' . (int) $idShop . ', ' . (int) str_replace('layered_selection_feat_', '', $key) . ',
-\'id_feature\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . $idCategory . ', ' . $idShop . ', ' . (int) str_replace('layered_selection_feat_', '', $key) . ',
+\'id_feature\',' . $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             }
 
                             ++$nbSqlValuesToInsert;

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1024,64 +1024,65 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             $filterData['shop_list'] = $shopList;
 
             foreach ($c as $idCategory => $category) {
+                $idCategory = (int) $idCategory;
                 if (!in_array($idCategory, $filterData['categories'])) {
                     $filterData['categories'][] = $idCategory;
                 }
 
-                if (!isset($nCategories[(int) $idCategory])) {
-                    $nCategories[(int) $idCategory] = 1;
+                if (!isset($nCategories[$idCategory])) {
+                    $nCategories[$idCategory] = 1;
                 }
-                if (!isset($doneCategories[(int) $idCategory]['cat'])) {
+                if (!isset($doneCategories[$idCategory]['cat'])) {
                     $filterData['layered_selection_subcategories'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['cat'] = true;
+                    $doneCategories[$idCategory]['cat'] = true;
                     $toInsert = true;
                 }
                 if (is_array($attributeGroupsById) && count($attributeGroupsById) > 0) {
                     foreach ($a as $kAttribute => $attribute) {
-                        if (!isset($doneCategories[(int) $idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]])) {
+                        if (!isset($doneCategories[$idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]])) {
                             $filterData['layered_selection_ag_' . (int) $attributeGroupsById[(int) $kAttribute]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                            $doneCategories[(int) $idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]] = true;
+                            $doneCategories[$idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]] = true;
                             $toInsert = true;
                         }
                     }
                 }
                 if (is_array($attributeGroupsById) && count($attributeGroupsById) > 0) {
                     foreach ($f as $kFeature => $feature) {
-                        if (!isset($doneCategories[(int) $idCategory]['f' . (int) $featuresById[(int) $kFeature]])) {
+                        if (!isset($doneCategories[$idCategory]['f' . (int) $featuresById[(int) $kFeature]])) {
                             $filterData['layered_selection_feat_' . (int) $featuresById[(int) $kFeature]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                            $doneCategories[(int) $idCategory]['f' . (int) $featuresById[(int) $kFeature]] = true;
+                            $doneCategories[$idCategory]['f' . (int) $featuresById[(int) $kFeature]] = true;
                             $toInsert = true;
                         }
                     }
                 }
 
-                if (!isset($doneCategories[(int) $idCategory]['q'])) {
+                if (!isset($doneCategories[$idCategory]['q'])) {
                     $filterData['layered_selection_stock'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['q'] = true;
+                    $doneCategories[$idCategory]['q'] = true;
                     $toInsert = true;
                 }
 
-                if (!isset($doneCategories[(int) $idCategory]['m'])) {
+                if (!isset($doneCategories[$idCategory]['m'])) {
                     $filterData['layered_selection_manufacturer'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['m'] = true;
+                    $doneCategories[$idCategory]['m'] = true;
                     $toInsert = true;
                 }
 
-                if (!isset($doneCategories[(int) $idCategory]['c'])) {
+                if (!isset($doneCategories[$idCategory]['c'])) {
                     $filterData['layered_selection_condition'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['c'] = true;
+                    $doneCategories[$idCategory]['c'] = true;
                     $toInsert = true;
                 }
 
-                if (!isset($doneCategories[(int) $idCategory]['w'])) {
+                if (!isset($doneCategories[$idCategory]['w'])) {
                     $filterData['layered_selection_weight_slider'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['w'] = true;
+                    $doneCategories[$idCategory]['w'] = true;
                     $toInsert = true;
                 }
 
-                if (!isset($doneCategories[(int) $idCategory]['p'])) {
+                if (!isset($doneCategories[$idCategory]['p'])) {
                     $filterData['layered_selection_price_slider'] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
-                    $doneCategories[(int) $idCategory]['p'] = true;
+                    $doneCategories[$idCategory]['p'] = true;
                     $toInsert = true;
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  1. Assign `$id_xyz = (int) $id_xyz` once at the beginning of `foreach` loop, then use `$id_xyz` in the rest. <br> 2. `$n` starts at `0`, then is modified by `++`, so there is no need to type cast.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29869
| How to test?  | A coding style change does not affect module's behaviors. <br>Check module Configuration in BO and filters block in FO to make sure nothing is broken. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/719)
<!-- Reviewable:end -->
