### PR TITLE
Fix category facet so it matches deep subcategories

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -24,6 +24,7 @@ use Category;
 use Configuration;
 use Context;
 use Db;
+use Shop;
 use Manufacturer;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters;
@@ -463,15 +464,28 @@ class Converter
                     break;
                 case self::TYPE_CATEGORY:
                     if (isset($receivedFilters[$filterLabel])) {
+                        // Collect valid names
+                        $requestedNames = [];
                         foreach ($receivedFilters[$filterLabel] as $queryFilter) {
-                            /*
-                             * This works only for categories that are child of the category we are browsing (or home category).
-                             * Categories deeper in the tree will never be found. This could be fixed by providing a unique ID
-                             * to the URL.
-                             */
-                            $categories = Category::searchByNameAndParentCategoryId($idLang, $queryFilter, (int) $idCategory);
-                            if ($categories) {
-                                $searchFilters[$filter['type']][] = $categories['id_category'];
+                            if (is_string($queryFilter) && $queryFilter !== '') {
+                                $requestedNames[] = $queryFilter;
+                            }
+                        }
+
+                        if (!empty($requestedNames)) {
+                            // Batch lookup by subtree; returns name => id_category mapping
+                            $foundMap = $this->findCategoriesByNamesInSubtree($idLang, $requestedNames, (int) $idCategory);
+
+                            foreach ($requestedNames as $queryFilter) {
+                                if (isset($foundMap[$queryFilter])) {
+                                    $searchFilters[$filter['type']][] = (int) $foundMap[$queryFilter];
+                                    continue;
+                                }
+                                // Fallback per-name (SQL single + BFS) if not resolved in batch
+                                $categoryRow = $this->findCategoryByNameInSubtree($idLang, $queryFilter, (int) $idCategory);
+                                if ($categoryRow) {
+                                    $searchFilters[$filter['type']][] = (int) $categoryRow['id_category'];
+                                }
                             }
                         }
                     }
@@ -656,5 +670,150 @@ class Converter
         }
 
         return $positionA <=> $positionB;
