### PR TITLE
Fix Converter.php for non category pages

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -400,7 +400,11 @@ class Converter
                 case self::TYPE_CATEGORY:
                     if (isset($facetAndFiltersLabels[$filterLabel])) {
                         foreach ($facetAndFiltersLabels[$filterLabel] as $queryFilter) {
-                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $idCategory);
+                            if ($query->getQueryType() == 'category') {
+                                $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $idCategory);
+                            } else {
+                                $categories = Category::searchByName($idLang, $queryFilter, true, false);
+                            }
                             if ($categories) {
                                 $searchFilters[$filter['type']][] = $categories['id_category'];
                             }


### PR DESCRIPTION
Fixes the bug that prevented filtering by category from working except for category pages. There is no need for parent category ID control, except for category pages.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In line with the newly added feature of the ps_facetedsearch module, it has also been enabled to work on Bestsellers, Price Drops, New products and Search pages. However, while the category filter was running on these pages, except for the category pages, the category filter was not working because it was checked whether the category was a sub-category of the current level category.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No follow up issue as it is outside of PrestaShop project
| How to test?  | On the new products page, you can test by trying filtering for a category that is not child to the main category.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/793)
<!-- Reviewable:end -->
