### PR TITLE
Minor refactoring

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -75,6 +75,11 @@ class Block
     private $dataAccessor;
 
     /**
+     * @var Provider
+     */
+    private $provider;
+
+    /**
      * @var ProductSearchQuery
      */
     private $query;
@@ -84,13 +89,15 @@ class Block
         Context $context,
         Db $database,
         DataAccessor $dataAccessor,
-        ProductSearchQuery $query
+        ProductSearchQuery $query,
+        Provider $provider
         ) {
         $this->searchAdapter = $searchAdapter;
         $this->context = $context;
         $this->database = $database;
         $this->dataAccessor = $dataAccessor;
         $this->query = $query;
+        $this->provider = $provider;
     }
 
     /**
@@ -112,14 +119,8 @@ class Block
             $idCategory = (int) Configuration::get('PS_HOME_CATEGORY');
         }
 
-        /* Get the filters for the current category */
-        $filters = $this->database->executeS(
-            'SELECT type, id_value, filter_show_limit, filter_type ' .
-            'FROM ' . _DB_PREFIX_ . 'layered_category ' .
-            'WHERE id_category = ' . $idCategory . ' ' .
-            'AND id_shop = ' . $idShop . ' ' .
-            'GROUP BY `type`, id_value ORDER BY position ASC'
-        );
+        // Get filters configured for the current query
+        $filters = $this->provider->getFiltersForQuery($this->query, $idShop);
 
         $filterBlocks = [];
         // iterate through each filter, and the get corresponding filter block

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -77,16 +77,23 @@ class Converter
      */
     private $dataAccessor;
 
+    /**
+     * @var Filters\Provider
+     */
+    private $provider;
+
     public function __construct(
         Context $context,
         Db $database,
         URLSerializer $urlSerializer,
-        Filters\DataAccessor $dataAccessor
+        Filters\DataAccessor $dataAccessor,
+        Filters\Provider $provider
     ) {
         $this->context = $context;
         $this->database = $database;
         $this->urlSerializer = $urlSerializer;
         $this->dataAccessor = $dataAccessor;
+        $this->provider = $provider;
     }
 
     public function getFacetsFromFilterBlocks(array $filterBlocks)
@@ -240,13 +247,8 @@ class Converter
 
         $searchFilters = [];
 
-        // Get filters configured for the current category
-        $filters = $this->database->executeS(
-            'SELECT type, id_value, filter_show_limit, filter_type FROM ' . _DB_PREFIX_ . 'layered_category
-            WHERE id_category = ' . $idCategory . '
-            AND id_shop = ' . $idShop . '
-            GROUP BY `type`, id_value ORDER BY position ASC'
-        );
+        // Get filters configured for the current query
+        $filters = $this->provider->getFiltersForQuery($query, $idShop);
 
         // Parse currently selected filters from URL into a nice array
         $facetAndFiltersLabels = $this->urlSerializer->unserialize($query->getEncodedFacets());
@@ -398,7 +400,7 @@ class Converter
                 case self::TYPE_CATEGORY:
                     if (isset($facetAndFiltersLabels[$filterLabel])) {
                         foreach ($facetAndFiltersLabels[$filterLabel] as $queryFilter) {
-                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $query->getIdCategory());
+                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $idCategory);
                             if ($categories) {
                                 $searchFilters[$filter['type']][] = $categories['id_category'];
                             }

--- a/src/Filters/Provider.php
+++ b/src/Filters/Provider.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Filters;
+
+use Db;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
+
+/**
+ * Class responsible for providing filters configured for current search query
+ */
+class Provider
+{
+    /**
+     * @var array
+     */
+    private $filters = [];
+
+    /**
+     * @var Db
+     */
+    private $database;
+
+    public function __construct(Db $database)
+    {
+        $this->database = $database;
+    }
+
+    /**
+     * Get filters for current search query
+     *
+     * @param ProductSearchQuery $query
+     * @param int $idShop
+     *
+     * @return array Filters
+     */
+    public function getFiltersForQuery(ProductSearchQuery $query, int $idShop)
+    {
+        if (empty($this->filters)) {
+            $this->filters = $this->database->executeS(
+            'SELECT type, id_value, filter_show_limit, filter_type FROM ' . _DB_PREFIX_ . 'layered_category
+            WHERE id_category = ' . (int) $query->getIdCategory() . '
+            AND id_shop = ' . $idShop . '
+            GROUP BY `type`, id_value ORDER BY position ASC'
+            );
+        }
+
+        return $this->filters;
+    }
+}

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\FacetedSearch\Hook;
 use Configuration;
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\Module\FacetedSearch\Product\SearchProvider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 
@@ -63,6 +64,7 @@ class ProductSearch extends AbstractHook
 
         $urlSerializer = new URLSerializer();
         $dataAccessor = new DataAccessor($this->module->getDatabase());
+        $provider = new Provider($this->module->getDatabase());
 
         // Return an instance of our searcher, ready to accept requests
         return new SearchProvider(
@@ -71,10 +73,13 @@ class ProductSearch extends AbstractHook
                 $this->module->getContext(),
                 $this->module->getDatabase(),
                 $urlSerializer,
-                $dataAccessor
+                $dataAccessor,
+                $provider
             ),
             $urlSerializer,
-            $dataAccessor
+            $dataAccessor,
+            null,
+            $provider
         );
     }
 }

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -61,18 +61,25 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
      */
     private $searchFactory;
 
