### PR TITLE
Add sorting by reference

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -97,6 +97,8 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         $sortPriceDesc = new SortOrder('product', 'price', 'desc');
         $sortDateAsc = new SortOrder('product', 'date_add', 'asc');
         $sortDateDesc = new SortOrder('product', 'date_add', 'desc');
+        $sortRefAsc = new SortOrder('product', 'reference', 'asc');
+        $sortRefDesc = new SortOrder('product', 'reference', 'desc');
         $translator = $this->module->getTranslator();
 
         $sortOrders = [
@@ -117,6 +119,12 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             ),
             $sortPriceDesc->setLabel(
                 $translator->trans('Price, high to low', [], 'Shop.Theme.Catalog')
+            ),
+            $sortRefAsc->setLabel(
+                $translator->trans('Reference, A to Z', [], 'Shop.Theme.Catalog')
+            ),
+            $sortRefDesc->setLabel(
+                $translator->trans('Reference, Z to A', [], 'Shop.Theme.Catalog')
             ),
         ];
 


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add sorting by reference in the prestashop categorie page.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that on the category with filters there is a new sorting option available

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/ps_facetedsearch/925)
<!-- Reviewable:end -->
