### PR TITLE
Add filters checkbox state in editing template;

### DIFF
--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -53,7 +53,7 @@
                 <li class="filter_list_item row" draggable="true">
                   <div class="col-lg-2">
                     <label class="switch-light prestashop-switch fixed-width-lg">
-                      <input name="{$filterId}" id="{$filterId}" type="checkbox" />
+                      <input name="{$filterId}" id="{$filterId}" type="checkbox" {if array_key_exists($filterId, $filters)} checked="checked"{/if}/>
                       <span>
                         <span>{l s='Yes' d='Admin.Global'}</span>
                         <span>{l s='No' d='Admin.Global'}</span>
@@ -95,8 +95,9 @@
                 {foreach $attribute_groups as $attribute_group}
                   <li class="filter_list_item row" draggable="true">
                     <div class="col-lg-2">
+                      {$filter_id="layered_selection_ag_`$attribute_group['id_attribute_group']`"}
                       <label class="switch-light prestashop-switch fixed-width-lg">
-                        <input name="layered_selection_ag_{(int)$attribute_group['id_attribute_group']}" id="layered_selection_ag_{(int)$attribute_group['id_attribute_group']}" type="checkbox" />
+                        <input name="{$filter_id}" id="{$filter_id}" type="checkbox" {if array_key_exists($filter_id, $filters)} checked="checked"{/if}/>
                         <span>
                           <span>{l s='Yes' d='Admin.Global'}</span>
                           <span>{l s='No' d='Admin.Global'}</span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Added check if filter's id is in filter array in template editing filter checkboxes. Moved layered_selection_ag to new variable cause its repeating 3 times.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#32987
| How to test?  | See PrestaShop/Prestashop#32987

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