+    /**
+     * @var Filters\Provider
+     */
+    private $provider;
+
     public function __construct(
         Ps_Facetedsearch $module,
         Filters\Converter $converter,
         URLSerializer $serializer,
         Filters\DataAccessor $dataAccessor,
-        SearchFactory $searchFactory = null
+        SearchFactory $searchFactory = null,
+        Filters\Provider $provider
     ) {
         $this->module = $module;
         $this->filtersConverter = $converter;
         $this->urlSerializer = $serializer;
         $this->dataAccessor = $dataAccessor;
         $this->searchFactory = $searchFactory === null ? new SearchFactory() : $searchFactory;
+        $this->provider = $provider;
     }
 
     /**
@@ -163,30 +170,15 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             $context,
             $this->module->getDatabase(),
             $this->dataAccessor,
-            $query
+            $query,
+            $this->provider
         );
 
-        // Get basic information about the context and see if we have these filters cached
-        $idShop = (int) $context->shop->id;
-        $idLang = (int) $context->language->id;
-        $idCurrency = (int) $context->currency->id;
-        $idCountry = (int) $context->country->id;
-        $idCategory = (int) $query->getIdCategory();
-
-        $filterHash = md5(
-            sprintf(
-                '%d-%d-%d-%d-%d-%s',
-                $idShop,
-                $idCurrency,
-                $idLang,
-                $idCategory,
-                $idCountry,
-                serialize($facetedSearchFilters)
-            )
-        );
-
-        // If not, we regenerate it and cache it
+        // Let's try to get filters from cache
+        $filterHash = $this->generateCacheKeyForQuery($query, $facetedSearchFilters);
         $filterBlock = $filterBlockSearch->getFromCache($filterHash);
+
+        // If not there, we regenerate it and cache it
         if (empty($filterBlock)) {
             $filterBlock = $filterBlockSearch->getFilterBlock($productsAndCount['count'], $facetedSearchFilters);
             $filterBlockSearch->insertIntoCache($filterHash, $filterBlock);
@@ -208,6 +200,32 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $result->setEncodedFacets($this->urlSerializer->serialize($facetFilters));
 
         return $result;
+    }
+
+    /**
+     * Generate unique cache hash to store blocks in cache
+     *
+     * @param ProductSearchQuery $query
+     * @param array $facetedSearchFilters
+     *
+     * @return string
+     */
+    private function generateCacheKeyForQuery(ProductSearchQuery $query, array $facetedSearchFilters)
+    {
+        $context = $this->module->getContext();
+        $filterHash = md5(
+            sprintf(
+                '%d-%d-%d-%d-%d-%s',
+                (int) $context->shop->id,
+                (int) $context->currency->id,
+                (int) $context->language->id,
+                (int) $query->getIdCategory(),
+                (int) $context->country->id,
+                serialize($facetedSearchFilters)
+            )
+        );
+
+        return $filterHash;
     }
 
     /**

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -31,6 +31,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
 use PrestaShop\Module\FacetedSearch\Filters\Block;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Shop;
@@ -118,7 +119,8 @@ class BlockTest extends MockeryTestCase
             $this->contextMock,
             $this->dbMock,
             new DataAccessor($this->dbMock),
-            $query
+            $query,
+            new Provider($this->dbMock)
         );
     }
 
@@ -1164,7 +1166,10 @@ class BlockTest extends MockeryTestCase
     {
         $this->dbMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category WHERE id_category = 12 AND id_shop = 1 GROUP BY `type`, id_value ORDER BY position ASC')
+            ->with('SELECT type, id_value, filter_show_limit, filter_type FROM ps_layered_category
+            WHERE id_category = 12
+            AND id_shop = 1
+            GROUP BY `type`, id_value ORDER BY position ASC')
             ->andReturn($result);
     }
 }

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -27,6 +27,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
@@ -79,7 +80,8 @@ class ConverterTest extends MockeryTestCase
             $this->contextMock,
             $this->dbMock,
             new URLSerializer(),
-            new DataAccessor($this->dbMock)
+            new DataAccessor($this->dbMock),
+            new Provider($this->dbMock)
         );
     }
 

--- a/tests/php/FacetedSearch/Product/SearchProviderTest.php
+++ b/tests/php/FacetedSearch/Product/SearchProviderTest.php
@@ -27,6 +27,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\Module\FacetedSearch\Product\SearchProvider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
@@ -147,7 +148,9 @@ class SearchProviderTest extends MockeryTestCase
             $this->module,
             $this->converter,
             $this->serializer,
-            new DataAccessor($this->database)
+            new DataAccessor($this->database),
+            null,
+            new Provider($this->database)
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Some minor refactoring discovered when working on https://github.com/PrestaShop/ps_facetedsearch/pull/757, to reduce that PR's scope. Details below.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Check that you see filters in front office and unit tests pass. No visible or behavior change.

### Changes
- I unified two DB queries to a single `getFiltersForQuery` function. This function is now in a new class `Filters\Provider`. This class is now passed in some new constructors. `BlockTest` needed to be changed a tiny bit to add new lines.
- In `createFacetedSearchFiltersFromQuery`, I was using `$query->getIdCategory()` instead of `$idCategory` with a possible fallback (https://github.com/PrestaShop/ps_facetedsearch/blob/6854ff296b833cbd6d905ef4aed5b59b7fca4116/src/Filters/Converter.php#L237), this was not obvious and does not affect nothing now, but when implementing the new functions, it popped up.
- I extracted filter hash to new `generateCacheKeyForQuery` function, to make the code cleaner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_facetedsearch/764)
<!-- Reviewable:end -->
