### PR TITLE
Update GH workflows: Node 14-16, PHP 7.2-8.2, Github actions v3

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -6,11 +6,11 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-versions: [ '12', '13', '14' ]
+                node-versions: [ '14', '16' ]
         steps:
             - name: Checkout
-              uses: actions/checkout@v2.0.0
-            - uses: actions/setup-node@v1
+              uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-versions }}
             - run: npm install

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,14 +2,11 @@ name: PHP tests
 on: [push, pull_request]
 jobs:
   php-linter:
-    name: PHP Syntax check 5.6 => 8.1
+    name: PHP Syntax check 7.2 => 8.2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
-
-      - name: PHP syntax checker 5.6
-        uses: prestashop/github-action-php-lint/5.6@master
+        uses: actions/checkout@v3.1.0
 
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master
@@ -26,6 +23,10 @@ jobs:
       - name: PHP syntax checker 8.1
         uses: prestashop/github-action-php-lint/8.1@master
 
+      - name: PHP syntax checker 8.2
+        uses: prestashop/github-action-php-lint/8.2@master
+
+
   # Check the PHP code follow the coding standards
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -37,10 +38,10 @@ jobs:
               php-version: '7.4'
 
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3.1.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -49,7 +50,7 @@ jobs:
         run: composer install
 
       - name: Run PHP-CS-Fixer
-        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --diff-format udiff
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
 
   # Run PHPStan against the module and a PrestaShop release
   phpstan:
@@ -60,18 +61,18 @@ jobs:
               presta-versions: ['1.7.6', '1.7.7', '1.7.8', 'latest']
       steps:
           - name: Checkout
-            uses: actions/checkout@v2.0.0
+            uses: actions/checkout@v3.1.0
 
           # Add vendor folder in cache to make next builds faster
           - name: Cache vendor folder
-            uses: actions/cache@v1
+            uses: actions/cache@v3
             with:
               path: vendor
               key: php-${{ hashFiles('composer.lock') }}
 
           # Add composer local folder in cache to make next builds faster
           - name: Cache composer folder
-            uses: actions/cache@v1
+            uses: actions/cache@v3
             with:
               path: ~/.composer/cache
               key: php-composer-cache
@@ -93,18 +94,18 @@ jobs:
           coverage: xdebug
 
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3.1.0
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
             path: vendor
             key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
             path: ~/.composer/cache
             key: php-composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,11 +2,14 @@ name: PHP tests
 on: [push, pull_request]
 jobs:
   php-linter:
-    name: PHP Syntax check 7.2 => 8.2
+    name: PHP Syntax check 7.1 => 8.2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
+
+      - name: PHP syntax checker 7.1
+        uses: prestashop/github-action-php-lint/7.1@master
 
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Recent PRs' tests have a lot of warnings about outdated Node, GH actions <br> (9 JS warnings and 21 PHP warnings in Release v3.13.1): <br> https://github.com/PrestaShop/ps_facetedsearch/actions/runs/5793944220 <br> https://github.com/PrestaShop/ps_facetedsearch/actions/runs/5793944222
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | GH workflows complete with less warnings about outdated Node, PHP, actions.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/902)
<!-- Reviewable:end -->
