### PR TITLE
Fix load JqueryUI for load good component - Link PR Prestashop #33563

### DIFF
--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -83,7 +83,7 @@ class ProductSearch extends AbstractHook
 
         // Assign assets
         if ((bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER')) {
-            $this->context->controller->addJqueryUi('slider');
+            $this->context->controller->addJqueryUi('ui.slider');
         }
         $this->context->controller->registerStylesheet(
             'facetedsearch_front',


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Currently, there is an error in Prestashop, it loads the whole jQuery UI library instead of only the necessary components called by the modules<br>If we correct this on Prestashop, we must also correct this call which does not have the correct syntax, it simply lacks the "ui." before.<br>This will have no impact on previous versions of Prestashop but will optimize webperfs for future versions
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#33563
| How to test?  | <p>Check on the Front side, the list of assets loaded in the network console of the web browser</p><p>Basic, you can test it will not change anything on the current version of Prestashop, we must have the following list of assets:</p><ul> <li>/js/jquery/ui/jquery-ui.min.js</li> <li>/js/jquery/ui/themes/base/minified/jquery.ui.theme.min.css</li> <li>/js/jquery/ui/themes/base/minified/jquery-ui.min.css</li></ul><p>If you want to test the PRs, then you must apply the following commit on your Prestashop: https://github.com/PrestaShop/PrestaShop/pull/33563/commits/92bfbd39a537a79d02b5148febd6515ece8df46c, we should have the following list:</p><ul> <li>/js/jquery/ui/jquery.ui.core.min.js</li> <li>/js/jquery/ui/jquery.ui.widget.min.js</li> <li>/js/jquery/ui/jquery.ui.mouse.min.js</li> <li>/js/jquery/ui/jquery.ui.slider.min.js</li> <li>/js/jquery/ui/themes/base/jquery.ui.core.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.widget.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.mouse.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.slider.css</li></ul>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/895)
<!-- Reviewable:end -->
