### PR TITLE
Use feature value position for ordering

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -232,6 +232,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
         }
 
+        Configuration::updateValue('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION', 0);
+
         return true;
     }
 
@@ -247,6 +249,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
+        Configuration::deleteByName('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION');
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_category');
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_filter');
@@ -722,6 +725,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
+            Configuration::updateValue('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION', (int) Tools::getValue('ps_layered_filter_feature_values_use_position'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -821,6 +825,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
             'add_new_filters_template_link' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1]),
+            'feature_values_use_position' => (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -27,6 +27,7 @@ if (file_exists($autoloadPath)) {
 }
 
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
+use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\HookDispatcher;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
@@ -826,6 +827,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
             'add_new_filters_template_link' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1]),
             'feature_values_use_position' => (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION'),
+            'feature_values_position_supported' => DataAccessor::isFeatureValuePositionSupported(),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -882,6 +882,9 @@ class Block
                 'name' => $featureValues[$idFeatureValue]['value'],
                 'url_name' => $featureValues[$idFeatureValue]['url_name'],
                 'meta_title' => $featureValues[$idFeatureValue]['meta_title'],
+                'position' => isset($featureValues[$idFeatureValue]['position'])
+                    ? (int) $featureValues[$idFeatureValue]['position']
+                    : 0,
             ];
 
             if (array_key_exists('id_feature', $selectedFilters)) {
@@ -907,6 +910,20 @@ class Block
      */
     private function sortFeatureBlock($featureBlock)
     {
+        // The merchant arranged the feature values by hand, so keep that order instead of
+        // sorting the names. Only reachable on cores that expose a position.
+        if (DataAccessor::isFeatureValuePositionSupported()
+            && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')
+        ) {
+            foreach ($featureBlock as $key => $value) {
+                uasort($featureBlock[$key]['values'], function ($a, $b) {
+                    return $a['position'] <=> $b['position'];
+                });
+            }
+
+            return $featureBlock;
+        }
+
         //Natural sort
         foreach ($featureBlock as $key => $value) {
             $temp = [];

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -910,20 +910,6 @@ class Block
      */
     private function sortFeatureBlock($featureBlock)
     {
-        // The merchant arranged the feature values by hand, so keep that order instead of
-        // sorting the names. Only reachable on cores that expose a position.
-        if (DataAccessor::isFeatureValuePositionSupported()
-            && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')
-        ) {
-            foreach ($featureBlock as $key => $value) {
-                uasort($featureBlock[$key]['values'], function ($a, $b) {
-                    return $a['position'] <=> $b['position'];
-                });
-            }
-
-            return $featureBlock;
-        }
-
         //Natural sort
         foreach ($featureBlock as $key => $value) {
             $temp = [];

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -27,7 +27,6 @@ use Db;
 use Manufacturer;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters;
-use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -52,6 +52,7 @@ class Converter
     const PROPERTY_URL_NAME = 'url_name';
     const PROPERTY_COLOR = 'color';
     const PROPERTY_TEXTURE = 'texture';
+    const PROPERTY_POSITION = 'position';
 
     /**
      * @var array
@@ -146,6 +147,10 @@ class Converter
                             ->setMagnitude($filterArray['nbr'])
                             ->setValue($id);
 
+                        if (isset($filterArray['position'])) {
+                            $filter->setProperty(self::PROPERTY_POSITION, (int) $filterArray['position']);
+                        }
+
                         if (isset($filterArray['url_name'])) {
                             $filter->setProperty(self::PROPERTY_URL_NAME, $filterArray['url_name']);
                         }
@@ -171,18 +176,20 @@ class Converter
 
                     $this->hideZeroValuesAndShowLimit($filters, (int) $filterBlock['filter_show_limit']);
 
-                    // Feature values keep the order DataAccessor returned them in when the shop
-                    // orders them by position, otherwise this would sort them alphabetically again
-                    // and the setting would have no visible effect.
-                    $keepDatabaseOrder = $filterBlock['type'] === self::TYPE_FEATURE
-                        && DataAccessor::isFeatureValuePositionSupported()
-                        && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION');
-
-                    if (!$keepDatabaseOrder
-                        && ((int) $filterBlock['filter_show_limit'] !== 0
-                            || ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP && $filterBlock['type'] !== self::TYPE_AVAILABILITY))
+                    if ((int) $filterBlock['filter_show_limit'] !== 0 ||
+                        ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP && $filterBlock['type'] !== self::TYPE_AVAILABILITY)
                     ) {
-                        usort($filters, [$this, 'sortFiltersByLabel']);
+                        // Feature values can be ordered the way the merchant arranged them instead
+                        // of alphabetically. This has to happen here rather than earlier, because
+                        // this sort runs last and would otherwise undo it.
+                        if ($filterBlock['type'] === self::TYPE_FEATURE
+                            && DataAccessor::isFeatureValuePositionSupported()
+                            && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')
+                        ) {
+                            usort($filters, [$this, 'sortFiltersByPosition']);
+                        } else {
+                            usort($filters, [$this, 'sortFiltersByLabel']);
+                        }
                     }
 
                     // No method available to add all filters
@@ -628,5 +635,26 @@ class Converter
         }
 
         return $collators[$locale];
+    }
+
+    /**
+     * Sort filters by the position the merchant gave them, falling back to the label so the
+     * order stays stable when positions are equal.
+     *
+     * @param Filter $a
+     * @param Filter $b
+     *
+     * @return int
+     */
+    private function sortFiltersByPosition(Filter $a, Filter $b)
+    {
+        $positionA = (int) $a->getProperty(self::PROPERTY_POSITION);
+        $positionB = (int) $b->getProperty(self::PROPERTY_POSITION);
+
+        if ($positionA === $positionB) {
+            return $this->sortFiltersByLabel($a, $b);
+        }
+
+        return $positionA <=> $positionB;
     }
 }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -27,6 +27,7 @@ use Db;
 use Manufacturer;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters;
+use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
@@ -171,8 +172,16 @@ class Converter
 
                     $this->hideZeroValuesAndShowLimit($filters, (int) $filterBlock['filter_show_limit']);
 
-                    if ((int) $filterBlock['filter_show_limit'] !== 0 ||
-                        ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP && $filterBlock['type'] !== self::TYPE_AVAILABILITY)
+                    // Feature values keep the order DataAccessor returned them in when the shop
+                    // orders them by position, otherwise this would sort them alphabetically again
+                    // and the setting would have no visible effect.
+                    $keepDatabaseOrder = $filterBlock['type'] === self::TYPE_FEATURE
+                        && DataAccessor::isFeatureValuePositionSupported()
+                        && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION');
+
+                    if (!$keepDatabaseOrder
+                        && ((int) $filterBlock['filter_show_limit'] !== 0
+                            || ($filterBlock['type'] !== self::TYPE_ATTRIBUTE_GROUP && $filterBlock['type'] !== self::TYPE_AVAILABILITY))
                     ) {
                         usort($filters, [$this, 'sortFiltersByLabel']);
                     }

--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -203,7 +203,7 @@ class DataAccessor
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_feature_value_lang_value` lifvlv ' .
                 'ON (v.`id_feature_value` = lifvlv.`id_feature_value` AND lifvlv.`id_lang` = ' . (int) $idLang . ') ' .
                 'WHERE v.`id_feature` = ' . (int) $idFeature . ' ' .
-                'ORDER BY vl.`value` ASC'
+                'ORDER BY v.`position` ASC'
             );
 
             foreach ($tempFeatureValues as $feature) {

--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -20,6 +20,7 @@
 
 namespace PrestaShop\Module\FacetedSearch\Filters;
 
+use Configuration;
 use Combination;
 use Db;
 use Shop;
@@ -193,6 +194,13 @@ class DataAccessor
         if (!isset($this->featureValues[$idLang][$idFeature])) {
             // Initialize only the requested feature without discarding other cached features for the language.
             $this->featureValues[$idLang][$idFeature] = [];
+
+            if ((bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')) {
+                $order = 'ORDER BY v.`position` ASC';
+            } else {
+                $order = 'ORDER BY vl.`value` ASC';
+            }
+
             $tempFeatureValues = $this->database->executeS(
                 'SELECT v.*, vl.*, ' .
                 'IF(lifvlv.`url_name` IS NULL OR lifvlv.`url_name` = "", NULL, lifvlv.`url_name`) AS url_name, ' .
@@ -203,7 +211,7 @@ class DataAccessor
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_feature_value_lang_value` lifvlv ' .
                 'ON (v.`id_feature_value` = lifvlv.`id_feature_value` AND lifvlv.`id_lang` = ' . (int) $idLang . ') ' .
                 'WHERE v.`id_feature` = ' . (int) $idFeature . ' ' .
-                'ORDER BY v.`position` ASC'
+                $order
             );
 
             foreach ($tempFeatureValues as $feature) {

--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -20,8 +20,8 @@
 
 namespace PrestaShop\Module\FacetedSearch\Filters;
 
-use Configuration;
 use Combination;
+use Configuration;
 use Db;
 use Shop;
 
@@ -182,6 +182,19 @@ class DataAccessor
     }
 
     /**
+     * Whether the core exposes a position on feature values.
+     *
+     * Added in PrestaShop 9.0 by PrestaShop/PrestaShop#37042. This module still supports 8.2,
+     * where the column does not exist and ordering by it would fail.
+     *
+     * @return bool
+     */
+    public static function isFeatureValuePositionSupported()
+    {
+        return version_compare(_PS_VERSION_, '9.0.0', '>=');
+    }
+
+    /**
      * Get feature values for given feature, with their associated layered information.
      *
      * @param int $idFeature
@@ -195,7 +208,11 @@ class DataAccessor
             // Initialize only the requested feature without discarding other cached features for the language.
             $this->featureValues[$idLang][$idFeature] = [];
 
-            if ((bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')) {
+            // feature_value.position only exists from PrestaShop 9.0 (PrestaShop/PrestaShop#37042),
+            // and this module still supports 8.2, where ordering by it is an unknown column.
+            if (self::isFeatureValuePositionSupported()
+                && (bool) Configuration::get('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION')
+            ) {
                 $order = 'ORDER BY v.`position` ASC';
             } else {
                 $order = 'ORDER BY vl.`value` ASC';

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -1021,6 +1021,7 @@ class BlockTest extends MockeryTestCase
                                 'name' => 'Cotton',
                                 'url_name' => 'something',
                                 'meta_title' => 'weird',
+                                'position' => 0,
                                 'checked' => true,
                             ],
                             21 => [
@@ -1028,6 +1029,7 @@ class BlockTest extends MockeryTestCase
                                 'name' => 'Test Custom value',
                                 'url_name' => 'url-custom-21',
                                 'meta_title' => 'title-custom-21',
+                                'position' => 0,
                             ],
                         ],
                         'name' => 'Composition',

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -67,6 +67,7 @@ class BlockTest extends MockeryTestCase
                     'PS_ORDER_OUT_OF_STOCK' => '1',
                     'PS_UNIDENTIFIED_GROUP' => '1',
                     'PS_LAYERED_FILTER_CATEGORY_DEPTH' => 3,
+                    'PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION' => 0,
                 ];
 
                 return $valueMap[$arg];

--- a/tests/php/FacetedSearch/Filters/DataAccessorTest.php
+++ b/tests/php/FacetedSearch/Filters/DataAccessorTest.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\FacetedSearch\Tests\Filters;
 
 use Combination;
+use Configuration;
 use Db;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -50,6 +51,16 @@ class DataAccessorTest extends MockeryTestCase
         $shopMock = Mockery::mock(Shop::class);
         $shopMock->shouldReceive('addSqlAssociation')->andReturn('');
         Shop::setStaticExpectations($shopMock);
+
+        $configurationMock = Mockery::mock(Configuration::class);
+        $configurationMock->shouldReceive('get')->andReturnUsing(function ($key) {
+            $valueMap = [
+                'PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION' => 0,
+            ];
+
+            return isset($valueMap[$key]) ? $valueMap[$key] : null;
+        });
+        Configuration::setStaticExpectations($configurationMock);
 
         $this->query = '';
         $dbMock = Mockery::mock(Db::class);

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -303,7 +303,8 @@
 		</div>
 	</div>
 
-        <div class="form-group">
+	{if $feature_values_position_supported}
+	<div class="form-group">
 	  <label class="col-lg-3 control-label">{l s='Use position for feature values ordering' d='Modules.Facetedsearch.Admin'}</label>
 	  <div class="col-lg-9">
 		<span class="switch prestashop-switch fixed-width-lg">
@@ -319,6 +320,7 @@
 		</span>
 	  </div>
 	</div>
+	{/if}
 
 	<div class="panel-footer">
 	  <button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -319,6 +319,11 @@
 		  <a class="slide-button btn"></a>
 		</span>
 	  </div>
+	  <div class="col-lg-9 col-lg-offset-3">
+		<div class="help-block">
+		  {l s='Order feature values in the filters the way they are arranged in Catalog > Features, instead of alphabetically.' d='Modules.Facetedsearch.Admin'}
+		</div>
+	  </div>
 	</div>
 	{/if}
 

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -303,6 +303,23 @@
 		</div>
 	</div>
 
+        <div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='Use position for feature values ordering' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_filter_feature_values_use_position" id="ps_layered_filter_feature_values_use_position_on" value="1"{if $feature_values_use_position} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_feature_values_use_position_on" class="radioCheck">
+			<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_filter_feature_values_use_position" id="ps_layered_filter_feature_values_use_position_off" value="0"{if !$feature_values_use_position} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_feature_values_use_position_off" class="radioCheck">
+			<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+	  </div>
+	</div>
+
 	<div class="panel-footer">
 	  <button type="submit" class="btn btn-default pull-right" name="submitLayeredSettings"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
 	</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use feature value new position field for ordering of feature values. Part of PrestaShop/PrestaShop#37042
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of PrestaShop/PrestaShop#35499 and PrestaShop/PrestaShop#32267
| How to test?  | If used together with parent PR, it should show feature values in faceted search in the order provided in BO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
