### PR TITLE
Use loose type for Translator

### DIFF
--- a/src/Form/Attribute/FormModifier.php
+++ b/src/Form/Attribute/FormModifier.php
@@ -30,17 +30,21 @@ namespace PrestaShop\Module\FacetedSearch\Form\Attribute;
 
 use PrestaShop\Module\FacetedSearch\Constraint\UrlSegment;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FormModifier
 {
     /**
-     * @var TranslatorComponent
+     * @var DataCollectorTranslator|TranslatorComponent
      */
     private $translator;
 
-    public function __construct(TranslatorComponent $translator)
+    /**
+     * @param DataCollectorTranslator|TranslatorComponent $translator
+     */
+    public function __construct($translator)
     {
         $this->translator = $translator;
     }

--- a/src/Form/AttributeGroup/FormModifier.php
+++ b/src/Form/AttributeGroup/FormModifier.php
@@ -32,17 +32,21 @@ use PrestaShop\Module\FacetedSearch\Constraint\UrlSegment;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FormModifier
 {
     /**
-     * @var TranslatorComponent
+     * @var DataCollectorTranslator|TranslatorComponent
      */
     private $translator;
 
-    public function __construct(TranslatorComponent $translator)
+    /**
+     * @param DataCollectorTranslator|TranslatorComponent $translator
+     */
+    public function __construct($translator)
     {
         $this->translator = $translator;
     }

--- a/src/Form/Feature/FormModifier.php
+++ b/src/Form/Feature/FormModifier.php
@@ -24,6 +24,7 @@ use Context;
 use PrestaShop\Module\FacetedSearch\Constraint\UrlSegment;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -46,9 +47,7 @@ class FormModifier
         FormBuilderInterface $formBuilder,
         array $data
     ) {
-        /**
-         * @var TranslatorComponent
-         */
+        /** @var DataCollectorTranslator|TranslatorComponent $translator */
         $translator = $this->context->getTranslator();
         $invalidCharsHint = $translator->trans(
             'Invalid characters: <>;=#{}_',

--- a/src/Form/FeatureValue/FormModifier.php
+++ b/src/Form/FeatureValue/FormModifier.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\FacetedSearch\Form\FeatureValue;
 use Context;
 use PrestaShop\Module\FacetedSearch\Constraint\UrlSegment;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Translation\DataCollectorTranslator;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -45,9 +46,7 @@ class FormModifier
         FormBuilderInterface $formBuilder,
         array $data
     ) {
-        /**
-         * @var TranslatorComponent
-         */
+        /** @var DataCollectorTranslator|TranslatorComponent $translator */
         $translator = $this->context->getTranslator();
         $invalidCharsHint = $translator->trans(
             'Invalid characters: <>;=#{}_',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use loose typing in classes as the core uses different Translator override and decoration that mess with the initial type, also with this the module should remain compatible with more PrestaShop versions
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | This PR only needs to be tested with the develop branch from the core, to validate it fixes the bug that prevents finishing the Attributes page However, the next release PR of the module should be tested with older versions like 8.1 or 8.0 or even as low as 1.7.6 since it's the minimum range

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
