### PR TITLE
Fix adding new category

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1595,36 +1595,4 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
             WHERE id_layered_filter = ' . (int) $idFilterTemplate
         );
     }
-
-    /**
-     * Checks if module is configured to automatically add some filter to new categories.
-     * If so, it adds the new category.
-     *
-     * @param int $idCategory ID of category being created
-     */
-    public function addCategoryToDefaultFilter($idCategory)
-    {
-        // Get default template
-        $defaultFilterTemplateId = (int) Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE');
-        if (empty($defaultFilterTemplateId)) {
-            return;
-        }
-
-        // Try to get it's data
-        $template = $this->getFilterTemplate($defaultFilterTemplateId);
-        if (empty($template)) {
-            return;
-        }
-
-        // Unserialize filters, add our category
-        $filters = Tools::unSerialize($template['filters']);
-        $filters['categories'][] = $idCategory;
-
-        // Update it in database
-        $sql = 'UPDATE ' . _DB_PREFIX_ . 'layered_filter ' .
-        'SET filters = "' . pSQL(serialize($filters)) . '", ' .
-        'n_categories = ' . (int) count($filters['categories']) . ' ' .
-        'WHERE id_layered_filter = ' . $defaultFilterTemplateId;
-        $this->getDatabase()->execute($sql);
-    }
 }

--- a/src/Hook/Category.php
+++ b/src/Hook/Category.php
@@ -101,12 +101,13 @@ class Category extends AbstractHook
             );
         }
 
-        if (!$rebuildNeeded) {
-            return;
+        // Rebuild filter table only if a category was removed from a filter
+        if ($rebuildNeeded) {
+            $this->module->buildLayeredCategories();
         }
 
+        // Flush cache all the time, because the category could be cached in a category filter block
         $this->module->invalidateLayeredFilterBlockCache();
-        $this->module->buildLayeredCategories();
     }
 
     /**

--- a/src/Hook/Category.php
+++ b/src/Hook/Category.php
@@ -20,6 +20,7 @@
 
 namespace PrestaShop\Module\FacetedSearch\Hook;
 
+use Configuration;
 use Tools;
 
 class Category extends AbstractHook
@@ -37,8 +38,9 @@ class Category extends AbstractHook
      */
     public function actionCategoryAdd(array $params)
     {
-        $this->module->addCategoryToDefaultFilter((int) $params['category']->id);
-        $this->module->rebuildLayeredCache([], [(int) $params['category']->id]);
+        $this->addCategoryToDefaultFilter((int) $params['category']->id);
+
+        // Flush filter block cache in all cases, so a new category shows up
         $this->module->invalidateLayeredFilterBlockCache();
     }
 
@@ -51,10 +53,10 @@ class Category extends AbstractHook
     {
         /*
          * The category status might (active, inactive) have changed,
-         * we have to update the layered cache table structure
+         * we have to update the layered cache table structure.
          */
         if (isset($params['category']) && !$params['category']->active) {
-            $this->cleanAndRebuildCategoryFilters($params);
+            $this->removeCategoryFromFilterTemplates((int) $params['category']->id);
         }
     }
 
@@ -65,35 +67,80 @@ class Category extends AbstractHook
      */
     public function actionCategoryDelete(array $params)
     {
-        $this->cleanAndRebuildCategoryFilters($params);
+        $this->removeCategoryFromFilterTemplates((int) $params['category']->id);
     }
 
     /**
      * Clean and rebuild category filters
      *
-     * @param array $params
+     * @param int $idCategory
      */
-    private function cleanAndRebuildCategoryFilters(array $params)
+    private function removeCategoryFromFilterTemplates(int $idCategory)
     {
-        $layeredFilterList = $this->database->executeS(
+        // Get all filter templates
+        $filterTemplates = $this->database->executeS(
             'SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter'
         );
 
-        foreach ($layeredFilterList as $layeredFilter) {
-            $data = Tools::unSerialize($layeredFilter['filters']);
+        $rebuildNeeded = false;
 
-            if (in_array((int) $params['category']->id, $data['categories'])) {
-                unset($data['categories'][array_search((int) $params['category']->id, $data['categories'])]);
-                $this->database->execute(
-                    'UPDATE `' . _DB_PREFIX_ . 'layered_filter`
-                    SET `filters` = \'' . pSQL(serialize($data)) . '\',
-                    n_categories = ' . (int) count($data['categories']) . ' 
-                    WHERE `id_layered_filter` = ' . (int) $layeredFilter['id_layered_filter']
-                );
+        // Go through each template, check if our category is set for this template.
+        // If yes, remove it and update the template.
+        foreach ($filterTemplates as $template) {
+            $filters = Tools::unSerialize($template['filters']);
+            if (!in_array((int) $idCategory, $filters['categories'])) {
+                continue;
             }
+            unset($filters['categories'][array_search((int) $idCategory, $filters['categories'])]);
+            $rebuildNeeded = true;
+            $this->database->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'layered_filter` 
+                SET `filters` = "' . pSQL(serialize($filters)) . '", 
+                n_categories = ' . (int) count($filters['categories']) . ' 
+                WHERE `id_layered_filter` = ' . (int) $template['id_layered_filter']
+            );
+        }
+
+        if (!$rebuildNeeded) {
+            return;
         }
 
         $this->module->invalidateLayeredFilterBlockCache();
+        $this->module->buildLayeredCategories();
+    }
+
+    /**
+     * Checks if module is configured to automatically add some filter to new categories.
+     * If so, it adds the new category.
+     *
+     * @param int $idCategory ID of category being created
+     */
+    public function addCategoryToDefaultFilter(int $idCategory)
+    {
+        // Get default template
+        $defaultFilterTemplateId = (int) Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE');
+        if (empty($defaultFilterTemplateId)) {
+            return;
+        }
+
+        // Try to get it's data
+        $template = $this->module->getFilterTemplate($defaultFilterTemplateId);
+        if (empty($template)) {
+            return;
+        }
+
+        // Unserialize filters, add our category
+        $filters = Tools::unSerialize($template['filters']);
+        $filters['categories'][] = $idCategory;
+
+        // Update it in database
+        $this->database->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'layered_filter` 
+            SET `filters` = "' . pSQL(serialize($filters)) . '", 
+            n_categories = ' . (int) count($filters['categories']) . ' 
+            WHERE `id_layered_filter` = ' . $defaultFilterTemplateId
+        );
+
         $this->module->buildLayeredCategories();
     }
 }


### PR DESCRIPTION
➡️ Note for QA and review - test are OK, the red is due to coveralls again.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | My new function that automatically adds newly created categories to a default filter (added in https://github.com/PrestaShop/ps_facetedsearch/pull/728) does not work properly, because I forgot to call `$this->module->buildLayeredCategories();`. I use this oportunity to also clean up the related code a bit.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Set up a default filter in faceted search. Go create a new category, add some product to it. Go to FO and see that you can see filters. Before, the category was added to the template, but the filters didn't work.

### Details
- Moved my adding function to Category class where it should be.
- Added the missing `$this->module->buildLayeredCategories();` call I forgot.
- Renamed `cleanAndRebuildCategoryFilters` to a more appropriate name `removeCategoryFromFilterTemplates` and passing only the category ID there, not the whole params array.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/763)
<!-- Reviewable:end -->
