### PR TITLE
Fix: Texture as product attribute don't appear in the facet filter

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -155,10 +155,10 @@ class Converter
                         }
 
                         if (isset($filterArray['color'])) {
-                            if ($filterArray['color'] != '') {
-                                $filter->setProperty(self::PROPERTY_COLOR, $filterArray['color']);
-                            } elseif (file_exists(_PS_COL_IMG_DIR_ . $id . '.jpg')) {
+                            if (file_exists(_PS_COL_IMG_DIR_ . $id . '.jpg')) {
                                 $filter->setProperty(self::PROPERTY_TEXTURE, _THEME_COL_DIR_ . $id . '.jpg');
+                            } elseif ($filterArray['color'] != '') {
+                                $filter->setProperty(self::PROPERTY_COLOR, $filterArray['color']);
                             }
                         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/39378. This change was suggested by @web-burn.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/Prestashop#39378
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/39378
| Sponsor company   | @Codencode 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
