### PR TITLE
Refacto applying filters, add tests

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -118,47 +118,27 @@ class Search
      */
     public function initSearch($selectedFilters)
     {
-        // Get category ID from the query or home category as a fallback
-        $idCategory = (int) $this->query->getIdCategory();
-        if (empty($idCategory)) {
-            $idCategory = (int) Configuration::get('PS_HOME_CATEGORY');
-        }
+        // Adds basic filters that are common for every search, like shop and group limitations
+        $this->addCommonFilters();
 
-        $psLayeredFullTree = Configuration::get('PS_LAYERED_FULL_TREE');
-        if (!$psLayeredFullTree) {
-            $this->addFilter('id_category', [$idCategory]);
-        }
+        // Add filters that the user has selected for current query
+        $this->addSearchFilters($selectedFilters);
 
-        $psLayeredFilterByDefaultCategory = Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
-        if ($psLayeredFilterByDefaultCategory) {
-            $this->addFilter('id_category_default', [$idCategory]);
-        }
+        // Adds filters that specific for category page
+        $this->addControllerSpecificFilters();
 
-        // Visibility of a product must be in catalog or both (search & catalog)
-        $this->addFilter('visibility', ['both', 'catalog']);
-
-        // User must belong to one of the groups that can access the product
-        if (Group::isFeatureActive()) {
-            $groups = FrontController::getCurrentCustomerGroups();
-
-            $this->addFilter('id_group', empty($groups) ? [Group::getCurrent()->id] : $groups);
-        }
-
-        $this->addSearchFilters(
-            $selectedFilters,
-            $psLayeredFullTree ? new Category($idCategory) : null,
-            (int) $this->context->shop->id
-        );
+        // Add group by and flush it, let's go
+        $this->getSearchAdapter()->addGroupBy('id_product');
+        $this->getSearchAdapter()->useFiltersAsInitialPopulation();
     }
 
     /**
+     * Adds filters that the user has specifically selected for current query
+     *
      * @param array $selectedFilters
-     * @param Category $parent
-     * @param int $idShop
      */
-    private function addSearchFilters($selectedFilters, $parent, $idShop)
+    private function addSearchFilters($selectedFilters)
     {
-        $hasCategory = false;
         foreach ($selectedFilters as $key => $filterValues) {
             if (!count($filterValues)) {
                 continue;
@@ -187,8 +167,6 @@ class Search
 
                 case 'category':
                     $this->addFilter('id_category', $filterValues);
-                    $this->getSearchAdapter()->resetFilter('id_category_default');
-                    $hasCategory = true;
                     break;
 
                 case 'quantity':
@@ -304,16 +282,58 @@ class Search
                     break;
             }
         }
+    }
 
-        if (!$hasCategory && $parent !== null) {
-            $this->getSearchAdapter()->addFilter('nleft', [$parent->nleft], '>=');
-            $this->getSearchAdapter()->addFilter('nright', [$parent->nright], '<=');
+    /**
+     * Adds filters that are common for every search
+     */
+    private function addCommonFilters()
+    {
+        // Setting proper shop
+        $this->getSearchAdapter()->addFilter('id_shop', [(int) $this->context->shop->id]);
+
+        // Visibility of a product must be in catalog or both (search & catalog)
+        $this->addFilter('visibility', ['both', 'catalog']);
+
+        // User must belong to one of the groups that can access the product
+        // (Actually it's categories that define access to a product, user must have access to at least
+        // one category the product is assigned to.)
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+            $this->addFilter('id_group', empty($groups) ? [Group::getCurrent()->id] : $groups);
+        }
+    }
+
+    /**
+     * Adds filters that specific for category page
+     */
+    private function addControllerSpecificFilters()
+    {
+        // If any category filter was user selected, we don't have anything to do here
+        if (!empty($this->getSearchAdapter()->getFilter('id_category'))) {
+            return;
         }
 
-        $this->getSearchAdapter()->addFilter('id_shop', [$idShop]);
-        $this->getSearchAdapter()->addGroupBy('id_product');
+        // Get category ID from the query or home category as a fallback
+        $idCategory = (int) $this->query->getIdCategory();
+        if (empty($idCategory)) {
+            $idCategory = (int) Configuration::get('PS_HOME_CATEGORY');
+        }
+        $category = new Category((int) $idCategory);
 
-        $this->getSearchAdapter()->useFiltersAsInitialPopulation();
+        // If we want to display only products from this category AND not it's subcategories,
+        // we add this one specific category ID, otherwise, we will add everything using nleft and nright
+        if (Configuration::get('PS_LAYERED_FULL_TREE')) {
+            $this->getSearchAdapter()->addFilter('nleft', [$category->nleft], '>=');
+            $this->getSearchAdapter()->addFilter('nright', [$category->nright], '<=');
+        } else {
+            $this->addFilter('id_category', [$idCategory]);
+        }
+
+        // If we want to display products, which have this category as their default category
+        if (Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY')) {
+            $this->addFilter('id_category_default', [$idCategory]);
+        }
     }
 
     /**

--- a/tests/php/FacetedSearch/MockProxy.php
+++ b/tests/php/FacetedSearch/MockProxy.php
@@ -84,6 +84,17 @@ class Category extends MockProxy
     protected static $mock;
 
     public $id = null;
+    public $nleft = null;
+    public $nright = null;
+
+    public function __construct($id)
+    {
+        if ($id === 12) {
+            $this->id = 12;
+            $this->nleft = 101;
+            $this->nright = 102;
+        }
+    }
 }
 
 class Group extends MockProxy

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -149,6 +149,9 @@ class SearchTest extends MockeryTestCase
         $this->assertEquals([], $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray());
     }
 
+    /**
+     * Tests basic initial load of category, when full tree is disabled and we want only products from default category
+     */
     public function testInitSearchWithEmptyFilters()
     {
         $this->search->initSearch([]);
@@ -199,6 +202,78 @@ class SearchTest extends MockeryTestCase
         $this->assertEquals([], $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray());
     }
 
