### PR TITLE
Do not respond if there are no filters

### DIFF
--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -53,11 +53,15 @@ class ProductSearch extends AbstractHook
             $params['query'] = $this->assignMissingQueryType($params['query']);
         }
 
+        // Initialize provider, we will need it right away to check if there are filters setup
+        $provider = new Provider($this->module->getDatabase());
+
         /*
          * Check if the type of query (controller) is supported by our module. If not, we
          * let the core do the search.
          */
-        if ($this->module->isControllerSupported($params['query']->getQueryType()) === false) {
+        if ($this->module->isControllerSupported($params['query']->getQueryType()) === false
+            || empty($provider->getFiltersForQuery($params['query'], (int) $this->context->shop->id))) {
             return null;
         }
 
@@ -85,7 +89,6 @@ class ProductSearch extends AbstractHook
 
         $urlSerializer = new URLSerializer();
         $dataAccessor = new DataAccessor($this->module->getDatabase());
-        $provider = new Provider($this->module->getDatabase());
 
         // Return an instance of our searcher, ready to accept requests
         return new SearchProvider(

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -53,15 +53,23 @@ class ProductSearch extends AbstractHook
             $params['query'] = $this->assignMissingQueryType($params['query']);
         }
 
-        // Initialize provider, we will need it right away to check if there are filters setup
-        $provider = new Provider($this->module->getDatabase());
-
         /*
          * Check if the type of query (controller) is supported by our module. If not, we
          * let the core do the search.
          */
-        if ($this->module->isControllerSupported($params['query']->getQueryType()) === false
-            || empty($provider->getFiltersForQuery($params['query'], (int) $this->context->shop->id))) {
+        if ($this->module->isControllerSupported($params['query']->getQueryType()) === false) {
+            return null;
+        }
+
+        // Initialize provider, we will need it right away to check if there are filters setup
+        $provider = new Provider($this->module->getDatabase());
+
+        /*
+         * If search controller is not specifically enabled, we don't return the instance.
+         * This condition will be removed when search controller support is fully implemented.
+         */
+        if ($params['query']->getQueryType() === 'search'
+            && empty($provider->getFiltersForQuery($params['query'], (int) $this->context->shop->id))) {
             return null;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Do not respond and provide search provider instance, if there are no filters set up for this controller.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31278
| How to test?  | Install develop, install faceted search, UNCHECK search page in your filter template. Go to FO, search for `THE ADVENTURE BEGINS FRAMED POSTER`, should find 2 products. Disable faceted search, see that the product order is still the same.

➡️ Position sort on this page is still not fixed, but it won't affect people if they don't want to use this module on the search page, which is marked as `experimental`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/788)
<!-- Reviewable:end -->
