### PR TITLE
Fixed incorrect language condition in LEFT JOIN (liaglv.id_lang instead of agl.id_lang)

### DIFF
--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -133,7 +133,7 @@ class DataAccessor
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_attribute_group` liag ' .
                 'ON (ag.`id_attribute_group` = liag.`id_attribute_group`) ' .
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_attribute_group_lang_value` AS liaglv ' .
-                'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND agl.`id_lang` = ' . (int) $idLang . ') ' .
+                'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = ' . (int) $idLang . ') ' .
                 'GROUP BY ag.id_attribute_group ORDER BY ag.`position` ASC'
             );
 

--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -134,7 +134,7 @@ class DataAccessor
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_attribute_group` liag ' .
                 'ON (ag.`id_attribute_group` = liag.`id_attribute_group`) ' .
                 'LEFT JOIN `' . _DB_PREFIX_ . 'layered_indexable_attribute_group_lang_value` AS liaglv ' .
-                'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND agl.`id_lang` = ' . (int) $idLang . ') ' .
+                'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = ' . (int) $idLang . ') ' .
                 'GROUP BY ag.id_attribute_group ORDER BY ag.`position` ASC'
             );
 

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -1085,7 +1085,7 @@ class BlockTest extends MockeryTestCase
                     'LEFT JOIN `ps_layered_indexable_attribute_group` liag ' .
                     'ON (ag.`id_attribute_group` = liag.`id_attribute_group`) ' .
                     'LEFT JOIN `ps_layered_indexable_attribute_group_lang_value` AS liaglv ' .
-                    'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND agl.`id_lang` = 2) ' .
+                    'ON (ag.`id_attribute_group` = liaglv.`id_attribute_group` AND liaglv.`id_lang` = 2) ' .
                     'GROUP BY ag.id_attribute_group ORDER BY ag.`position` ASC'
                 )
                 ->andReturn($attributeGroups);

--- a/tests/php/FacetedSearch/Filters/DataAccessorTest.php
+++ b/tests/php/FacetedSearch/Filters/DataAccessorTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Tests\Filters;
+
+use Combination;
+use Db;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
+use Shop;
+
+class DataAccessorTest extends MockeryTestCase
+{
+    private const ID_LANG = 2;
+
+    /**
+     * @var DataAccessor
+     */
+    private $dataAccessor;
+
+    /**
+     * @var string Last query handed to the database
+     */
+    private $query;
+
+    protected function setUp()
+    {
+        $combinationMock = Mockery::mock(Combination::class);
+        $combinationMock->shouldReceive('isFeatureActive')->andReturn(true);
+        Combination::setStaticExpectations($combinationMock);
+
+        $shopMock = Mockery::mock(Shop::class);
+        $shopMock->shouldReceive('addSqlAssociation')->andReturn('');
+        Shop::setStaticExpectations($shopMock);
+
+        $this->query = '';
+        $dbMock = Mockery::mock(Db::class);
+        $dbMock->shouldReceive('executeS')
+            ->andReturnUsing(function ($query) {
+                $this->query = $query;
+
+                return [];
+            });
+
+        $this->dataAccessor = new DataAccessor($dbMock);
+    }
+
+    /**
+     * The url_name shown in filter URLs lives in the layered_indexable_*_lang_value tables, so the
+     * language condition of that join has to be applied to the lang value table itself. Applying it
+     * to the neighbouring *_lang table instead leaves the join unrestricted, and the row kept by the
+     * GROUP BY is then whichever language the server happens to return - the shop shows the browsed
+     * language's name next to another language's URL.
+     *
+     * @dataProvider getLangValueJoins
+     *
+     * @param string $method
+     * @param array $arguments
+     * @param string $table
+     * @param string $alias
+     */
+    public function testLangValueJoinIsRestrictedOnItsOwnTable($method, array $arguments, $table, $alias)
+    {
+        call_user_func_array([$this->dataAccessor, $method], $arguments);
+
+        $joinCondition = $this->extractJoinCondition($this->query, $table, $alias);
+
+        $this->assertContains(
+            $alias . '.`id_lang` = ' . self::ID_LANG,
+            $joinCondition,
+            sprintf('The %s join must be restricted on %s.id_lang.', $table, $alias)
+        );
+    }
+
+    /**
+     * @dataProvider getLangValueJoins
+     *
+     * @param string $method
+     * @param array $arguments
+     * @param string $table
+     * @param string $alias
+     */
+    public function testLangValueJoinDoesNotBorrowAnotherTablesLangColumn($method, array $arguments, $table, $alias)
+    {
+        call_user_func_array([$this->dataAccessor, $method], $arguments);
+
+        $joinCondition = $this->extractJoinCondition($this->query, $table, $alias);
+
+        preg_match_all('/(\w+)\.`id_lang`/', $joinCondition, $matches);
+
+        $this->assertSame(
+            [$alias],
+            array_unique($matches[1]),
+            sprintf('Only %s.id_lang may appear in the %s join condition.', $alias, $table)
+        );
+    }
+
+    public function getLangValueJoins()
+    {
+        return [
+            'attributes' => [
+                'getAttributes',
+                [self::ID_LANG, 1],
+                'layered_indexable_attribute_lang_value',
+                'lialv',
+            ],
+            'attribute groups' => [
+                'getAttributesGroups',
+                [self::ID_LANG],
+                'layered_indexable_attribute_group_lang_value',
+                'liaglv',
+            ],
+            'features' => [
+                'getFeatures',
+                [self::ID_LANG],
+                'layered_indexable_feature_lang_value',
+                'liflv',
+            ],
+            'feature values' => [
+                'getFeatureValues',
+                [1, self::ID_LANG],
+                'layered_indexable_feature_value_lang_value',
+                'lifvlv',
+            ],
+        ];
+    }
+
+    /**
+     * Returns the ON (...) condition of the join introducing $alias.
+     *
+     * @param string $query
+     * @param string $table
+     * @param string $alias
+     *
+     * @return string
+     */
+    private function extractJoinCondition($query, $table, $alias)
+    {
+        $pattern = '/' . preg_quote(_DB_PREFIX_ . $table, '/') . '`?\s*(?:AS\s+)?' . preg_quote($alias, '/') . '\s*ON\s*\((?P<condition>[^)]*)\)/i';
+
+        $this->assertRegExp($pattern, $query, sprintf('Expected a join on %s aliased as %s.', $table, $alias));
+        preg_match($pattern, $query, $matches);
+
+        return $matches['condition'];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In the current implementation of the SQL query, the language condition in the LEFT JOIN for the ps_layered_indexable_attribute_group_lang_value table is incorrectly applied to the agl (attribute group language) table. This causes the language condition to be applied to the wrong table, which leads to incorrect results in multi-language environments. 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| How to test?  | In the PrestaShop back office, set the url_name (friendly URL) for the attribute (e.g., size) in multiple languages. On the frontend, switch between languages and apply the filter. Check that the friendly URL in the filter matches the correct language-specific url_name as configured in the backend.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<img width="449" alt="Screenshot 2025-01-29 at 5 37 57 PM" src="https://github.com/user-attachments/assets/0fd9f821-e2b7-46d1-a4bb-633eacda4102" />



<img width="1414" alt="Screenshot 2025-01-29 at 5 39 05 PM" src="https://github.com/user-attachments/assets/359306cd-f87a-458a-842c-caa243bf605a" />

The query is expected to return the url_name (e.g., storrelse) for language ID 3, but it is currently returning the url_name (e.g., size) for language ID 1. This results in incorrect URL names being used for filters in multi-language environments.