### PR TITLE
Make search as fast as original provider

### DIFF
--- a/src/Product/CoreSearchBackport.php
+++ b/src/Product/CoreSearchBackport.php
@@ -1,0 +1,413 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Product;
+
+use Configuration;
+use Context;
+use Db;
+use FrontController;
+use Group;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
+use Search;
+use Shop;
+use Tools;
+
+/**
+ * PrestaShop core does not provide a reasonable (fast) way to get product pool to to search
+ * without extra performance overhead we don't need. This class contains fast backports of
+ * Search::find method of every major for this purpose.
+ *
+ * This class will be removed when we are able to get product pool from Search class directly.
+ */
+class CoreSearchBackport
+{
+    /**
+     * Returns a pool of product IDs to use when filtering products on search controller.
+     *
+     * @param ProductSearchQuery $query
+     *
+     * @return array Pool of product IDs
+     */
+    public function getProductPool(ProductSearchQuery $query)
+    {
+        // Get search expression from query
+        $expression = Tools::replaceAccentedChars(urldecode($query->getSearchString()));
+
+        // No changes in 8.0 to 8.1
+        if (version_compare(_PS_VERSION_, '8.0.0', '>=')) {
+            return $this->get80($expression);
+        } elseif (version_compare(_PS_VERSION_, '1.7.8.0', '>=')) {
+            return $this->get178($expression);
+        } elseif (version_compare(_PS_VERSION_, '1.7.7.0', '>=')) {
+            return $this->get177($expression);
+        } else {
+            return $this->get176($expression);
+        }
+    }
+
+    /**
+     * Backported from 1.7.6.9
+     *
+     * @param string $expr
+     *
+     * @return array Pool of product IDs
+     */
+    public function get176($expr)
+    {
+        $context = Context::getContext();
+        $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+
+        $intersect_array = [];
+        $words = Search::extractKeyWords($expr, $context->language->id, false, $context->language->iso_code);
+
+        foreach ($words as $key => $word) {
+            if (!empty($word) && strlen($word) >= (int) Configuration::get('PS_SEARCH_MINWORDLEN')) {
+                $sql_param_search = Search::getSearchParamFromWord($word);
+
+                $intersect_array[] = 'SELECT DISTINCT si.id_product
+        FROM ' . _DB_PREFIX_ . 'search_word sw
+        LEFT JOIN ' . _DB_PREFIX_ . 'search_index si ON sw.id_word = si.id_word
+        WHERE sw.id_lang = ' . (int) $context->language->id . '
+          AND sw.id_shop = ' . $context->shop->id . '
+          AND sw.word LIKE
+        \'' . $sql_param_search . '\'';
+            } else {
+                unset($words[$key]);
+            }
+        }
+
+        if (!count($words)) {
+            return [];
+        }
+
+        $sql_groups = '';
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+            $sql_groups = 'AND cg.`id_group` ' . (count($groups) ? 'IN (' . implode(',', $groups) . ')' : '=' . (int) Configuration::get('PS_UNIDENTIFIED_GROUP'));
+        }
+
+        $results = $db->executeS('
+      SELECT DISTINCT cp.`id_product`
+      FROM `' . _DB_PREFIX_ . 'category_product` cp
+      ' . (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . '
+      INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category`
+      INNER JOIN `' . _DB_PREFIX_ . 'product` p ON cp.`id_product` = p.`id_product`
+      ' . Shop::addSqlAssociation('product', 'p', false) . '
+      WHERE c.`active` = 1
+      AND product_shop.`active` = 1
+      AND product_shop.`visibility` IN ("both", "search")
+      AND product_shop.indexed = 1
+      ' . $sql_groups, true, false);
+
+        $eligible_products = [];
+        foreach ($results as $row) {
+            $eligible_products[] = $row['id_product'];
+        }
+
+        $eligible_products2 = [];
+        foreach ($intersect_array as $query) {
+            foreach ($db->executeS($query, true, false) as $row) {
+                $eligible_products2[] = $row['id_product'];
+            }
+        }
+
+        return array_unique(array_intersect($eligible_products, array_unique($eligible_products2)));
+    }
+
+    /**
+     * Backported from 1.7.7.8
+     *
+     * @param string $expr
+     *
+     * @return array Pool of product IDs
+     */
+    public function get177($expr)
+    {
+        $context = Context::getContext();
+        $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+
+        $fuzzyLoop = 0;
+        $eligibleProducts2 = null;
+        $words = Search::extractKeyWords($expr, $context->language->id, false, $context->language->iso_code);
+        $fuzzyMaxLoop = (int) Configuration::get('PS_SEARCH_FUZZY_MAX_LOOP');
+        $psFuzzySearch = (int) Configuration::get('PS_SEARCH_FUZZY');
+        $psSearchMinWordLength = (int) Configuration::get('PS_SEARCH_MINWORDLEN');
+
+        foreach ($words as $key => $word) {
+            if (empty($word) || strlen($word) < $psSearchMinWordLength) {
+                unset($words[$key]);
+                continue;
+            }
+
+            $sql_param_search = Search::getSearchParamFromWord($word);
+            $sql = 'SELECT DISTINCT si.id_product ' .
+        'FROM ' . _DB_PREFIX_ . 'search_word sw ' .
+        'LEFT JOIN ' . _DB_PREFIX_ . 'search_index si ON sw.id_word = si.id_word ' .
+        'LEFT JOIN ' . _DB_PREFIX_ . 'product_shop product_shop ON (product_shop.`id_product` = si.`id_product`) ' .
+        'WHERE sw.id_lang = ' . (int) $context->language->id . ' ' .
+        'AND sw.id_shop = ' . $context->shop->id . ' ' .
+        'AND product_shop.`active` = 1 ' .
+        'AND product_shop.`visibility` IN ("both", "search") ' .
+        'AND product_shop.indexed = 1 ' .
+        'AND sw.word LIKE ';
+
+            while (!($result = $db->executeS($sql . "'" . $sql_param_search . "';", true, false))) {
+                if (
+          !$psFuzzySearch
+          || $fuzzyLoop++ > $fuzzyMaxLoop
+          || !($sql_param_search = Search::findClosestWeightestWord($context, $word))
+        ) {
+                    break;
+                }
+            }
+
+            if (!$result) {
+                unset($words[$key]);
+                continue;
+            }
+
+            $productIds = array_column($result, 'id_product');
+            if ($eligibleProducts2 === null) {
+                $eligibleProducts2 = $productIds;
+            } else {
+                $eligibleProducts2 = array_intersect($eligibleProducts2, $productIds);
+            }
+        }
+
+        if (!count($words)) {
+            return [];
+        }
+
+        $sqlGroups = '';
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+            $sqlGroups = 'AND cg.`id_group` ' . (count($groups) ? 'IN (' . implode(',', $groups) . ')' : '=' . (int) Group::getCurrent()->id);
+        }
+
+        $results = $db->executeS(
+      'SELECT DISTINCT cp.`id_product` ' .
+        'FROM `' . _DB_PREFIX_ . 'category_product` cp ' .
+        (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . ' ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category` ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'product` p ON cp.`id_product` = p.`id_product` ' .
+        Shop::addSqlAssociation('product', 'p', false) . ' ' .
+        'WHERE c.`active` = 1 ' .
+        'AND product_shop.`active` = 1 ' .
+        'AND product_shop.`visibility` IN ("both", "search") ' .
+        'AND product_shop.indexed = 1 ' . $sqlGroups,
+      true,
+      false
+    );
+
+        $eligibleProducts = array_column($results, 'id_product');
+
+        return array_unique(array_intersect($eligibleProducts, array_unique($eligibleProducts2)));
+    }
+
+    /**
+     * Backported from 1.7.8.8
+     *
+     * @param string $expr
+     *
+     * @return array Pool of product IDs
+     */
+    public function get178($expr)
+    {
+        $context = Context::getContext();
+        $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+
+        $fuzzyLoop = 0;
+        $eligibleProducts2 = null;
+        $words = Search::extractKeyWords($expr, $context->language->id, false, $context->language->iso_code);
+        $fuzzyMaxLoop = (int) Configuration::get('PS_SEARCH_FUZZY_MAX_LOOP');
+        $psFuzzySearch = (int) Configuration::get('PS_SEARCH_FUZZY');
+        $psSearchMinWordLength = (int) Configuration::get('PS_SEARCH_MINWORDLEN');
+
+        foreach ($words as $key => $word) {
+            if (empty($word) || strlen($word) < $psSearchMinWordLength) {
+                unset($words[$key]);
+                continue;
+            }
+
+            $sql_param_search = Search::getSearchParamFromWord($word);
+            $sql = 'SELECT DISTINCT si.id_product ' .
+        'FROM ' . _DB_PREFIX_ . 'search_word sw ' .
+        'LEFT JOIN ' . _DB_PREFIX_ . 'search_index si ON sw.id_word = si.id_word ' .
+        'LEFT JOIN ' . _DB_PREFIX_ . 'product_shop product_shop ON (product_shop.`id_product` = si.`id_product`) ' .
+        'WHERE sw.id_lang = ' . (int) $context->language->id . ' ' .
+        'AND sw.id_shop = ' . $context->shop->id . ' ' .
+        'AND product_shop.`active` = 1 ' .
+        'AND product_shop.`visibility` IN ("both", "search") ' .
+        'AND product_shop.indexed = 1 ' .
+        'AND sw.word LIKE ';
+
+            while (!($result = $db->executeS($sql . "'" . $sql_param_search . "';", true, false))) {
+                if (
+          !$psFuzzySearch
+          || $fuzzyLoop++ > $fuzzyMaxLoop
+          || !($sql_param_search = Search::findClosestWeightestWord($context, $word))
+        ) {
+                    break;
+                }
+            }
+
+            if (!$result) {
+                unset($words[$key]);
+                continue;
+            }
+
+            $productIds = array_column($result, 'id_product');
+            if ($eligibleProducts2 === null) {
+                $eligibleProducts2 = $productIds;
+            } else {
+                $eligibleProducts2 = array_intersect($eligibleProducts2, $productIds);
+            }
+        }
+
+        if (!count($words) || !count($eligibleProducts2)) {
+            return [];
+        }
+
+        $sqlGroups = '';
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+            $sqlGroups = 'AND cg.`id_group` ' . (count($groups) ? 'IN (' . implode(',', $groups) . ')' : '=' . (int) Group::getCurrent()->id);
+        }
+
+        $results = $db->executeS(
+      'SELECT DISTINCT cp.`id_product` ' .
+        'FROM `' . _DB_PREFIX_ . 'category_product` cp ' .
+        (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . ' ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category` ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'product` p ON cp.`id_product` = p.`id_product` ' .
+        Shop::addSqlAssociation('product', 'p', false) . ' ' .
+        'WHERE c.`active` = 1 ' .
+        'AND product_shop.`active` = 1 ' .
+        'AND product_shop.`visibility` IN ("both", "search") ' .
+        'AND product_shop.indexed = 1 ' .
+        'AND cp.id_product IN (' . implode(',', $eligibleProducts2) . ')' . $sqlGroups,
+      true,
+      false
+    );
+
+        return array_column($results, 'id_product');
+    }
+
+    /**
+     * Backported 8.0.1
+     *
+     * @param string $expr
+     *
+     * @return array Pool of product IDs
+     */
+    public function get80($expr)
+    {
+        $context = Context::getContext();
+        $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+
+        $fuzzyLoop = 0;
+        $wordCnt = 0;
+        $eligibleProducts2Full = [];
+        $expressions = explode(';', $expr);
+        $fuzzyMaxLoop = (int) Configuration::get('PS_SEARCH_FUZZY_MAX_LOOP');
+        $psFuzzySearch = (int) Configuration::get('PS_SEARCH_FUZZY');
+        $psSearchMinWordLength = (int) Configuration::get('PS_SEARCH_MINWORDLEN');
+        foreach ($expressions as $expression) {
+            $eligibleProducts2 = null;
+            $words = Search::extractKeyWords($expression, $context->language->id, false, $context->language->iso_code);
+            foreach ($words as $key => $word) {
+                if (empty($word) || strlen($word) < $psSearchMinWordLength) {
+                    unset($words[$key]);
+                    continue;
+                }
+
+                $sql_param_search = Search::getSearchParamFromWord($word);
+                $sql = 'SELECT DISTINCT si.id_product ' .
+          'FROM ' . _DB_PREFIX_ . 'search_word sw ' .
+          'LEFT JOIN ' . _DB_PREFIX_ . 'search_index si ON sw.id_word = si.id_word ' .
+          'LEFT JOIN ' . _DB_PREFIX_ . 'product_shop product_shop ON (product_shop.`id_product` = si.`id_product`) ' .
+          'WHERE sw.id_lang = ' . (int) $context->language->id . ' ' .
+          'AND sw.id_shop = ' . $context->shop->id . ' ' .
+          'AND product_shop.`active` = 1 ' .
+          'AND product_shop.`visibility` IN ("both", "search") ' .
+          'AND product_shop.indexed = 1 ' .
+          'AND sw.word LIKE ';
+
+                while (!($result = $db->executeS($sql . "'" . $sql_param_search . "';", true, false))) {
+                    if (
+            !$psFuzzySearch
+            || $fuzzyLoop++ > $fuzzyMaxLoop
+            || !($sql_param_search = Search::findClosestWeightestWord($context, $word))
+          ) {
+                        break;
+                    }
+                }
+
+                if (!$result) {
+                    unset($words[$key]);
+                    continue;
+                }
+
+                $productIds = array_column($result, 'id_product');
+                if ($eligibleProducts2 === null) {
+                    $eligibleProducts2 = $productIds;
+                } else {
+                    $eligibleProducts2 = array_intersect($eligibleProducts2, $productIds);
+                }
+            }
+            $wordCnt += count($words);
+            if ($eligibleProducts2) {
+                $eligibleProducts2Full = array_merge($eligibleProducts2Full, $eligibleProducts2);
+            }
+        }
+
+        $eligibleProducts2Full = array_unique($eligibleProducts2Full);
+
+        if (!$wordCnt || !count($eligibleProducts2Full)) {
+            return [];
+        }
+
+        $sqlGroups = '';
+        if (Group::isFeatureActive()) {
+            $groups = FrontController::getCurrentCustomerGroups();
+            $sqlGroups = 'AND cg.`id_group` ' . (count($groups) ? 'IN (' . implode(',', $groups) . ')' : '=' . (int) Group::getCurrent()->id);
+        }
+
+        $results = $db->executeS(
+      'SELECT DISTINCT cp.`id_product` ' .
+        'FROM `' . _DB_PREFIX_ . 'category_product` cp ' .
+        (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . ' ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category` ' .
+        'INNER JOIN `' . _DB_PREFIX_ . 'product` p ON cp.`id_product` = p.`id_product` ' .
+        Shop::addSqlAssociation('product', 'p', false) . ' ' .
+        'WHERE c.`active` = 1 ' .
+        'AND product_shop.`active` = 1 ' .
+        'AND product_shop.`visibility` IN ("both", "search") ' .
+        'AND product_shop.indexed = 1 ' .
+        'AND cp.id_product IN (' . implode(',', $eligibleProducts2Full) . ')' . $sqlGroups,
+      true,
+      false
+    );
+
+        return array_column($results, 'id_product');
+    }
+}

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -28,8 +28,6 @@ use Group;
 use PrestaShop\Module\FacetedSearch\Adapter\AbstractAdapter;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL as MySQLAdapter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
