### PR TITLE
Flush cache on upgrade

### DIFF
--- a/upgrade/upgrade-3.13.0.php
+++ b/upgrade/upgrade-3.13.0.php
@@ -29,5 +29,8 @@ function upgrade_module_3_13_0(Ps_Facetedsearch $module)
         'actionAfterUpdateFeatureValueFormHandler',
     ];
 
+    // Flush block cache, we changed availability logic a bit
+    $module->invalidateLayeredFilterBlockCache();
+
     return $module->registerHook($newHooks);
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We changed a logic of availability logic a bit (https://github.com/PrestaShop/ps_facetedsearch/pull/883#issuecomment-1648160837) and it would be good to flush block cache, users could see old values before their next CRON cleaning run.
| Type?         | 
| BC breaks?    |
| Deprecations? | 
| Fixed ticket? |
| How to test?  | Does not need QA - the same line of code is used when upgrading to previous version - https://github.com/PrestaShop/ps_facetedsearch/blob/dev/upgrade/upgrade-3.12.0.php.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/884)
<!-- Reviewable:end -->