+    /**
+     * Tests basic initial load of category, when full tree is enabled
+     */
+    public function testInitSearchWithEmptyFiltersAndFullTree()
+    {
+        $mock = Mockery::mock(Configuration::class);
+        $mock->shouldReceive('get')
+            ->andReturnUsing(function ($arg) {
+                $valueMap = [
+                    'PS_STOCK_MANAGEMENT' => true,
+                    'PS_ORDER_OUT_OF_STOCK' => true,
+                    'PS_HOME_CATEGORY' => true,
+                    'PS_LAYERED_FULL_TREE' => true,
+                    'PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY' => false,
+                ];
+
+                return $valueMap[$arg];
+            });
+
+        Configuration::setStaticExpectations($mock);
+
+        $this->search->initSearch([]);
+
+        $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
+        $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
+        $this->assertEquals(
+            [
+                'nleft' => [
+                    '>=' => [
+                        [
+                            101,
+                        ],
+                    ],
+                ],
+                'nright' => [
+                    '<=' => [
+                        [
+                            102,
+                        ],
+                    ],
+                ],
+                'id_shop' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+                'visibility' => [
+                    '=' => [
+                        [
+                            'both',
+                            'catalog',
+                        ],
+                    ],
+                ],
+                'id_group' => [
+                    '=' => [
+                        [
+                            1,
+                        ],
+                    ],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getFilters()->toArray()
+        );
+        $this->assertEquals([], $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->toArray());
+    }
+
+    /**
+     * Tests filtering with user filters, including a specific selected category
+     */
     public function testInitSearchWithAllFilters()
     {
         $this->search->initSearch(
@@ -293,9 +368,6 @@ class SearchTest extends MockeryTestCase
                 ],
                 'id_category' => [
                     '=' => [
-                        [
-                            12,
-                        ],
                         [
                             6,
                         ],


### PR DESCRIPTION
➡️ QA - read the PR description and test scenarios provided.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | 
| Fixed ticket? | 
| How to test?  | Try test scenarios below.

### What it's about
- This is another extracted part of https://github.com/PrestaShop/ps_facetedsearch/pull/757. 
- Basically, we have three "kinds" of filters that are applied to a search.
  - Ones that are common for all pages (even for other controllers potentially) and are applied all the time, no matter what.
  - Then you have filters that customers select in front office by themselves in left column.
  - And you have the filters specific for the current controller, currently only a category page.
- It's a mess now and it needs to be cleaned up a bit. So I got to work:

### What you should know to approve and understand the code
- When "Show full tree is enabled" in settings, the module uses `nleft`/`nright` filters. If not, it uses specific `id_category` filter.
- If "Show only products from subcategories" is enabled, it also adds `id_category_default` filter.

### What I did
- User specified filters stay in `addSearchFilters`. That's good.
- I moved all common filters to `addCommonFilters`. This concerns shop ID, group limit and product visibility.
- Page specific filters are moved to a new function called `addControllerSpecificFilters`.
  - The logic is slightly changed. Before it was like taking three right turns instead of one left. :-)
  - Before, it was applying `id_category_default` filter first and then removing it again by calling `resetFilter()` Now, it checks if any user selected category filter was applied, and only if not, it sets the `id_category_default` filter and other filters like `nleft` and `nright`.
- Fixed a test error that appeared. When I submit a search with user selected filters containing category `6`, why there should be categories `6` and `12` in expected answer? There should be `id_category=6` filter only.
- Added a new test that checks if proper `nleft`/`nright` filters are added instead of id_category, depending on `PS_LAYERED_FULL_TREE` configuration.

### Why I do this in this separate PR
- In https://github.com/PrestaShop/ps_facetedsearch/pull/757, I will just modify one `addControllerSpecificFilters` function and it will be much easier to review and troubleshoot.
- It's much easier to troubleshoot and add tests when other controllers are not mixing in.

### What to test in QA
- **You don't have to check backoffice, nothing was done there.**
- Scenario 1
  - Put one product only to category `Women`. **Don't put it in Clothes**.
  - Enable `Show products from subcategories`, go to category `Clothes`, see that you can see this product.
  - Disable `Show products from subcategories`, go to category `Clothes`, see that you cannot see this product.
- Scenario 2
  - Put one product to categories `Men` and `Women`. Set default category of this product to `Women`.
  - Enable `Show products only from default category`, see that you can see this product only in `Women` and not in `Men`.
  - Disable `Show products only from default category`, see that you can see this product both in `Women` and `Men` categories.

### Github is not very good at showing the difference, it looks much cleaner IRL 👍
![code](https://user-images.githubusercontent.com/6097524/213243364-68e16078-93dc-4d39-bb81-4f6c76655bff.jpg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/775)
<!-- Reviewable:end -->
