### PR TITLE
feat: add hooks to extend faceted search filters and supported contro…

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1726,7 +1726,7 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
 
     public function initializeSupportedControllers()
     {
-        $this->setSupportedControllers([
+        $supportedControllers = [
             'category' => [
                 'name' => $this->trans('Category', [], 'Modules.Facetedsearch.Admin'),
                 'cacheable' => true,
@@ -1755,6 +1755,23 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                 'name' => $this->trans('Search', [], 'Modules.Facetedsearch.Admin'),
                 'cacheable' => false,
             ],
-        ]);
+        ];
+
+        $additionalSupportedControllers = Hook::exec(
+            'actionFacetedSearchSetSupportedControllers',
+            [],
+            null,
+            true,
+            true,
+            false,
+            null,
+            true
+        );
+
+        if ($additionalSupportedControllers && is_array($additionalSupportedControllers)) {
+            $supportedControllers = array_merge($supportedControllers, $additionalSupportedControllers);
+        }
+
+        $this->setSupportedControllers($supportedControllers);
     }
 }

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1757,20 +1757,12 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
             ],
         ];
 
-        $additionalSupportedControllers = Hook::exec(
+        Hook::exec(
             'actionFacetedSearchSetSupportedControllers',
-            [],
-            null,
-            true,
-            true,
-            false,
-            null,
-            true
+            [
+                'supportedControllers' => &$supportedControllers,
+            ]
         );
-
-        if ($additionalSupportedControllers && is_array($additionalSupportedControllers)) {
-            $supportedControllers = array_merge($supportedControllers, $additionalSupportedControllers);
-        }
 
         $this->setSupportedControllers($supportedControllers);
     }

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -25,6 +25,7 @@ use Configuration;
 use Context;
 use FrontController;
 use Group;
+use Hook;
 use PrestaShop\Module\FacetedSearch\Adapter\AbstractAdapter;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL as MySQLAdapter;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
@@ -450,6 +451,14 @@ class Search
                 empty($productPool) ? ['NULL'] : $productPool
             );
         }
+
+        Hook::exec(
+            'actionFacetedSearchFilters',
+            [
+                'search' => $this,
+                'query' => $this->query,
+            ]
+        );
     }
 
     /**

--- a/tests/php/FacetedSearch/MockProxy.php
+++ b/tests/php/FacetedSearch/MockProxy.php
@@ -144,3 +144,9 @@ class FrontController extends MockProxy
     // Redeclare to use this instead MockProxy::mock
     protected static $mock;
 }
+
+class Hook extends MockProxy
+{
+    // Redeclare to use this instead of MockProxy::$mock
+    protected static $mock;
+}

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -24,6 +24,7 @@ use Configuration;
 use Context;
 use FrontController;
 use Group;
+use Hook;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
@@ -93,6 +94,11 @@ class SearchTest extends MockeryTestCase
             ->andReturn('category');
 
         $this->search->setQuery($query);
+
+        $hookMock = Mockery::mock(Hook::class);
+        $hookMock->shouldReceive('exec')
+            ->andReturn([]);
+        Hook::setStaticExpectations($hookMock);
     }
 
     public function testGetFacetedSearchTypeAdapter()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | This PR aims to make the module more flexible by allowing the use of filters in ad hoc controllers developed by other modules. Two new hooks have been added: `actionFacetedSearchSetSupportedControllers`: allows adding a new controller to display it in the filter template configuration, `actionFacetedSearchFilters`: allows setting the starting filter on which "to apply the filters."
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      |1. Install the module [cnc_sampleproductlisting.zip](https://github.com/user-attachments/files/21950718/cnc_sampleproductlisting.zip) - 2. - Edit template filter (in configuration of Faceted search module) and select new page controller **Product listing filters** - 3. go to module configuration of cnc_sampleproductlisting module - 4. Copy the URL Link listing controller and open it in the browser - 5.View product with id 1,2,3,4 which are the products that the module sets in the display using the "hookActionFacetedSearchFilters" hook. - 6. Interact with the filters to verify that the system applies the filters only to the 4 products.
| Sponsor company   | @Codencode 

### This is the template configuration page
The new controller created by the sample module appears here.
<img width="1903" height="955" alt="edit-tilter-template" src="https://github.com/user-attachments/assets/bff4ed02-74bd-429d-b338-51809adb2e00" />

### This is the page of the front controller created by the sample module.


<img width="1903" height="955" alt="front-controller" src="https://github.com/user-attachments/assets/37b35075-656f-4646-92b1-f577c0501301" />

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