+    }
+
+    /**
+     * Find a category by exact name within a given subtree (based on nested set nleft/nright), without core changes.
+     *
+     * @param int $idLang
+     * @param string $categoryName
+     * @param int $idRootCategory
+     *
+     * @return array|false
+     */
+    private function findCategoryByNameInSubtree($idLang, $categoryName, $idRootCategory)
+    {
+        if (!is_string($categoryName) || $categoryName === '') {
+            return false;
+        }
+
+        $interval = Category::getInterval((int) $idRootCategory);
+        if (empty($interval)) {
+            return false;
+        }
+
+        $query = new \DbQuery();
+        $query->select('c.*, cl.*');
+        $query->from('category', 'c');
+        // Shop association equivalent to Shop::addSqlAssociation('category', 'c')
+        $query->leftJoin(
+            'category_shop',
+            'category_shop',
+            'c.`id_category` = category_shop.`id_category` AND category_shop.`id_shop` = ' . (int) $this->context->shop->id
+        );
+        $query->leftJoin(
+            'category_lang',
+            'cl',
+            'c.`id_category` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl')
+        );
+        $query->where("cl.`name` = '" . pSQL($categoryName) . "'");
+        $query->where('c.`nleft` >= ' . (int) $interval['nleft']);
+        $query->where('c.`nright` <= ' . (int) $interval['nright']);
+        $query->where('c.`id_category` != ' . (int) Configuration::get('PS_HOME_CATEGORY'));
+        $query->where('c.`active` = 1');
+        $query->orderBy('c.`level_depth` ASC');
+        $query->limit(1);
+
+        $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
+        if ($row) {
+            return $row;
+        }
+
+        // Fallback: BFS over children if SQL match not found (handles edge cases on older cores/shops setups)
+        return $this->findCategoryByNameInSubtreeFallback($idLang, $categoryName, (int) $idRootCategory);
+    }
+
+    /**
+     * Batch variant: resolve multiple names within the subtree in a single query.
+     * Returns associative map name => id_category (exact matches only).
+     *
+     * @param int $idLang
+     * @param string[] $categoryNames
+     * @param int $idRootCategory
+     *
+     * @return array<string,int>
+     */
+    private function findCategoriesByNamesInSubtree($idLang, array $categoryNames, $idRootCategory)
+    {
+        $cleanNames = [];
+        foreach ($categoryNames as $name) {
+            if (is_string($name) && $name !== '') {
+                $cleanNames[] = pSQL($name);
+            }
+        }
+        if (empty($cleanNames)) {
+            return [];
+        }
+
+        $interval = Category::getInterval((int) $idRootCategory);
+        if (empty($interval)) {
+            return [];
+        }
+
+        $inList = "'" . implode("','", $cleanNames) . "'";
+
+        $query = new \DbQuery();
+        $query->select('c.`id_category`, cl.`name`');
+        $query->from('category', 'c');
+        $query->leftJoin(
+            'category_shop',
+            'category_shop',
+            'c.`id_category` = category_shop.`id_category` AND category_shop.`id_shop` = ' . (int) $this->context->shop->id
+        );
+        $query->leftJoin(
+            'category_lang',
+            'cl',
+            'c.`id_category` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl')
+        );
+        $query->where('cl.`name` IN (' . $inList . ')');
+        $query->where('c.`nleft` >= ' . (int) $interval['nleft']);
+        $query->where('c.`nright` <= ' . (int) $interval['nright']);
+        $query->where('c.`id_category` != ' . (int) Configuration::get('PS_HOME_CATEGORY'));
+        $query->where('c.`active` = 1');
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query) ?: [];
+        $map = [];
+        foreach ($rows as $row) {
+            // exact name mapping, first match wins (the query is subtree-scoped)
+            if (!isset($map[$row['name']])) {
+                $map[$row['name']] = (int) $row['id_category'];
+            }
+        }
+        return $map;
+    }
+
+    /**
+     * Fallback traversal when SQL subtree lookup finds nothing: breadth-first search by children.
+     *
+     * @param int $idLang
+     * @param string $categoryName
+     * @param int $idRootCategory
+     *
+     * @return array|false
+     */
+    private function findCategoryByNameInSubtreeFallback($idLang, $categoryName, $idRootCategory)
+    {
+        $queue = [(int) $idRootCategory];
+        $visited = [];
+
+        while (!empty($queue)) {
+            $currentId = array_shift($queue);
+            if (isset($visited[$currentId])) {
+                continue;
+            }
+            $visited[$currentId] = true;
+
+            $match = Category::searchByNameAndParentCategoryId($idLang, $categoryName, (int) $currentId);
+            if ($match && isset($match['id_category'])) {
+                return $match;
+            }
+
+            $children = Category::getChildren((int) $currentId, $idLang);
+            foreach ($children as $child) {
+                $queue[] = (int) $child['id_category'];
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -473,18 +473,12 @@ class Converter
                         }
 
                         if (!empty($requestedNames)) {
-                            // Batch lookup by subtree; returns name => id_category mapping
+                            // One subtree-scoped lookup resolves every requested name.
                             $foundMap = $this->findCategoriesByNamesInSubtree($idLang, $requestedNames, (int) $idCategory);
 
                             foreach ($requestedNames as $queryFilter) {
                                 if (isset($foundMap[$queryFilter])) {
                                     $searchFilters[$filter['type']][] = (int) $foundMap[$queryFilter];
-                                    continue;
-                                }
-                                // Fallback per-name (SQL single + BFS) if not resolved in batch
-                                $categoryRow = $this->findCategoryByNameInSubtree($idLang, $queryFilter, (int) $idCategory);
-                                if ($categoryRow) {
-                                    $searchFilters[$filter['type']][] = (int) $categoryRow['id_category'];
                                 }
                             }
                         }
@@ -673,65 +667,20 @@ class Converter
     }
 
     /**
-     * Find a category by exact name within a given subtree (based on nested set nleft/nright), without core changes.
+     * Resolve category names to ids within the subtree of the browsed category.
      *
-     * @param int $idLang
-     * @param string $categoryName
-     * @param int $idRootCategory
+     * Scoped with the nested set bounds so categories deeper than the direct children are found
+     * too, which is what makes the facet usable when the category filter depth is not 1.
      *
-     * @return array|false
-     */
-    private function findCategoryByNameInSubtree($idLang, $categoryName, $idRootCategory)
-    {
-        if (!is_string($categoryName) || $categoryName === '') {
-            return false;
-        }
-
-        $interval = Category::getInterval((int) $idRootCategory);
-        if (empty($interval)) {
-            return false;
-        }
-
-        $query = new \DbQuery();
-        $query->select('c.*, cl.*');
-        $query->from('category', 'c');
-        // Shop association equivalent to Shop::addSqlAssociation('category', 'c')
-        $query->leftJoin(
-            'category_shop',
-            'category_shop',
-            'c.`id_category` = category_shop.`id_category` AND category_shop.`id_shop` = ' . (int) $this->context->shop->id
-        );
-        $query->leftJoin(
-            'category_lang',
-            'cl',
-            'c.`id_category` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl')
-        );
-        $query->where("cl.`name` = '" . pSQL($categoryName) . "'");
-        $query->where('c.`nleft` >= ' . (int) $interval['nleft']);
-        $query->where('c.`nright` <= ' . (int) $interval['nright']);
-        $query->where('c.`id_category` != ' . (int) Configuration::get('PS_HOME_CATEGORY'));
-        $query->where('c.`active` = 1');
-        $query->orderBy('c.`level_depth` ASC');
-        $query->limit(1);
-
-        $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
-        if ($row) {
-            return $row;
-        }
-
-        // Fallback: BFS over children if SQL match not found (handles edge cases on older cores/shops setups)
-        return $this->findCategoryByNameInSubtreeFallback($idLang, $categoryName, (int) $idRootCategory);
-    }
-
-    /**
-     * Batch variant: resolve multiple names within the subtree in a single query.
-     * Returns associative map name => id_category (exact matches only).
+     * Names are not unique in a tree, so the order below decides which category a duplicated name
+     * resolves to: the shallowest one, then the lowest id. Any tie-break would be arbitrary, this
+     * one is at least stable. Telling two same-named categories apart needs an id in the URL.
      *
      * @param int $idLang
      * @param string[] $categoryNames
      * @param int $idRootCategory
      *
-     * @return array<string,int>
+     * @return array<string,int> name => id_category
      */
     private function findCategoriesByNamesInSubtree($idLang, array $categoryNames, $idRootCategory)
     {
@@ -750,70 +699,33 @@ class Converter
             return [];
         }
 
