### PR TITLE
Improvement of sub-categories count

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -131,7 +131,7 @@ class MySQL extends AbstractAdapter
 
         if ($this->categoryCount === true) {
             foreach($whereConditions as $key => $oneCondition) {
-                if ($oneCondition === "p.id_group='1'") {
+                if (strpos($oneCondition, 'p.id_group') !== false) {
                     unset($whereConditions[$key]);
                 }
                 if (strpos($oneCondition, 'p.nleft') !== false || strpos($oneCondition, 'p.nright') !== false) {
@@ -858,7 +858,6 @@ class MySQL extends AbstractAdapter
 
         $operationsFilters = clone $initialPopulation->getOperationsFilters();
         foreach ($operationsFilters as $operationName => $operations) {
-            $message = "Add operation ${operationName} with operation " . json_encode($operations);
             $this->addOperationsFilter(
                 $operationName,
                 $operations

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -825,6 +825,7 @@ class MySQL extends AbstractAdapter
         $this->setOrderField('');
 
         $this->copyOperationsFilters();
+
         return $this->execute();
     }
 

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -102,7 +102,6 @@ class MySQL extends AbstractAdapter
             unset($filterToTableMapping['nleft']);
             unset($filterToTableMapping['nright']);
             unset($filterToTableMapping['id_group']);
-            unset($filterToTableMapping['level_depth']);
         }
 
         // Process and generate all fields for the SQL query below
@@ -135,9 +134,6 @@ class MySQL extends AbstractAdapter
         if ($this->categoryCount === true) {
             foreach ($whereConditions as $key => $oneCondition) {
                 if (strpos($oneCondition, 'p.id_group') !== false) {
-                    unset($whereConditions[$key]);
-                }
-                if (strpos($oneCondition, 'p.level_depth') !== false) {
                     unset($whereConditions[$key]);
                 }
                 if (strpos($oneCondition, 'p.nleft') !== false || strpos($oneCondition, 'p.nright') !== false) {

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -132,9 +132,8 @@ class MySQL extends AbstractAdapter
             }
         }
 
-
         if ($this->categoryCount === true) {
-            foreach($whereConditions as $key => $oneCondition) {
+            foreach ($whereConditions as $key => $oneCondition) {
                 if (strpos($oneCondition, 'p.id_group') !== false) {
                     unset($whereConditions[$key]);
                 }

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -102,6 +102,7 @@ class MySQL extends AbstractAdapter
             unset($filterToTableMapping['nleft']);
             unset($filterToTableMapping['nright']);
             unset($filterToTableMapping['id_group']);
+            unset($filterToTableMapping['level_depth']);
         }
 
         // Process and generate all fields for the SQL query below
@@ -135,6 +136,9 @@ class MySQL extends AbstractAdapter
         if ($this->categoryCount === true) {
             foreach($whereConditions as $key => $oneCondition) {
                 if (strpos($oneCondition, 'p.id_group') !== false) {
+                    unset($whereConditions[$key]);
+                }
+                if (strpos($oneCondition, 'p.level_depth') !== false) {
                     unset($whereConditions[$key]);
                 }
                 if (strpos($oneCondition, 'p.nleft') !== false || strpos($oneCondition, 'p.nright') !== false) {

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -812,9 +812,9 @@ class MySQL extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function valueCount($fieldName = null, $categoryCount = false)
+    public function valueCount($fieldName = null)
     {
-        $this->categoryCount = $categoryCount;
+        $this->categoryCount = $fieldName === 'id_category';
         $this->resetGroupBy();
         if ($fieldName !== null) {
             $this->addGroupBy($fieldName);

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -989,7 +989,10 @@ class Block
             $categories[$value['id_category']] = $value;
         }
 
-        $categoryCount = null !== _PS_FACETED_NEWCOUNT_ ? _PS_FACETED_NEWCOUNT_ : true;
+        $categoryCount = true;
+        if (true === defined('_PS_FACETED_NEWCOUNT_') && null !== _PS_FACETED_NEWCOUNT_) {
+            $categoryCount = (bool) _PS_FACETED_NEWCOUNT_;
+        }
         $results = $filteredSearchAdapter->valueCount('id_category', $categoryCount);
 
         $categoriesId = [];
@@ -997,12 +1000,9 @@ class Block
             $query = new \DbQuery();
             $query->select('id_category');
             $query->from('category');
-            $depth = (int) $parent->level_depth + 1;
-            $nleft = $parent->nleft;
-            $nright = $parent->nright;
-            $query->where('level_depth <= ' . $depth);
-            $query->where('nleft > ' . $nleft);
-            $query->where('nright < ' . $nright);
+            $query->where('level_depth <= ' . (int) $parent->level_depth + 1);
+            $query->where('nleft > ' . $parent->nleft);
+            $query->where('nright < ' . $parent->nright);
             $resultCategories = \Db::getInstance()->executeS($query);
             foreach($resultCategories as $oneCategory) {
                 $categoriesId[] = $oneCategory['id_category'];

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -1017,7 +1017,7 @@ class Block
                 continue;
             }
 
-            if ($categoryCount && empty($categoriesId) === false && in_array($idCategory, $categoriesId) === false) {
+            if ($categoryCount && in_array($idCategory, $categoriesId) === false) {
                 continue;
             }
 

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -1000,9 +1000,10 @@ class Block
             $query = new \DbQuery();
             $query->select('id_category');
             $query->from('category');
-            $query->where('level_depth <= ' . (int) $parent->level_depth + 1);
-            $query->where('nleft > ' . $parent->nleft);
-            $query->where('nright < ' . $parent->nright);
+            $depth = (int) Configuration::get('PS_LAYERED_FILTER_CATEGORY_DEPTH', null, null, null, 1);
+            $query->where('level_depth <= ' . ((int) $parent->level_depth + $depth));
+            $query->where('nleft > ' . (int) $parent->nleft);
+            $query->where('nright < ' . (int) $parent->nright);
             $resultCategories = \Db::getInstance()->executeS($query);
             foreach($resultCategories as $oneCategory) {
                 $categoriesId[] = $oneCategory['id_category'];

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -1001,7 +1001,9 @@ class Block
             $query->select('id_category');
             $query->from('category');
             $depth = (int) Configuration::get('PS_LAYERED_FILTER_CATEGORY_DEPTH', null, null, null, 1);
-            $query->where('level_depth <= ' . ((int) $parent->level_depth + $depth));
+            if ($depth > 0) {
+                $query->where('level_depth <= ' . ((int) $parent->level_depth + $depth));
+            }
             $query->where('nleft > ' . (int) $parent->nleft);
             $query->where('nright < ' . (int) $parent->nright);
             $resultCategories = \Db::getInstance()->executeS($query);

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -989,27 +989,22 @@ class Block
             $categories[$value['id_category']] = $value;
         }
 
-        $categoryCount = true;
-        if (true === defined('_PS_FACETED_NEWCOUNT_') && null !== _PS_FACETED_NEWCOUNT_) {
-            $categoryCount = (bool) _PS_FACETED_NEWCOUNT_;
-        }
-        $results = $filteredSearchAdapter->valueCount('id_category', $categoryCount);
-
+        $results = $filteredSearchAdapter->valueCount('id_category');
+        // To filter results, instead to make a complex query, we will filter them in the code after
+        // So we retrieve here all categories linked to the parent one according to configuration (only IDs)
         $categoriesId = [];
-        if ($categoryCount === true) {
-            $query = new \DbQuery();
-            $query->select('id_category');
-            $query->from('category');
-            $depth = (int) Configuration::get('PS_LAYERED_FILTER_CATEGORY_DEPTH', null, null, null, 1);
-            if ($depth > 0) {
-                $query->where('level_depth <= ' . ((int) $parent->level_depth + $depth));
-            }
-            $query->where('nleft > ' . (int) $parent->nleft);
-            $query->where('nright < ' . (int) $parent->nright);
-            $resultCategories = \Db::getInstance()->executeS($query);
-            foreach ($resultCategories as $oneCategory) {
-                $categoriesId[] = $oneCategory['id_category'];
-            }
+        $query = new \DbQuery();
+        $query->select('id_category');
+        $query->from('category');
+        $depth = (int) Configuration::get('PS_LAYERED_FILTER_CATEGORY_DEPTH', null, null, null, 1);
+        if ($depth > 0) {
+            $query->where('level_depth <= ' . ((int) $parent->level_depth + $depth));
+        }
+        $query->where('nleft > ' . (int) $parent->nleft);
+        $query->where('nright < ' . (int) $parent->nright);
+        $resultCategories = \Db::getInstance()->executeS($query);
+        foreach ($resultCategories as $oneCategory) {
+            $categoriesId[] = $oneCategory['id_category'];
         }
 
         foreach ($results as $key => $values) {
@@ -1020,7 +1015,8 @@ class Block
                 continue;
             }
 
-            if ($categoryCount && in_array($idCategory, $categoriesId) === false) {
+            // If category count is not in the list of categories linked to the parent one, we skip it
+            if (in_array($idCategory, $categoriesId) === false) {
                 continue;
             }
 

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -1005,7 +1005,7 @@ class Block
             $query->where('nleft > ' . (int) $parent->nleft);
             $query->where('nright < ' . (int) $parent->nright);
             $resultCategories = \Db::getInstance()->executeS($query);
-            foreach($resultCategories as $oneCategory) {
+            foreach ($resultCategories as $oneCategory) {
                 $categoriesId[] = $oneCategory['id_category'];
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

|              Questions            | Answers
| ----------------------- | -------------------------------------------------------
|        Description?       | Improve products count performance from sub-categories on category page (more details after).
|      Type             | improvement 
|        BC breaks?     | no
|        Deprecations?              | no
|        Fixed ticket?    | No issue opened
|        How to test?     | Display category with several sub-categories and configuration mentionned above.

---------------------
#### Description - Main objectives

When product count and sub-categories is enabled, the SQL query to retrieve the number of products per sub-category on a category page was particularly slow, and could slow down or even bring the MySQL server to its knees. This enhancement splits the process into two queries (one to retrieve the category list) and the second to output the product count. Considerable performance gains (12x to 100x faster depending number of products / categories).

#### More details on configuration used

First of all, we need to display one category with filters and sub-categories count enabled :  
Configuration('_PS_LAYERED_FULL_TREE_') = 1 
Configuration('_PS_LAYERED_SHOW_QTIES_') = 1  
![image](https://github.com/user-attachments/assets/f0f63e7d-f558-4560-a4bb-c67f997eda14)


Then the category must have one model with sub categories filters enabled (_layered_selection_subcategories_) : 
![image](https://github.com/user-attachments/assets/2e373279-0678-4f44-86a8-d7b83b6350e7)

It's better to test without cache of blocks filters enabled and without cache to be abble to see performance before / after. You can add the constant _PS_FACETED_NEWCOUNT_ in your defines.inc.php (or custom) to false to get previous count and compare before / after.

---------------------
#### Explaination of diagnostic with ps profiling tool.

I noticed that the main slow query was pointing the sub-categories count. 
So i tried to go deeper and check which request(s) is | are concerned.
I discover that the sub-categories product count was the main issue here and split the process in two
requests (one big as before and a very small to filter results with concerned categories).

---------------------

#### First case - Shop with 200k+ products - 415 categories - Display of category with 5500 products

**Before**
![image](https://github.com/user-attachments/assets/c281817f-40be-4970-914d-713c60131a2a)

**After**
![image](https://github.com/user-attachments/assets/b02c1673-7719-4c35-9087-6d195f3c4290)

As we can see we have following result : 

- **Before** - **11610 ms** with 253980 results - 2195 queries
- **After** - **931 ms** with 3344771556 results - 2196 queries (**12x faster**)
We have one more query to get the categories concerned by the filters after, and then count is filtered
and we have the same results in output.

---------------------

#### Second case - Shop with 5k+ products - 289 categories - Display of category with 700 products

**Before**
![image](https://github.com/user-attachments/assets/c3a83b17-f146-4ef3-bc8d-edd4bbaaf964)


**After**
![image](https://github.com/user-attachments/assets/93fac32f-101d-4a42-9f02-7b224d25fcfc)


As we can see we have following result : 

- **Before** - **3664 ms** with 28896 results - 2009 queries
- **After** - **27.5 ms** with 326163600 results - 2010 queries (**133x faster**)
Same thing one more query to get categories concerned instead of add it in request for count.

---------------------

To be sure that output was the same i had some json exports before after but feel free to make the
same tests and point to me any issue about this and how to reproduce.

There is some conditions remaining to allow us to test ([_PS_FACETED_NEWCOUNT_](https://github.com/202ecommerce/ps_facetedsearch/blob/dev/src/Filters/Block.php#L992)) i can quickly remove
this when all is approved.

**Updated the 2026/06/19** - Tests variables and conditons are now here : 
https://github.com/202ecommerce/ps_facetedsearch/tree/dev-categories-tests

To make easier validation of code there is no more test variable and conditions in this pull request.
If you test this branch, you will see logs files in /var/log/facetedsearch-count-{date}.log

With one GET parameter "newCategoryCount" set to 0 in the category page we will have in the logs
the previous count (time and number of categories).
Without the parameter or set to 1 you will keep this evolution in.
The logs will mention After or Before informations in the results and this allow to be sure that
after and before this update we have the same results.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
