### PR TITLE
$controllers returned always false

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -597,7 +597,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         if (Tools::isSubmit('SubmitFilter')) {
             // Get filter data
             $templateName = Tools::getValue('layered_tpl_name');
-            $controllers = Tools::getValue('controllers');
+            $controllers = Tools::getValue('controllers')?Tools::getValue('controllers'):array_keys($this->supportedControllers);
             $categoryBox = Tools::getValue('categoryBox');
 
             if (empty($templateName)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Bugfix when storing ps_facetedsearch template, for some reason the template edit form doesn't pass any "controllers" thus $controllers = Tools::getValue('controllers'); always returns false and shows the error message "You must select at least one page." , so if there are no controllers passed this "fix" will get the controllers list from the class attribute $supportedControllers

| Type?         | bug fix 

| Deprecations? |  no

| How to test?  | saving a faceted search template, without fix it (always) returns error message "You must select at least one page."

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/907)
<!-- Reviewable:end -->
