### PR TITLE
Remove unused hardcoded price specs and mock them instead

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -928,69 +928,33 @@ class Block
     {
         /* @var Currency */
         $currency = $this->context->currency;
-        // New method since PS 1.7.6
-        if (isset($this->context->currentLocale) && method_exists($this->context->currentLocale, 'getPriceSpecification')) {
-            /* @var PriceSpecification */
-            $priceSpecification = $this->context->currentLocale->getPriceSpecification($currency->iso_code);
-            /* @var NumberSymbolList */
-            $symbolList = $priceSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN);
 
-            $symbol = [
-                $symbolList->getDecimal(),
-                $symbolList->getGroup(),
-                $symbolList->getList(),
-                $symbolList->getPercentSign(),
-                $symbolList->getMinusSign(),
-                $symbolList->getPlusSign(),
-                $symbolList->getExponential(),
-                $symbolList->getSuperscriptingExponent(),
-                $symbolList->getPerMille(),
-                $symbolList->getInfinity(),
-                $symbolList->getNaN(),
-            ];
+        /* @var PriceSpecification */
+        $priceSpecification = $this->context->currentLocale->getPriceSpecification($currency->iso_code);
 
-            return array_merge(
-                ['symbol' => $symbol],
-                $priceSpecification->toArray()
-            );
-        }
+        /* @var NumberSymbolList */
 
-        // Default symbol configuration
+        // TODO - How to use Locale::NUMBERING_SYSTEM_LATIN so the tests can find it?
+        $symbolList = $priceSpecification->getSymbolsByNumberingSystem('latn');
+        // $symbolList = $priceSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN);
+
         $symbol = [
-            '.',
-            ',',
-            ';',
-            '%',
-            '-',
-            '+',
-            'E',
-            '×',
-            '‰',
-            '∞',
-            'NaN',
+            $symbolList->getDecimal(),
+            $symbolList->getGroup(),
+            $symbolList->getList(),
+            $symbolList->getPercentSign(),
+            $symbolList->getMinusSign(),
+            $symbolList->getPlusSign(),
+            $symbolList->getExponential(),
+            $symbolList->getSuperscriptingExponent(),
+            $symbolList->getPerMille(),
+            $symbolList->getInfinity(),
+            $symbolList->getNaN(),
         ];
-        // The property `$precision` exists only from PS 1.7.6. On previous versions, all prices have 2 decimals
-        $precision = isset($currency->precision) ? $currency->precision : 2;
-        $formats = explode(';', $currency->format);
-        if (count($formats) > 1) {
-            $positivePattern = $formats[0];
-            $negativePattern = $formats[1];
-        } else {
-            $positivePattern = $currency->format;
-            $negativePattern = $currency->format;
-        }
 
-        return [
-            'positivePattern' => $positivePattern,
-            'negativePattern' => $negativePattern,
-            'symbol' => $symbol,
-            'maxFractionDigits' => $precision,
-            'minFractionDigits' => $precision,
-            'groupingUsed' => true,
-            'primaryGroupSize' => 3,
-            'secondaryGroupSize' => 3,
-            'currencyCode' => $currency->iso_code,
-            'currencySymbol' => $currency->sign,
-        ];
+        return array_merge(
+            ['symbol' => $symbol],
+            $priceSpecification->toArray()
+        );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When getting price specifications, there was a condition that checkes if price specs can be retrieved in the "new way", since 1.7.6, `if (isset($this->context->currentLocale) && method_exists($this->context->currentLocale, 'getPriceSpecification')) {`, or if it should return some hardcoded fallback specifications. Because the minimum supported version is 1.7.6, this condition is no longer needed and the hardcoded price specs below were used only in tests.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Tests are green.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/784)
<!-- Reviewable:end -->
