### PR TITLE
Pass attribute information with the results

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -164,6 +164,13 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         // Init the search with the initial population associated with the current filters
         $facetedSearch->initSearch($facetedSearchFilters);
 
+        // Request combination IDs if we have some attributes to search by.
+        // If not, we won't use this to let the core select the default combination.
+        if ($this->shouldPassCombinationIds($facetedSearchFilters)) {
+            $facetedSearch->getSearchAdapter()->getInitialPopulation()->addSelectField('id_product_attribute');
+            $facetedSearch->getSearchAdapter()->addSelectField('id_product_attribute');
+        }
+
         // Load the product searcher, it gets the Adapter through Search object
         $filterProductSearch = new Filters\Products($facetedSearch);
 
@@ -585,5 +592,17 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $queryString = str_replace('%2F', '/', http_build_query($params, '', '&'));
 
         return $url . ($queryString ? "?$queryString" : '');
+    }
+
+    /**
+     * Checks if we should return information about combinations to the core
+     *
+     * @param array $facetedSearchFilters filters passed in the query and parsed by our module
+     *
+     * @return bool if should add attributes to the select
+     */
+    private function shouldPassCombinationIds(array $facetedSearchFilters)
+    {
+        return !empty($facetedSearchFilters['id_attribute_group']);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

### Description
- This PR passes the information of the found combination to the core. If it's not passed, the core will select the default combination.
- It allows the core to better show data in the listings, depending on the combination found - mainly the image, link, price. (see https://github.com/PrestaShop/PrestaShop/pull/33363)
- Even without that PR, you can see a difference, that if you filter for Black T-shirt, the link of the product it found will lead to black tshirt combination right away. With the mentioned PR, you will even see a black photo.
- So if you filter the products, it can take you directly to a Black t-shirt combination, instead of the default one.
- It passes the id of the combination ONLY if you filtered by some attributes.
  - When you filter by stock, price, features - you still see the default combination.
  - When you filter by some attribute - you see the first combination found closest to the filters you requested.

### By default - default combination
![default combination](https://github.com/PrestaShop/ps_facetedsearch/assets/6097524/93f0e192-f428-431a-97f2-fd9c91094707)

### If filtering by attribute - more precise combination
![selected](https://github.com/PrestaShop/ps_facetedsearch/assets/6097524/e2e4b094-bb79-4cb3-a138-44569ec7e8a2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/886)
<!-- Reviewable:end -->