-use Search as SearchCore;
-use Tools;
 
 class Search
 {
@@ -132,33 +130,6 @@ class Search
         // Add group by and flush it, let's go
         $this->getSearchAdapter()->addGroupBy('id_product');
         $this->getSearchAdapter()->useFiltersAsInitialPopulation();
-    }
-
-    public function getProductIdsUsingCoreSearch()
-    {
-        // Search using the core functionality
-        // It doesn't provide a function to disable a limit, so we use maximum integer of the platform
-        $result = SearchCore::find(
-            $this->context->language->id,
-            Tools::replaceAccentedChars(urldecode($this->query->getSearchString())),
-            1,
-            PHP_INT_MAX,
-            'position',
-            'desc',
-            false,
-            false,
-            null
-        );
-
-        // Extract IDs from the result
-        // If nothing is found, we return a value (NULL string) that will ensure empty result
-        // It would be better to stop the search sooner in  the logic, in the future.
-        $product_ids = array_column($result['result'], 'id_product');
-        if (empty($product_ids)) {
-            return ['NULL'];
-        }
-
-        return $product_ids;
     }
 
     /**
@@ -414,9 +385,20 @@ class Search
             $this->getSearchAdapter()->addFilter('reduction', [0], '>');
         }
 
-        // Search
+        /*
+         * Search controller
+         *
+         * We are using a fast backport to get a product pool, which is then passed to the query.
+         * Core search provider does simmilar thing. If nothing is found, we return a value
+         * (NULL string) that will ensure empty result. It would be better to stop the search
+         * sooner in the logic, in the future.
+         */
         if ($this->query->getQueryType() == 'search') {
-            $this->getSearchAdapter()->addFilter('id_product', $this->getProductIdsUsingCoreSearch());
+            $productPool = (new CoreSearchBackport())->getProductPool($this->query);
+            $this->getSearchAdapter()->addFilter(
+                'id_product', 
+                empty($productPool) ? ['NULL'] : $productPool
+            );
         }
     }
 

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -396,7 +396,7 @@ class Search
         if ($this->query->getQueryType() == 'search') {
             $productPool = (new CoreSearchBackport())->getProductPool($this->query);
             $this->getSearchAdapter()->addFilter(
-                'id_product', 
+                'id_product',
                 empty($productPool) ? ['NULL'] : $productPool
             );
         }