-        $inList = "'" . implode("','", $cleanNames) . "'";
-
         $query = new \DbQuery();
         $query->select('c.`id_category`, cl.`name`');
         $query->from('category', 'c');
-        $query->leftJoin(
+        $query->innerJoin(
             'category_shop',
-            'category_shop',
-            'c.`id_category` = category_shop.`id_category` AND category_shop.`id_shop` = ' . (int) $this->context->shop->id
+            'cs',
+            'cs.`id_category` = c.`id_category` AND cs.`id_shop` = ' . (int) $this->context->shop->id
         );
-        $query->leftJoin(
+        $query->innerJoin(
             'category_lang',
             'cl',
             'c.`id_category` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl')
         );
-        $query->where('cl.`name` IN (' . $inList . ')');
+        $query->where("cl.`name` IN ('" . implode("','", $cleanNames) . "')");
         $query->where('c.`nleft` >= ' . (int) $interval['nleft']);
         $query->where('c.`nright` <= ' . (int) $interval['nright']);
         $query->where('c.`id_category` != ' . (int) Configuration::get('PS_HOME_CATEGORY'));
         $query->where('c.`active` = 1');
+        $query->orderBy('c.`level_depth` ASC, c.`id_category` ASC');
 
-        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query) ?: [];
         $map = [];
-        foreach ($rows as $row) {
-            // exact name mapping, first match wins (the query is subtree-scoped)
+        foreach (Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query) ?: [] as $row) {
             if (!isset($map[$row['name']])) {
                 $map[$row['name']] = (int) $row['id_category'];
             }
         }
+
         return $map;
-    }
-
-    /**
-     * Fallback traversal when SQL subtree lookup finds nothing: breadth-first search by children.
-     *
-     * @param int $idLang
-     * @param string $categoryName
-     * @param int $idRootCategory
-     *
-     * @return array|false
-     */
-    private function findCategoryByNameInSubtreeFallback($idLang, $categoryName, $idRootCategory)
-    {
-        $queue = [(int) $idRootCategory];
-        $visited = [];
-
-        while (!empty($queue)) {
-            $currentId = array_shift($queue);
-            if (isset($visited[$currentId])) {
-                continue;
-            }
-            $visited[$currentId] = true;
-
-            $match = Category::searchByNameAndParentCategoryId($idLang, $categoryName, (int) $currentId);
-            if ($match && isset($match['id_category'])) {
-                return $match;
-            }
-
-            $children = Category::getChildren((int) $currentId, $idLang);
-            foreach ($children as $child) {
-                $queue[] = (int) $child['id_category'];
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -24,7 +24,6 @@ use Category;
 use Configuration;
 use Context;
 use Db;
-use Shop;
 use Manufacturer;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters;
@@ -32,6 +31,7 @@ use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
+use Shop;
 
 class Converter
 {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | ps_facetedsearch: fix category facet so it matches deep subcategories (not only direct children). Implemented entirely in module to keep backward compatibility with PS 1.7/8/9. Uses a single subtree-scoped query (nleft/nright) to resolve category names within the current category subtree. Adds a batch multi-name lookup to minimize DB round-trips and a safe BFS fallback when needed.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [PrestaShop/Prestashop#29727](https://github.com/PrestaShop/PrestaShop/issues/29727).
| How to test?      | 1) Enable ps_facetedsearch and the “Categories” facet. <br/>2) Create a tree: Parent (P) → Child (C) → Grandchild (G). Assign products to all categories <br/>3) Rebuild the module’s index and clear cache. <br/>4) Go to FO category page of P. <br/>5) In the Categories facet, select G. Expected: product list shows only products from G (previously deeper subcategories were not matched).
| Sponsor company   | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
