### PR TITLE
Hide out of stock products from any filter

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -151,12 +151,9 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
     protected function getDefaultFilters()
     {
-        return [
+        $filters = [
             'layered_selection_subcategories' => [
                 'label' => 'Sub-categories filter',
-            ],
-            'layered_selection_stock' => [
-                'label' => 'Product stock filter',
             ],
             'layered_selection_condition' => [
                 'label' => 'Product condition filter',
@@ -176,6 +173,17 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 'label' => 'Product extras filter',
             ],
         ];
+        // if we are not showing out of stock products, we do not show the Availability filter
+        if (Configuration::get('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK') === '0'){
+            $filters = array_merge(
+                $filters,[
+                    'layered_selection_stock' => [
+                        'label' => 'Product stock filter',
+                    ]
+                ]
+            );
+        }
+        return $filters;
     }
 
     public function install()
@@ -207,6 +215,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_ATTRIBUTE_ANCHOR_SEPARATOR', '-');
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
+            Configuration::updateValue('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', 0);
@@ -246,6 +255,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_CATEGORY_DEPTH');
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
+        Configuration::deleteByName('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_category');
@@ -710,11 +720,17 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_CATEGORY_DEPTH', (int) Tools::getValue('ps_layered_filter_category_depth'));
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
+            Configuration::updateValue('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK', (int) Tools::getValue('ps_layered_filter_hide_out_of_stock'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
+
+            // if we are not showing out of stock products, we do not show the Availability filter
+            if ((int) Tools::getValue('ps_layered_filter_hide_out_of_stock') === 1) {
+                $this->getDatabase()->execute('DELETE FROM`' . _DB_PREFIX_ . 'layered_category` WHERE `type` = "availability"');
+            }
 
             $message = '<div class="alert alert-success">' . $this->trans('Settings saved successfully', [], 'Modules.Facetedsearch.Admin') . '</div>';
             $this->invalidateLayeredFilterBlockCache();
@@ -802,6 +818,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'limit_warning' => $this->displayLimitPostWarning(21 + count($attributeGroups) * 3 + count($features) * 3),
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
+            'hide_out_of_stock' => (bool) Configuration::get('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -322,6 +322,16 @@ class Search
                     break;
             }
         }
+        // Show only products in stock
+        if (Configuration::get('PS_LAYERED_FILTER_HIDE_OUT_OF_STOCK')=== '1'){
+            $operationsFilter[] = [
+                ['quantity', [0], '>'],
+            ];
+            $this->getSearchAdapter()->addOperationsFilter(
+                self::STOCK_MANAGEMENT_FILTER,
+                $operationsFilter
+            );
+        }
     }
 
     /**

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -262,6 +262,23 @@
 	  </div>
 	</div>
 
+	<div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='Hide out of stock' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_filter_hide_out_of_stock" id="ps_layered_filter_hide_out_of_stock_on" value="1"{if $hide_out_of_stock} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_hide_out_of_stock_on" class="radioCheck">
+			<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_filter_hide_out_of_stock" id="ps_layered_filter_hide_out_of_stock_off" value="0"{if !$hide_out_of_stock} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_hide_out_of_stock_off" class="radioCheck">
+			<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+	  </div>
+	</div>
+
   <div class="form-group">
     <label class="col-lg-3 control-label">{l s='Use Jquery UI slider' d='Modules.Facetedsearch.Admin'}</label>
     <div class="col-lg-9">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We have add an option on the settings to hide products without stock, this solve the issue https://github.com/PrestaShop/PrestaShop/issues/10018. Also when this option is enable, it disable the Availability filter, if the filter was enabled before activating the option "Hide out of stock", it deletes from table layered_category any availability type register to disable it
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10018
| How to test?  | On the setting enable the option: "Hide out of stock"

![image](https://github.com/PrestaShop/ps_facetedsearch/assets/46203943/3ade9c14-9e44-4d2c-b32b-f53e7b42510f)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
