### PR TITLE
take into an account the "visibility" by shop

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -187,6 +187,13 @@ class MySQL extends AbstractAdapter
                 $this->getContext()->shop->id . ' AND ps.active = TRUE)',
                 'joinType' => self::INNER_JOIN,
             ],
+            'visibility' => [
+                'tableName' => 'product_shop',
+                'tableAlias' => 'ps',
+                'joinCondition' => '(p.id_product = ps.id_product AND ps.id_shop = ' .
+                    $this->getContext()->shop->id . ' AND ps.active = TRUE)',
+                'joinType' => self::INNER_JOIN,
+            ],
             'id_feature_value' => [
                 'tableName' => 'feature_product',
                 'tableAlias' => 'fp',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module doesn't take into account the parameter 'visibility' configured for the shop context.
| Type?         | bug fix 
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Configure multishop. On the product page, configure the different "visibility" (both/none) per the shops. Current result: the module takes the 'visibility' from table 'product' that is wrong for some shop. Expected result: visibility of the product according to the configurations. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/820)
<!-- Reviewable:end -->
