### PR TITLE
Fix empty stock filter, add comments

### DIFF
--- a/src/Adapter/InterfaceAdapter.php
+++ b/src/Adapter/InterfaceAdapter.php
@@ -169,7 +169,7 @@ interface InterfaceAdapter
     public function addOperationsFilter($filterName, array $operations);
 
     /**
-     * Add fieldName in the current search result
+     * Add fieldName in the current search result. If the field already exists, it's skipped.
      *
      * @param string $fieldName
      *

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -93,23 +93,26 @@ class MySQL extends AbstractAdapter
      */
     public function getQuery()
     {
+        // Prepare mapping for joined tables
         $filterToTableMapping = $this->getFieldMapping();
+
+        // Process and generate all fields for the SQL query below
         $orderField = $this->computeOrderByField($filterToTableMapping);
 
+        // Now, let's build the query...
+        // If this query IS the initial population (the base table), we are selecting from product table
         if ($this->getInitialPopulation() === null) {
             $referenceTable = _DB_PREFIX_ . 'product';
         } else {
             $referenceTable = '(' . $this->getInitialPopulation()->getQuery() . ')';
         }
 
-        $query = 'SELECT ';
-
         $selectFields = $this->computeSelectFields($filterToTableMapping);
         $whereConditions = $this->computeWhereConditions($filterToTableMapping);
         $joinConditions = $this->computeJoinConditions($filterToTableMapping);
         $groupFields = $this->computeGroupByFields($filterToTableMapping);
 
-        $query .= implode(', ', $selectFields) . ' FROM ' . $referenceTable . ' p';
+        $query = 'SELECT ' . implode(', ', $selectFields) . ' FROM ' . $referenceTable . ' p';
 
         foreach ($joinConditions as $joinAliasInfos) {
             foreach ($joinAliasInfos as $tableAlias => $joinInfos) {
@@ -365,23 +368,26 @@ class MySQL extends AbstractAdapter
     {
         $orderField = $this->getOrderField();
 
+        // If we have set an initial population, add this field into initial population selects
         if ($this->getInitialPopulation() !== null && !empty($orderField)) {
             $this->getInitialPopulation()->addSelectField($orderField);
         }
 
-        // do not try to process the orderField if it already has an alias, or if it's a group function
+        // Do not try to process the orderField if it already has an alias, or if it's a group function
         if (empty($orderField) || strpos($orderField, '.') !== false
             || strpos($orderField, '(') !== false) {
             return $orderField;
         }
 
+        // Alter order by field if it's a price column
         if ($orderField === 'price') {
             $orderField = $this->getOrderDirection() === 'asc' ? 'price_min' : 'price_max';
         }
 
+        // Add table mapping or p. prefix depending on field type
         $orderField = $this->computeFieldName($orderField, $filterToTableMapping, true);
 
-        // put some products at the end of the list
+        // Alter order by field and add some products to the end of the list, if required
         $orderField = $this->computeShowLast($orderField, $filterToTableMapping);
 
         return $orderField;
@@ -485,6 +491,7 @@ class MySQL extends AbstractAdapter
      */
     protected function computeSelectFields(array $filterToTableMapping)
     {
+        // Add already added select fields to current query
         $selectFields = [];
         foreach ($this->getSelectFields() as $key => $selectField) {
             $selectFields[] = $this->computeFieldName($selectField, $filterToTableMapping);
@@ -784,8 +791,11 @@ class MySQL extends AbstractAdapter
      */
     public function useFiltersAsInitialPopulation()
     {
+        // Initial population has NO LIMIT and no ORDER BY
         $this->setLimit(null);
         $this->setOrderField('');
+
+        // We add basic select fields we will need to matter what
         $this->setSelectFields(
             [
                 'id_product',
@@ -797,7 +807,11 @@ class MySQL extends AbstractAdapter
                 'sales',
             ]
         );
+
+        // Clone it, add it to initial population
         $this->initialPopulation = clone $this;
+
+        // Reset all filters so we start clean and add only the base select, we don't need anything else
         $this->resetAll();
         $this->addSelectField('id_product');
     }

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -125,11 +125,14 @@ class Search
         // Add filters that the user has selected for current query
         $this->addSearchFilters($selectedFilters);
 
-        // Adds filters that specific for category page
+        // Adds filters that specific for this controller
         $this->addControllerSpecificFilters();
 
-        // Add group by and flush it, let's go
+        // Add group by to remove duplicate values
         $this->getSearchAdapter()->addGroupBy('id_product');
+
+        // Move the current search into the "initialPopulation"
+        // This initialPopulation will be used to generate the base table in the final query
         $this->getSearchAdapter()->useFiltersAsInitialPopulation();
     }
 
@@ -312,7 +315,7 @@ class Search
     {
         // Category page
         if ($this->query->getQueryType() == 'category') {
-            // If any category filter was user selected, we don't have anything to do here
+            // We check if some specific filter of this type wasn't added before by the customer
             if (!empty($this->getSearchAdapter()->getFilter('id_category'))) {
                 return;
             }

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -506,7 +506,8 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
     /**
      * Remove the facet when there's only 1 result.
-     * Keep facet status when it's a slider
+     * Keep facet status when it's a slider.
+     * Keep facet status if it's a availability facet.
      *
      * @param array $facets
      * @param int $totalProducts
@@ -522,12 +523,6 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 continue;
             }
 
-            // We won't apply this to availability facet, let's keep the value displayed
-            // Don't worry, the facet will be hidden if there are no values with products
-            if ($facet->getType() == 'availability') {
-                continue;
-            }
-
             // Now the rest of facets - we apply this logic
             $totalFacetProducts = 0;
             $usefulFiltersCount = 0;
@@ -538,21 +533,22 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 }
             }
 
+            // We display the facet in several cases
             $facet->setDisplayed(
-                // There are two filters displayed
+                // If there are two filters available
                 $usefulFiltersCount > 1
                 ||
-                /*
-                 * There is only one fitler and the
-                 * magnitude is different than the
-                 * total products
-                 */
+                // There is only one filter available, but it furhter reduces the product selection
                 (
                     count($facet->getFilters()) === 1
                     && $totalFacetProducts < $totalProducts
                     && $usefulFiltersCount > 0
                 )
+                ||
+                // If there is only one filter, but it's availability filter - we want this one to be displayed all the time
+                ($usefulFiltersCount === 1 && $facet->getType() == 'availability')
             );
+            // Other cases - hidden by default
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you open a page with no products, it shows empty availability filter. The same problem if you disable stock management. I did it wrong the last time. This PR fixes the issue. Also, I added some comments.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Disable stock management in BO and see that there is no longer an empty filter in the left column.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/916)
<!-- Reviewable:end -->
