### PR TITLE
Performance improvements

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -329,11 +329,10 @@ class Search
      */
     private function addCommonFilters()
     {
-        // Setting proper shop
-        $this->getSearchAdapter()->addFilter('id_shop', [(int) $this->context->shop->id]);
-
-        // Visibility of a product must be in catalog or both (search & catalog)
-        $this->addFilter('visibility', ['both', 'catalog']);
+        // Setting proper shop if multishop is enabled
+        if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')) {
+            $this->getSearchAdapter()->addFilter('id_shop', [(int) $this->context->shop->id]);
+        }
 
         // User must belong to one of the groups that can access the product
         // (Actually it's categories that define access to a product, user must have access to at least


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Improved both cold and hot query performance by 2-15x
| Type?         |  improvement
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

Changes:

- id_shop filter will be only added if multishop feature is enabled
- product visibility filter is removed from the base query and added to the outer
- category_product table join on the outer query was removed
- removed all unused selects/joins from base query such as id_manufacture, price, on_sale etc. and added them as joins to $filterToTableMapping.

Performance:
There are the execution times for the queries generated by the module. 
Cold means the faceted blocks are not yet cached, and warm means the blocks are cached, only the base query is running.

- category 1:
  cold: 412ms -> 74ms
  warm: 31ms -> 2ms
- category 2:
  cold: 673ms -> 258ms
  warm: 46ms -> 14ms
- category 3:
  cold: 506ms -> 105ms
  warm: 36ms -> 5ms
- category 4:
  cold: 81ms -> 23ms
  warm: 4ms -> 1ms

Test setup is a dev machine with ryzen 7700x, nvme ssd, 32gb ram, I expect better improvements on weaker configs.

