### PR TITLE
Unify availability filter naming

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[3.11.1]]></version>
+    <version><![CDATA[3.12.0]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -96,7 +96,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '3.11.1';
+        $this->version = '3.12.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -986,7 +986,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             `controller` VARCHAR(64) NOT NULL,
             `id_category` INT(10) UNSIGNED NOT NULL,
             `id_value` INT(10) UNSIGNED NULL DEFAULT \'0\',
-            `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'quantity\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL,
+            `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'availability\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL,
             `position` INT(10) UNSIGNED NOT NULL,
             `filter_type` int(10) UNSIGNED NOT NULL DEFAULT 0,
             `filter_show_limit` int(10) UNSIGNED NOT NULL DEFAULT 0,
@@ -1274,7 +1274,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                             ++$n;
 
                             if ($key == 'layered_selection_stock') {
-                                $sqlInsert .= '(' . (int) $idCategory . ', \'' . $controller . '\', ' . (int) $idShop . ', NULL,\'quantity\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
+                                $sqlInsert .= '(' . (int) $idCategory . ', \'' . $controller . '\', ' . (int) $idShop . ', NULL,\'availability\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_subcategories') {
                                 $sqlInsert .= '(' . (int) $idCategory . ', \'' . $controller . '\', ' . (int) $idShop . ', NULL,\'category\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';
                             } elseif ($key == 'layered_selection_condition') {

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -135,8 +135,8 @@ class Block
                 case 'condition':
                     $filterBlocks[] = $this->getConditionsBlock($filter, $selectedFilters);
                     break;
-                case 'quantity':
-                    $filterBlocks[] = $this->getQuantitiesBlock($filter, $selectedFilters);
+                case 'availability':
+                    $filterBlocks[] = $this->getAvailabilitiesBlock($filter, $selectedFilters);
                     break;
                 case 'manufacturer':
                     $filterBlocks[] = $this->getManufacturersBlock($filter, $selectedFilters, $idLang);
@@ -421,7 +421,7 @@ class Block
      *
      * @return array
      */
-    private function getQuantitiesBlock($filter, $selectedFilters)
+    private function getAvailabilitiesBlock($filter, $selectedFilters)
     {
         if ($this->psStockManagement === null) {
             $this->psStockManagement = (bool) Configuration::get('PS_STOCK_MANAGEMENT');
@@ -501,10 +501,10 @@ class Block
             $availabilityOptions[2]['nbr'] = $filteredSearchAdapter->count();
 
             // If some filter was selected, we want to show only this single filter, it does not make sense to show others
-            if (isset($selectedFilters['quantity'])) {
+            if (isset($selectedFilters['availability'])) {
                 // We loop through selected filters and assign it to our options and remove the rest
                 foreach ($availabilityOptions as $key => $values) {
-                    if (in_array($key, $selectedFilters['quantity'], true)) {
+                    if (in_array($key, $selectedFilters['availability'], true)) {
                         $availabilityOptions[$key]['checked'] = true;
                     }
                 }
@@ -512,8 +512,8 @@ class Block
         }
 
         $quantityBlock = [
-            'type_lite' => 'quantity',
-            'type' => 'quantity',
+            'type_lite' => 'availability',
+            'type' => 'availability',
             'id_key' => 0,
             'name' => $this->context->getTranslator()->trans('Availability', [], 'Modules.Facetedsearch.Shop'),
             'values' => $availabilityOptions,

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -43,7 +43,6 @@ class Converter
     const TYPE_CATEGORY = 'category';
     const TYPE_CONDITION = 'condition';
     const TYPE_FEATURE = 'id_feature';
-    const TYPE_QUANTITY = 'quantity';
     const TYPE_MANUFACTURER = 'manufacturer';
     const TYPE_PRICE = 'price';
     const TYPE_WEIGHT = 'weight';
@@ -116,13 +115,11 @@ class Converter
                 case self::TYPE_CATEGORY:
                 case self::TYPE_CONDITION:
                 case self::TYPE_MANUFACTURER:
-                case self::TYPE_QUANTITY:
+                case self::TYPE_AVAILABILITY:
                 case self::TYPE_ATTRIBUTE_GROUP:
                 case self::TYPE_FEATURE:
                     $type = $filterBlock['type'];
-                    if ($filterBlock['type'] === self::TYPE_QUANTITY) {
-                        $type = 'availability';
-                    } elseif ($filterBlock['type'] == self::TYPE_ATTRIBUTE_GROUP) {
+                    if ($filterBlock['type'] == self::TYPE_ATTRIBUTE_GROUP) {
                         $type = 'attribute_group';
                         $facet->setProperty(self::TYPE_ATTRIBUTE_GROUP, $filterBlock['id_key']);
                         if (isset($filterBlock['url_name'])) {
@@ -230,6 +227,16 @@ class Converter
     }
 
     /**
+     * This method is responsible of parsing the search filters sent in the query.
+     * These filters come from the URL in 99 % of cases.
+     *
+     * It will unserialize it and convert it to actual unique and valid values that
+     * we will later use to construct the database query. All invalid filters in the
+     * query (unknown value, deleted in shop etc.) are ignored.
+     *
+     * Filters that are found (if any) will be later used in initSearch method, along
+     * with some predefined ones related the the controller we are on.
+     *
      * @param ProductSearchQuery $query
      *
      * @return array
@@ -247,14 +254,20 @@ class Converter
 
         $searchFilters = [];
 
-        // Get filters configured for the current query
+        // Get filters configured in module settings for the current query
         $filters = $this->provider->getFiltersForQuery($query, $idShop);
 
-        // Parse currently selected filters from URL into a nice array
+        /*
+         * Parses submitted encoded facets from (URL) string into a nice array.
+         *
+         * Facets are set to the URL with a textual representation. This unfortunately does not
+         * work very well, because there could be duplicate values for both facet and filter.
+         * For example, if there are two features, feature values or categories with the same name.
+         */
         $facetAndFiltersLabels = $this->urlSerializer->unserialize($query->getEncodedFacets());
 
         // Go through filters that are configured and find out which should be activated,
-        // depending on what was provided in the URL
+        // depending on what was provided in the encodedFacets.
         foreach ($filters as $filter) {
             $filterLabel = $this->convertFilterTypeToLabel($filter['type']);
 
@@ -273,7 +286,7 @@ class Converter
                         }
                     }
                     break;
-                case self::TYPE_QUANTITY:
+                case self::TYPE_AVAILABILITY:
                     if (!isset($facetAndFiltersLabels[$filterLabel])) {
                         // No need to filter if no information
                         continue 2;
@@ -400,6 +413,11 @@ class Converter
                 case self::TYPE_CATEGORY:
                     if (isset($facetAndFiltersLabels[$filterLabel])) {
                         foreach ($facetAndFiltersLabels[$filterLabel] as $queryFilter) {
+                            /*
+                             * This works only for categories that are child of the category we are browsing (or home category).
+                             * Categories deeper in the tree will never be found. This could be fixed by providing a unique ID
+                             * to the URL.
+                             */
                             $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $idCategory);
                             if ($categories) {
                                 $searchFilters[$filter['type']][] = $categories['id_category'];
@@ -450,7 +468,7 @@ class Converter
                 return $this->context->getTranslator()->trans('Weight', [], 'Modules.Facetedsearch.Shop');
             case self::TYPE_CONDITION:
                 return $this->context->getTranslator()->trans('Condition', [], 'Modules.Facetedsearch.Shop');
-            case self::TYPE_QUANTITY:
+            case self::TYPE_AVAILABILITY:
                 return $this->context->getTranslator()->trans('Availability', [], 'Modules.Facetedsearch.Shop');
             case self::TYPE_MANUFACTURER:
                 return $this->context->getTranslator()->trans('Brand', [], 'Modules.Facetedsearch.Shop');

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -198,7 +198,7 @@ class Search
                     $this->addFilter('id_category', $filterValues);
                     break;
 
-                case 'quantity':
+                case 'availability':
                     /*
                     * $filterValues options can have following values:
                     * 0 - Not available - 0 or less quantity and disabled backorders

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -336,12 +336,12 @@ class BlockTest extends MockeryTestCase
     public function testGetFiltersBlockWithQuantities()
     {
         $this->mockTranslator([
-            [['Availability', [], 'Modules.Facetedsearch.Shop'], 'Quantity'],
+            [['Availability', [], 'Modules.Facetedsearch.Shop'], 'Availability'],
             [['Not available', [], 'Modules.Facetedsearch.Shop'], 'Not available'],
             [['In stock', [], 'Modules.Facetedsearch.Shop'], 'In stock'],
             [['Available', [], 'Modules.Facetedsearch.Shop'], 'Available'],
         ]);
-        $this->mockLayeredCategory([['type' => 'quantity', 'filter_show_limit' => 0, 'filter_type' => 1]]);
+        $this->mockLayeredCategory([['type' => 'availability', 'filter_show_limit' => 0, 'filter_type' => 1]]);
 
         $adapterInitialMock = Mockery::mock(MySQL::class)->makePartial();
         $adapterInitialMock->resetAll();
@@ -375,10 +375,10 @@ class BlockTest extends MockeryTestCase
             [
                 'filters' => [
                     [
-                        'type_lite' => 'quantity',
-                        'type' => 'quantity',
+                        'type_lite' => 'availability',
+                        'type' => 'availability',
                         'id_key' => 0,
-                        'name' => 'Quantity',
+                        'name' => 'Availability',
                         'values' => [
                             [
                                 'name' => 'Not available',
@@ -402,7 +402,7 @@ class BlockTest extends MockeryTestCase
             $this->block->getFilterBlock(
                 10,
                 [
-                    'quantity' => [
+                    'availability' => [
                         1,
                     ],
                 ]

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -417,11 +417,11 @@ class ConverterTest extends MockeryTestCase
                 ],
             ],
 
-            // Quantity
+            // Availability
             [
                 [
-                    'type_lite' => 'quantity',
-                    'type' => 'quantity',
+                    'type_lite' => 'availability',
+                    'type' => 'availability',
                     'id_key' => 0, 'name' => 'Availability',
                     'values' => [
                         0 => [

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -104,7 +104,7 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithoutCorrectSelectedFilters()
     {
-        $this->search->initSearch(['quantity' => []]);
+        $this->search->initSearch(['availability' => []]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
@@ -290,7 +290,7 @@ class SearchTest extends MockeryTestCase
                 'category' => [
                     [6],
                 ],
-                'quantity' => [
+                'availability' => [
                     0,
                 ],
                 'weight' => [
@@ -636,7 +636,7 @@ class SearchTest extends MockeryTestCase
             ->andReturn('category');
         $this->search->setQuery($query);
 
-        $this->search->initSearch(['quantity' => [0]]);
+        $this->search->initSearch(['availability' => [0]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
@@ -686,7 +686,7 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithFirstQuantityFilters()
     {
-        $this->search->initSearch(['quantity' => [1]]);
+        $this->search->initSearch(['availability' => [1]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
@@ -720,7 +720,7 @@ class SearchTest extends MockeryTestCase
 
     public function testInitSearchWithSecondQuantityFilters()
     {
-        $this->search->initSearch(['quantity' => [2]]);
+        $this->search->initSearch(['availability' => [2]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
@@ -750,7 +750,7 @@ class SearchTest extends MockeryTestCase
 
         Group::setStaticExpectations($groupMock);
 
-        $this->search->initSearch(['quantity' => [2]]);
+        $this->search->initSearch(['availability' => [2]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());
@@ -798,7 +798,7 @@ class SearchTest extends MockeryTestCase
 
         FrontController::setStaticExpectations($frontControllerMock);
 
-        $this->search->initSearch(['quantity' => [2]]);
+        $this->search->initSearch(['availability' => [2]]);
 
         $this->assertEquals([], $this->search->getSearchAdapter()->getFilters()->toArray());
         $this->assertEquals([], $this->search->getSearchAdapter()->getOperationsFilters()->toArray());

--- a/upgrade/upgrade-3.12.0.php
+++ b/upgrade/upgrade-3.12.0.php
@@ -23,13 +23,19 @@ if (!defined('_PS_VERSION_')) {
 
 function upgrade_module_3_12_0($module)
 {
-    // Change quantity naming to availability in existing filters
+    // Add availabilility to allowed types
     Db::getInstance()->execute(
-        'ALTER TABLE `' . _DB_PREFIX_ . 'layered_category` 
-        CHANGE `type` `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'availability\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL;');
+        'ALTER TABLE `' . _DB_PREFIX_ . 'layered_category`
+        CHANGE `type` `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'quantity\',\'availability\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL;');
 
+    // Upgrade all generated filters
     Db::getInstance()->execute(
         'UPDATE `' . _DB_PREFIX_ . 'layered_category` SET type=\'availability\' WHERE type=\'quantity\';');
+
+    // Remove the old enum from types
+    Db::getInstance()->execute(
+        'ALTER TABLE `' . _DB_PREFIX_ . 'layered_category`
+        CHANGE `type` `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'availability\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL;');
 
     // Flush block cache
     $module->invalidateLayeredFilterBlockCache();

--- a/upgrade/upgrade-3.12.0.php
+++ b/upgrade/upgrade-3.12.0.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_12_0($module)
+{
+    // Change quantity naming to availability in existing filters
+    Db::getInstance()->execute(
+        'ALTER TABLE `' . _DB_PREFIX_ . 'layered_category` 
+        CHANGE `type` `type` ENUM(\'category\',\'id_feature\',\'id_attribute_group\',\'availability\',\'condition\',\'manufacturer\',\'weight\',\'price\') NOT NULL;');
+
+    Db::getInstance()->execute(
+        'UPDATE `' . _DB_PREFIX_ . 'layered_category` SET type=\'availability\' WHERE type=\'quantity\';');
+
+    // Flush block cache
+    $module->invalidateLayeredFilterBlockCache();
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I have unified the naming of availability filter. It was a mix and match of `quantity`/`availability` nomenclature, with both `TYPE_AVAILABILITY` and `TYPE_QUANTITY` constants existing. Added some comments here and there.
| Type?         | refacto
| BC breaks?    | No BC breaks, FO template was already using 'availability' naming.
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that filters show up and the availability filter works correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/780)
<!-- Reviewable:end -->