--- a/tests/php/phpstan/phpstan-1.7.6.neon
+++ b/tests/php/phpstan/phpstan-1.7.6.neon
@@ -13,3 +13,4 @@ parameters:
     - '~^Access to an undefined property Cookie::\$id_lang\.$~'
     - '~^Parameter #1 \$string of method PrestaShop\\Module\\FacetedSearch\\URLSerializer::unserialize\(\) expects string, array given\.$~'
     - '~^Call to an undefined static method Search::findClosestWeightestWord\(\)\.$~'
+    - '~^Parameter #1 \$master of static method DbCore::getInstance\(\) expects bool, int given\.$~'

--- a/tests/php/phpstan/phpstan-1.7.6.neon
+++ b/tests/php/phpstan/phpstan-1.7.6.neon
@@ -12,3 +12,4 @@ parameters:
     - '~^Parameter #\d+ \$(.+?) of class Category constructor expects null, int given\.$~'
     - '~^Access to an undefined property Cookie::\$id_lang\.$~'
     - '~^Parameter #1 \$string of method PrestaShop\\Module\\FacetedSearch\\URLSerializer::unserialize\(\) expects string, array given\.$~'
+    - '~^Call to an undefined static method Search::findClosestWeightestWord\(\)\.$~'

--- a/tests/php/phpstan/phpstan-1.7.7.neon
+++ b/tests/php/phpstan/phpstan-1.7.7.neon
@@ -9,3 +9,4 @@ parameters:
     - '~^Parameter #\d+ \$\w+ of static method ProductCore::priceCalculation\(\) expects \w+, \w+ given\.$~'
     - '~^Access to an undefined property Cookie::\$id_lang\.$~'
     - '~^Parameter #1 \$string of method PrestaShop\\Module\\FacetedSearch\\URLSerializer::unserialize\(\) expects string, array given\.$~'
