### PR TITLE
Fix sortable path

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -739,7 +739,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $this->context->smarty->assign('uri', $this->getPathUri());
 
         // Assign assets
-        if (file_exists(_PS_ROOT_DIR_ . _PS_JS_DIR_ . 'vendor/Sortable.min.js')) {
+        if (file_exists(_PS_ROOT_DIR_ . '/js/vendor/Sortable.min.js')) {
             $this->context->controller->addJS(_PS_JS_DIR_ . 'vendor/Sortable.min.js');
         } else {
             if (method_exists($this->context->controller, 'addJquery')) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes issue with checkboxes not working on 8.1 and errors in console. `_PS_JS_DIR_` is an url not a directory path, which is not very obvious without checking it's definition. `define('_PS_JS_DIR_', __PS_BASE_URI__.'js/');`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#32987
| How to test?  | Check that checkboxes stay checked after reopening the edit screen. I think this issue only happens when using prestashop in a subfolder - like `localhost/dev/`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/881)
<!-- Reviewable:end -->
