### PR TITLE
Use numeric IDs for filter values (concept)

### DIFF
--- a/src/Adapter/index.php
+++ b/src/Adapter/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Constraint/index.php
+++ b/src/Constraint/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Definition/AvailabilityType.php
+++ b/src/Definition/AvailabilityType.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Definition;
+
+class AvailabilityType
+{
+    const AVAILABILITY_IN_STOCK = 2;
+    const AVAILABILITY_AVAILABLE = 1;
+    const AVAILABILITY_NOT_AVAILABLE = 0;
+}

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -651,8 +651,8 @@ class Block
                     'name' => $attributeGroup['attribute_group_name'],
                     'is_color_group' => (bool) $attributeGroup['is_color_group'],
                     'values' => [],
-                    'url_name' => $attributeGroup['url_name'],
-                    'meta_title' => $attributeGroup['meta_title'],
+                    'url_name' => $attributeGroup['attribute_group_name'],
+                    'meta_title' => $attributeGroup['attribute_group_name'],
                     'filter_show_limit' => (int) $filter['filter_show_limit'],
                     'filter_type' => $filter['filter_type'],
                 ];
@@ -661,8 +661,8 @@ class Block
             $attributesBlock[$idAttributeGroup]['values'][$idAttribute] = [
                 'name' => $attribute['name'],
                 'nbr' => $count,
-                'url_name' => $attribute['url_name'],
-                'meta_title' => $attribute['meta_title'],
+                'url_name' => $attribute['name'],
+                'meta_title' => $attribute['name'],
             ];
 
             if ($attributesBlock[$idAttributeGroup]['is_color_group'] !== false) {
@@ -766,8 +766,8 @@ class Block
                     'id_key' => $idFeature,
                     'values' => [],
                     'name' => $feature['name'],
-                    'url_name' => $feature['url_name'],
-                    'meta_title' => $feature['meta_title'],
+                    'url_name' => $feature['name'],
+                    'meta_title' => $feature['name'],
                     'filter_show_limit' => (int) $filter['filter_show_limit'],
                     'filter_type' => $filter['filter_type'],
                 ];