+    - '~^Parameter #1 \$master of static method DbCore::getInstance\(\) expects bool, int given\.$~'

--- a/tests/php/phpstan/phpstan-1.7.8.neon
+++ b/tests/php/phpstan/phpstan-1.7.8.neon
@@ -8,3 +8,4 @@ parameters:
     - '~^Parameter #3 \$groupBy of static method CurrencyCore::getCurrencies\(\) expects bool, Shop given\.$~'
     - '~^Parameter #\d+ \$\w+ of static method ProductCore::priceCalculation\(\) expects \w+, \w+ given\.$~'
     - '~^Access to an undefined property Cookie::\$id_lang\.$~'
+    - '~^Parameter #1 \$master of static method DbCore::getInstance\(\) expects bool, int given\.$~'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Instead of leveraging the search controller, which is not optimal for our usecase, I reimplemented a part of core search functionality to the module itself, which will make it as fast as the original provider.
| Type?         |  improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below.

**How to test**
- _You don't need to test other pages than search, they were not touched._
- _You don't need to test the filtering in the left column._
- Order of the products could be different compared to when the module is disabled, because the sorting by relevance is not yet implemented.
- **Do test** that the search page finds the same results as if the module is disabled. Try it on 1.7.6 and 8.0.1.

**Example of a performance boost**
Before
- Load Time 3457 ms - You'd better run your shop on a toaster
- Querying Time 2628 ms
- Queries 14950

After
- Load Time 660 ms - Unicorn powered webserver!
- Querying Time 457 ms
- Queries 1505

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/789)
<!-- Reviewable:end -->
