### PR TITLE
Update MySQL.php

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -248,7 +248,7 @@ class MySQL extends AbstractAdapter
             'out_of_stock' => [
                 'tableName' => 'stock_available',
                 'tableAlias' => 'sa',
-                'joinCondition' => '(p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute' .
+                'joinCondition' => '(p.id_product = sa.id_product AND (pac.id_product_attribute = sa.id_product_attribute OR (pac.id_product_attribute IS NULL AND sa.id_product_attribute = 0)) ' .
                 $stockCondition . ')',
                 'joinType' => self::LEFT_JOIN,
                 'dependencyField' => 'id_attribute',
@@ -256,7 +256,7 @@ class MySQL extends AbstractAdapter
             'quantity' => [
                 'tableName' => 'stock_available',
                 'tableAlias' => 'sa',
-                'joinCondition' => '(p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute' .
+                'joinCondition' => '(p.id_product = sa.id_product AND (pac.id_product_attribute = sa.id_product_attribute OR (pac.id_product_attribute IS NULL AND sa.id_product_attribute = 0)) ' .
                 $stockCondition . ')',
                 'joinType' => self::LEFT_JOIN,
                 'dependencyField' => 'id_attribute',


### PR DESCRIPTION
Improves query speed for MySQL 5.7, MariaDB 10.3+

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | improvement| BC breaks?    | yes / no
| Deprecations? | no
| Fixed ticket? | [Fixes PrestaShop/Prestashop#{issue number here](https://github.com/PrestaShop/PrestaShop/issues/35524)}.
| How to test?  | A database with tens of thousands of products is required. MariaDB 11+ is required.
When using a faceted filter and selecting more than one feature, the query execution time exceeds one minute. With this improvement, that time is reduced to hundredths of a second.