@@ -781,8 +781,8 @@ class Block
             $featureBlock[$idFeature]['values'][$idFeatureValue] = [
                 'nbr' => $count,
                 'name' => $featureValues[$idFeatureValue]['value'],
-                'url_name' => $featureValues[$idFeatureValue]['url_name'],
-                'meta_title' => $featureValues[$idFeatureValue]['meta_title'],
+                'url_name' => $featureValues[$idFeatureValue]['value'],
+                'meta_title' => $featureValues[$idFeatureValue]['value'],
             ];
 
             if (array_key_exists('id_feature', $selectedFilters)) {

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -28,6 +28,7 @@ use Feature;
 use Group;
 use Manufacturer;
 use PrestaShop\Module\FacetedSearch\Adapter\InterfaceAdapter;
+use PrestaShop\Module\FacetedSearch\Definition\AvailabilityType;
 use PrestaShop\Module\FacetedSearch\Product\Search;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberSymbolList;
@@ -435,7 +436,7 @@ class Block
         $availabilityOptions = [];
         if ($this->psStockManagement) {
             $availabilityOptions = [
-                0 => [
+                AvailabilityType::AVAILABILITY_NOT_AVAILABLE => [
                     'name' => $this->context->getTranslator()->trans(
                         'Not available',
                         [],
@@ -443,7 +444,7 @@ class Block
                     ),
                     'nbr' => 0,
                 ],
-                1 => [
+                AvailabilityType::AVAILABILITY_AVAILABLE => [
                     'name' => $this->context->getTranslator()->trans(
                         'Available',
                         [],
@@ -451,7 +452,7 @@ class Block
                     ),
                     'nbr' => 0,
                 ],
-                2 => [
+                AvailabilityType::AVAILABILITY_IN_STOCK => [
                     'name' => $this->context->getTranslator()->trans(
                         'In stock',
                         [],
@@ -473,7 +474,7 @@ class Block
                     ],
                 ]
             );
-            $availabilityOptions[0]['nbr'] = $filteredSearchAdapter->count();
+            $availabilityOptions[AvailabilityType::AVAILABILITY_NOT_AVAILABLE]['nbr'] = $filteredSearchAdapter->count();
 
             // Products in stock, or with out-of-stock ordering enabled
             $filteredSearchAdapter->addOperationsFilter(
@@ -487,7 +488,7 @@ class Block
                     ],
                 ]
             );
-            $availabilityOptions[1]['nbr'] = $filteredSearchAdapter->count();
+            $availabilityOptions[AvailabilityType::AVAILABILITY_AVAILABLE]['nbr'] = $filteredSearchAdapter->count();
 
             // Products in stock
             $filteredSearchAdapter->addOperationsFilter(
@@ -498,7 +499,7 @@ class Block
                     ],
                 ]
             );
-            $availabilityOptions[2]['nbr'] = $filteredSearchAdapter->count();
+            $availabilityOptions[AvailabilityType::AVAILABILITY_IN_STOCK]['nbr'] = $filteredSearchAdapter->count();
 
             // If some filter was selected, we want to show only this single filter, it does not make sense to show others
             if (isset($selectedFilters['availability'])) {

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -651,8 +651,8 @@ class Block
                     'name' => $attributeGroup['attribute_group_name'],
                     'is_color_group' => (bool) $attributeGroup['is_color_group'],
                     'values' => [],
-                    'url_name' => $attributeGroup['attribute_group_name'],
-                    'meta_title' => $attributeGroup['attribute_group_name'],
+                    'url_name' => null,
+                    'meta_title' => null,
                     'filter_show_limit' => (int) $filter['filter_show_limit'],
                     'filter_type' => $filter['filter_type'],
                 ];
@@ -661,8 +661,8 @@ class Block
             $attributesBlock[$idAttributeGroup]['values'][$idAttribute] = [
                 'name' => $attribute['name'],
                 'nbr' => $count,
-                'url_name' => $attribute['name'],
-                'meta_title' => $attribute['name'],
+                'url_name' => null,
+                'meta_title' => null,
             ];
 
             if ($attributesBlock[$idAttributeGroup]['is_color_group'] !== false) {
@@ -766,8 +766,8 @@ class Block
                     'id_key' => $idFeature,
                     'values' => [],
                     'name' => $feature['name'],
-                    'url_name' => $feature['name'],
-                    'meta_title' => $feature['name'],
+                    'url_name' => null,
+                    'meta_title' => null,
                     'filter_show_limit' => (int) $filter['filter_show_limit'],
                     'filter_type' => $filter['filter_type'],
                 ];
@@ -781,8 +781,8 @@ class Block
             $featureBlock[$idFeature]['values'][$idFeatureValue] = [
                 'nbr' => $count,
                 'name' => $featureValues[$idFeatureValue]['value'],
-                'url_name' => $featureValues[$idFeatureValue]['value'],
-                'meta_title' => $featureValues[$idFeatureValue]['value'],
+                'url_name' => null,
+                'meta_title' => null,
             ];
 
             if (array_key_exists('id_feature', $selectedFilters)) {

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -52,11 +52,6 @@ class Converter
     const PROPERTY_COLOR = 'color';
     const PROPERTY_TEXTURE = 'texture';
 
-    // Availability
-    const AVAILABILITY_IN_STOCK = 2;
-    const AVAILABILITY_AVAILABLE = 1;
-    const AVAILABILITY_NOT_AVAILABLE = 0;
-
     /**
      * @var array
      */

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -307,7 +307,6 @@ class Converter
                     // Load all features on the shop
                     $features = $this->dataAccessor->getFeatures($idLang);
                     foreach ($features as $feature) {
-
                         // Check if this filter is the one from the filter
                         if ($filter['id_value'] != $feature['id_feature']) {
                             continue;
@@ -333,7 +332,6 @@ class Converter
                     // Load all atrributes on the shop
                     $attributesGroup = $this->dataAccessor->getAttributesGroups($idLang);
                     foreach ($attributesGroup as $attributeGroup) {
-
                         // Check if this attribute is the one from the filter
                         if ($filter['id_value'] != $attributeGroup['id_attribute_group']) {
                             continue;

--- a/src/Filters/index.php
+++ b/src/Filters/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Form/Feature/index.php
+++ b/src/Form/Feature/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Form/index.php
+++ b/src/Form/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Hook/index.php
+++ b/src/Hook/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -27,6 +27,7 @@ use FrontController;
 use Group;
 use PrestaShop\Module\FacetedSearch\Adapter\AbstractAdapter;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL as MySQLAdapter;
+use PrestaShop\Module\FacetedSearch\Definition\AvailabilityType;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 
 class Search
@@ -192,13 +193,13 @@ class Search
                     // Simple cases with 1 option selected
                     if (count($filterValues) == 1) {
                         // Not available
-                        if ($filterValues[0] == 0) {
+                        if ($filterValues[0] == AvailabilityType::AVAILABILITY_NOT_AVAILABLE) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '<='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
                             ];
                         // Available
-                        } elseif ($filterValues[0] == 1) {
+                        } elseif ($filterValues[0] == AvailabilityType::AVAILABILITY_AVAILABLE) {
                             $operationsFilter[] = [
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
                             ];
@@ -206,7 +207,7 @@ class Search
                                 ['quantity', [0], '>'],
                             ];
                         // In stock
-                        } elseif ($filterValues[0] == 2) {
+                        } elseif ($filterValues[0] == AvailabilityType::AVAILABILITY_IN_STOCK) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '>'],
                             ];
@@ -214,10 +215,10 @@ class Search
                         // Cases with 2 options selected
                     } elseif (count($filterValues) == 2) {
                         // Not available and available, we show everything
-                        if (in_array(0, $filterValues) && in_array(1, $filterValues)) {
+                        if (in_array(AvailabilityType::AVAILABILITY_NOT_AVAILABLE, $filterValues) && in_array(AvailabilityType::AVAILABILITY_AVAILABLE, $filterValues)) {
                             break;
                         // Not available or in stock
-                        } elseif (in_array(0, $filterValues) && in_array(2, $filterValues)) {
+                        } elseif (in_array(AvailabilityType::AVAILABILITY_NOT_AVAILABLE, $filterValues) && in_array(AvailabilityType::AVAILABILITY_IN_STOCK, $filterValues)) {
                             $operationsFilter[] = [
                                 ['quantity', [0], '<='],
                                 ['out_of_stock', $this->psOrderOutOfStock ? [0] : [0, 2], '='],
@@ -226,7 +227,7 @@ class Search
                                 ['quantity', [0], '>'],
                             ];
                         // Available or in stock
-                        } elseif (in_array(1, $filterValues) && in_array(2, $filterValues)) {
+                        } elseif (in_array(AvailabilityType::AVAILABILITY_AVAILABLE, $filterValues) && in_array(AvailabilityType::AVAILABILITY_IN_STOCK, $filterValues)) {
                             $operationsFilter[] = [
                                 ['out_of_stock', $this->psOrderOutOfStock ? [1, 2] : [1], '='],
                             ];

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -451,7 +451,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
     {
         // first get the currently active facetFilter in an array
         $originalFacetFilters = $this->urlSerializer->getActiveFacetFiltersFromFacets($facets);
-
+        
         foreach ($facets as $facet) {
             $activeFacetFilters = $originalFacetFilters;
             // If only one filter can be selected, we keep track of

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -451,7 +451,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
     {
         // first get the currently active facetFilter in an array
         $originalFacetFilters = $this->urlSerializer->getActiveFacetFiltersFromFacets($facets);
-        
+
         foreach ($facets as $facet) {
             $activeFacetFilters = $originalFacetFilters;
             // If only one filter can be selected, we keep track of

--- a/src/Product/index.php
+++ b/src/Product/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/URLSerializer.php
+++ b/src/URLSerializer.php
@@ -20,7 +20,6 @@
 
 namespace PrestaShop\Module\FacetedSearch;
 
-use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
 

--- a/src/URLSerializer.php
+++ b/src/URLSerializer.php
@@ -37,17 +37,17 @@ class URLSerializer
      */
     public function addFilterToFacetFilters(array $facetFilters, Filter $facetFilter, Facet $facet)
     {
-        $facetLabel = $this->getFacetLabel($facet);
+        $facetIdentifier = $this->getFacetIdentifier($facet);
 
         if ($facet->getProperty('range')) {
             $facetValue = $facet->getProperty('values');
-            $facetFilters[$facetLabel] = [
+            $facetFilters[$facetIdentifier] = [
                 $facetFilter->getProperty('symbol'),
                 isset($facetValue[0]) ? $facetValue[0] : $facet->getProperty('min'),
                 isset($facetValue[1]) ? $facetValue[1] : $facet->getProperty('max'),
             ];
         } else {
-            $facetFilters[$facetLabel][$facetFilter->getValue()] = $facetFilter->getValue();
+            $facetFilters[$facetIdentifier][$facetFilter->getValue()] = $facetFilter->getValue();
         }
 
         return $facetFilters;
@@ -64,14 +64,14 @@ class URLSerializer
      */
     public function removeFilterFromFacetFilters(array $facetFilters, Filter $facetFilter, $facet)
     {
-        $facetLabel = $this->getFacetLabel($facet);
+        $facetIdentifier = $this->getFacetIdentifier($facet);
 
         if ($facet->getProperty('range')) {
-            unset($facetFilters[$facetLabel]);
+            unset($facetFilters[$facetIdentifier]);
         } else {
-            unset($facetFilters[$facetLabel][$facetFilter->getValue()]);
-            if (empty($facetFilters[$facetLabel])) {
-                unset($facetFilters[$facetLabel]);
+            unset($facetFilters[$facetIdentifier][$facetFilter->getValue()]);
+            if (empty($facetFilters[$facetIdentifier])) {
+                unset($facetFilters[$facetIdentifier]);
             }
         }
 
@@ -93,14 +93,14 @@ class URLSerializer
                     continue;
                 }
 
-                $facetLabel = $this->getFacetLabel($facet);
+                $facetIdentifier = $this->getFacetIdentifier($facet);
                 if (!$facet->getProperty('range')) {
-                    $facetFilters[$facetLabel][$facetFilter->getValue()] = $facetFilter->getValue();
+                    $facetFilters[$facetIdentifier][$facetFilter->getValue()] = $facetFilter->getValue();
                     continue;
                 }
 
                 $facetValue = $facetFilter->getValue();
-                $facetFilters[$facetLabel] = [
+                $facetFilters[$facetIdentifier] = [
                     $facetFilter->getProperty('symbol'),
                     $facetValue[0],
                     $facetValue[1],
@@ -118,29 +118,17 @@ class URLSerializer
      *
      * @return string
      */
-    private function getFacetLabel(Facet $facet)
+    private function getFacetIdentifier(Facet $facet)
     {
-        if ($facet->getProperty(Converter::PROPERTY_URL_NAME) !== null) {
-            return $facet->getProperty(Converter::PROPERTY_URL_NAME);
+        $identifier = $facet->getType();
+        if ($identifier === 'attribute_group') {
+            $identifier .= '_' . $facet->getProperty('id_attribute_group');
+        }
+        if ($identifier === 'feature') {
+            $identifier .= '_' . $facet->getProperty('id_feature');
         }
 
-        return $facet->getLabel();
-    }
-
-    /**
-     * Get Facet Filter label
-     *
-     * @param Filter $facetFilter
-     *
-     * @return string
-     */
-    private function getFilterLabel(Filter $facetFilter)
-    {
-        if ($facetFilter->getProperty(Converter::PROPERTY_URL_NAME) !== null) {
-            return $facetFilter->getProperty(Converter::PROPERTY_URL_NAME);
-        }
-
-        return $facetFilter->getLabel();
+        return $identifier;
     }
 
     /**

--- a/src/URLSerializer.php
+++ b/src/URLSerializer.php
@@ -38,7 +38,6 @@ class URLSerializer
     public function addFilterToFacetFilters(array $facetFilters, Filter $facetFilter, Facet $facet)
     {
         $facetLabel = $this->getFacetLabel($facet);
-        $filterLabel = $this->getFilterLabel($facetFilter);
 
         if ($facet->getProperty('range')) {
             $facetValue = $facet->getProperty('values');
@@ -48,7 +47,7 @@ class URLSerializer
                 isset($facetValue[1]) ? $facetValue[1] : $facet->getProperty('max'),
             ];
         } else {
-            $facetFilters[$facetLabel][$filterLabel] = $filterLabel;
+            $facetFilters[$facetLabel][$facetFilter->getValue()] = $facetFilter->getValue();
         }
 
         return $facetFilters;
@@ -70,8 +69,7 @@ class URLSerializer
         if ($facet->getProperty('range')) {
             unset($facetFilters[$facetLabel]);
         } else {
-            $filterLabel = $this->getFilterLabel($facetFilter);
-            unset($facetFilters[$facetLabel][$filterLabel]);
+            unset($facetFilters[$facetLabel][$facetFilter->getValue()]);
             if (empty($facetFilters[$facetLabel])) {
                 unset($facetFilters[$facetLabel]);
             }
@@ -96,9 +94,8 @@ class URLSerializer
                 }
 
                 $facetLabel = $this->getFacetLabel($facet);
-                $filterLabel = $this->getFilterLabel($facetFilter);
                 if (!$facet->getProperty('range')) {
-                    $facetFilters[$facetLabel][$filterLabel] = $filterLabel;
+                    $facetFilters[$facetLabel][$facetFilter->getValue()] = $facetFilter->getValue();
                     continue;
                 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -945,8 +945,8 @@ class BlockTest extends MockeryTestCase
                     'custom' => '0',
                     'id_lang' => '1',
                     'value' => 'Cotton',
-                    'url_name' => 'something',
-                    'meta_title' => 'weird',
+                    'url_name' => null,
+                    'meta_title' => null,
                 ],
                 [
                     'id_feature_value' => '6',
@@ -990,8 +990,8 @@ class BlockTest extends MockeryTestCase
                     'custom' => '1',
                     'id_lang' => '1',
                     'value' => 'Test Custom value',
-                    'url_name' => 'url-custom-21',
-                    'meta_title' => 'title-custom-21',
+                    'url_name' => null,
+                    'meta_title' => null,
                 ],
             ]
         );
@@ -1007,15 +1007,15 @@ class BlockTest extends MockeryTestCase
                             4 => [
                                 'nbr' => '2',
                                 'name' => 'Cotton',
-                                'url_name' => 'something',
-                                'meta_title' => 'weird',
+                                'url_name' => null,
+                                'meta_title' => null,
                                 'checked' => true,
                             ],
                             21 => [
                                 'nbr' => '3',
                                 'name' => 'Test Custom value',
-                                'url_name' => 'url-custom-21',
-                                'meta_title' => 'title-custom-21',
+                                'url_name' => null,
+                                'meta_title' => null,
                             ],
                         ],
                         'name' => 'Composition',

--- a/tests/php/FacetedSearch/URLSerializerTest.php
+++ b/tests/php/FacetedSearch/URLSerializerTest.php
@@ -76,15 +76,15 @@ class URLSerializerTest extends MockeryTestCase
 
     public function testGetActiveFilters()
     {
-        $first = $this->mockFilter('Tops', true);
-        $second = $this->mockFilter('Robes', false);
+        $first = $this->mockFilter('Tops', true, 123);
+        $second = $this->mockFilter('Robes', false, 124);
 
         $facet = $this->mockFacet('Categories', ['range' => false]);
         $facet->shouldReceive('getFilters')
             ->andReturn([$first, $second]);
 
         $this->assertEquals(
-            ['Categories' => ['Tops' => 'Tops']],
+            ['Categories' => [123 => 123]],
             $this->serializer->getActiveFacetFiltersFromFacets([$facet])
         );
     }
@@ -104,7 +104,7 @@ class URLSerializerTest extends MockeryTestCase
 
     public function testAddAndRemoveFiltersWithoutRange()
     {
-        $filter = $this->mockFilter('Tops');
+        $filter = $this->mockFilter('Tops', false, 123);
         $facet = $this->mockFacet('Categories', ['range' => false]);
         $facetsFilters = $this->serializer->addFilterToFacetFilters(
             [],
@@ -112,7 +112,7 @@ class URLSerializerTest extends MockeryTestCase
             $facet
         );
         $this->assertEquals(
-            ['Categories' => ['Tops' => 'Tops']],
+            ['Categories' => [123 => 123]],
             $facetsFilters
         );
         $facetsFilters = $this->serializer->removeFilterFromFacetFilters(

--- a/views/templates/admin/_functions/index.php
+++ b/views/templates/admin/_functions/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/views/templates/admin/_partials/index.php
+++ b/views/templates/admin/_partials/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/views/templates/front/catalog/index.php
+++ b/views/templates/front/catalog/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;


### PR DESCRIPTION
🚧 Work in progress - will remove also the url_name forms, attribute indexing etc.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Uses unique values for filter values - feature values, attribute values, categories and others. This fixes many things - category filter for deeper categories, values with the same name, fixes all problems with URL encoding.
| Type?         | refacto
| BC breaks?    | yes - behavior changed
| Deprecations? | -
| Fixed ticket? | Fixes PrestaShop/Prestashop#22637, Fixes PrestaShop/Prestashop#23726, Fixes PrestaShop/Prestashop#15635, Fixes PrestaShop/Prestashop#29727
| How to test?  | Play around with module and see that filtering still works fine.

![Snímek obrazovky 2023-01-31 163011](https://user-images.githubusercontent.com/6097524/215812714-05932efd-6000-4bc6-b984-3b96d691a473.jpg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/779)
<!-- Reviewable:end -->
