### PR TITLE
Fix: ps_facetedsearch - In template creation, filters counter in BO is not correct

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -873,7 +873,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'attribute_groups' => $attributeGroups,
             'features' => $features,
             'filters' => $filters,
-            'total_filters' => 6 + count($attributeGroups) + count($features),
+            'total_filters' => 7 + count($attributeGroups) + count($features),
             'default_filters' => $this->getDefaultFilters(),
             'categories_tree' => $treeCategoriesHelper->render(),
             'controller_options' => $controller_options,


### PR DESCRIPTION
The fixed filters are 7 and not 6, and they are as follows:
1. Sub-categories filter
2. Product stock filter
3. Product extras filter
4. Product condition filter
5. Product brand filter
6. Product weight filter (slider)
7. Product price filter (slider)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | see https://github.com/PrestaShop/PrestaShop/issues/37587
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/37587
| How to test?  | see https://github.com/PrestaShop/PrestaShop/issues/37587
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
