### PR TITLE
Remove deprecated number format

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -421,10 +421,10 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                     $unit = Configuration::get('PS_WEIGHT_UNIT');
                     $filter->setLabel(
                         sprintf(
-                            '%1$s%2$s - %3$s%4$s',
-                            Tools::displayNumber($min),
+                            '%1$s %2$s - %3$s %4$s',
+                            $context->getCurrentLocale()->formatNumber($min),
                             $unit,
-                            Tools::displayNumber($max),
+                            $context->getCurrentLocale()->formatNumber($max),
                             $unit
                         )
                     );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | To format weight in "active filters" section, this module was still using `Tools::displayNumber`. This is deprecated since 1.7.5, minimum supported version of this module is 1.7.6.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No QA needed.

No visible change except space between number and unit.
![Snímek obrazovky 2023-02-02 172424](https://user-images.githubusercontent.com/6097524/216382455-2b9d7bff-233f-401d-97fa-d0ecb39171e1.jpg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/783)
<!-- Reviewable:end -->
