### PR TITLE
Deprecate standalone endpoints to match PrestaShop 9.0 new security policy

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+# In PrestaShop 9.0 php files are now protected so we allow only specific endpoints to be accessible
+<FilesMatch "ps_facetedsearch-.+\.php$">
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order Allow,Deny
+        Allow from all
+    </IfModule>
+
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+</FilesMatch>

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+class Ps_FacetedSearchCronModuleFrontController extends ModuleFrontController
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->ajax = true;
+    }
+
+    public function postProcess()
+    {
+        if (substr(Tools::hash('ps_facetedsearch/index'), 0, 10) != Tools::getValue('token')) {
+            header('HTTP/1.1 403 Forbidden');
+            header('Status: 403 Forbidden');
+            $this->ajaxRender('Bad token');
+
+            return;
+        }
+
+        $action = Tools::getValue('action');
+        switch ($action) {
+            case 'indexAttributes':
+                Shop::setContext(Shop::CONTEXT_ALL);
+
+                $psFacetedsearch = new Ps_Facetedsearch();
+                $psFacetedsearch->indexAttributes();
+                $psFacetedsearch->indexFeatures();
+                $psFacetedsearch->indexAttributeGroup();
+
+                $this->ajaxRender('1');
+                break;
+            case 'clearCache':
+                $psFacetedsearch = new Ps_Facetedsearch();
+                $this->ajaxRender($psFacetedsearch->invalidateLayeredFilterBlockCache());
+                break;
+            case 'indexPrices':
+                Shop::setContext(Shop::CONTEXT_ALL);
+
+                $module = new Ps_Facetedsearch();
+                if (Tools::getValue('full')) {
+                    $this->ajaxRender($module->fullPricesIndexProcess((int) Tools::getValue('cursor'), (bool) Tools::getValue('ajax'), true));
+                } else {
+                    $this->ajaxRender($module->pricesIndexProcess((int) Tools::getValue('cursor'), (bool) Tools::getValue('ajax')));
+                }
+
+                break;
+            default:
+                header('HTTP/1.1 403 Forbidden');
+                header('Status: 403 Forbidden');
+                $this->ajaxRender('Unknown action');
+        }
+    }
+}

--- a/ps_facetedsearch-attribute-indexer.php
+++ b/ps_facetedsearch-attribute-indexer.php
@@ -17,6 +17,14 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
+/*
+ * This standalone endpoint is deprecated, it should not be used anymore and should be removed along with the
+ * htaccess file that still allows it to work despite the security policy from the core forbidding this kind
+ * of file to be executed.
+ */
+@trigger_error('This endpoint has been deprecated and will be removed in the next major version for this module, you should rely on Ps_FacetedSearchCronModuleFrontController instead.', E_USER_DEPRECATED);
+
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/ps_facetedsearch.php';
 

--- a/ps_facetedsearch-clear-cache.php
+++ b/ps_facetedsearch-clear-cache.php
@@ -17,6 +17,14 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
+/*
+ * This standalone endpoint is deprecated, it should not be used anymore and should be removed along with the
+ * htaccess file that still allows it to work despite the security policy from the core forbidding this kind
+ * of file to be executed.
+ */
+@trigger_error('This endpoint has been deprecated and will be removed in the next major version for this module, you should rely on Ps_FacetedSearchCronModuleFrontController instead.', E_USER_DEPRECATED);
+
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/ps_facetedsearch.php';
 

--- a/ps_facetedsearch-price-indexer.php
+++ b/ps_facetedsearch-price-indexer.php
@@ -17,6 +17,14 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
+/*
+ * This standalone endpoint is deprecated, it should not be used anymore and should be removed along with the
+ * htaccess file that still allows it to work despite the security policy from the core forbidding this kind
+ * of file to be executed.
+ */
+@trigger_error('This endpoint has been deprecated and will be removed in the next major version for this module, you should rely on Ps_FacetedSearchCronModuleFrontController instead.', E_USER_DEPRECATED);
+
 require_once __DIR__ . '/../../config/config.inc.php';
 require_once __DIR__ . '/ps_facetedsearch.php';
 

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -779,20 +779,20 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     public function renderAdminMain()
     {
         // General purpose variables
-        $moduleUrl = Tools::getProtocol(Tools::usingSecureMode()) . $_SERVER['HTTP_HOST'] . $this->getPathUri();
         $features = $this->getAvailableFeatures();
         $attributeGroups = $this->getAvailableAttributes();
 
+        $cronToken = substr(Tools::hash('ps_facetedsearch/index'), 0, 10);
         $this->context->smarty->assign([
             'PS_LAYERED_INDEXED' => (int) Configuration::getGlobalValue('PS_LAYERED_INDEXED'),
             'current_url' => Tools::safeOutput(preg_replace('/&deleteFilterTemplate=[0-9]*&id_layered_filter=[0-9]*/', '', $_SERVER['REQUEST_URI'])),
             'id_lang' => $this->getContext()->cookie->id_lang,
-            'token' => substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
+            'token' => $cronToken,
             'base_folder' => urlencode(_PS_ADMIN_DIR_),
-            'price_indexer_url' => $moduleUrl . 'ps_facetedsearch-price-indexer.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
-            'full_price_indexer_url' => $moduleUrl . 'ps_facetedsearch-price-indexer.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10) . '&full=1',
-            'attribute_indexer_url' => $moduleUrl . 'ps_facetedsearch-attribute-indexer.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
-            'clear_cache_url' => $moduleUrl . 'ps_facetedsearch-clear-cache.php' . '?token=' . substr(Tools::hash('ps_facetedsearch/index'), 0, 10),
+            'price_indexer_url' => $this->context->link->getModuleLink('ps_facetedsearch', 'cron', ['ajax' => true, 'action' => 'indexPrices', 'token' => $cronToken]),
+            'full_price_indexer_url' => $this->context->link->getModuleLink('ps_facetedsearch', 'cron', ['ajax' => true, 'action' => 'indexPrices', 'full' => 1, 'token' => $cronToken]),
+            'attribute_indexer_url' => $this->context->link->getModuleLink('ps_facetedsearch', 'cron', ['ajax' => true, 'action' => 'indexAttributes', 'token' => $cronToken]),
+            'clear_cache_url' => $this->context->link->getModuleLink('ps_facetedsearch', 'cron', ['ajax' => true, 'action' => 'clearCache', 'token' => $cronToken]),
             'filters_templates' => $this->getExistingFiltersOverview(),
             'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
             'cache_enabled' => Configuration::get('PS_LAYERED_CACHE_ENABLED'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allow executing only the specific PHP files as external endpoints, required since PrestaShop 9.0 because additional security was added in this PR https://github.com/PrestaShop/PrestaShop/pull/34184 The idea in this PR is to allow access to very specific files to prevent unwanted accesses on malicious files
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Install a shop based on develop branch, go to the module administration of faceted search and try to build indexes or clear the cache. An error message should appear and when you check the network in browser developer tools you should see that the ajax request was forbidden (403 error). Now use the branch from this PR and do the same, the ajax calls should now be successful.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
