### PR TITLE
Remove condition to get currency

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -1030,71 +1030,29 @@ class Block
      */
     private function preparePriceSpecifications()
     {
-        /* @var Currency */
-        $currency = $this->context->currency;
-        // New method since PS 1.7.6
-        if (isset($this->context->currentLocale) && method_exists($this->context->currentLocale, 'getPriceSpecification')) {
-            /* @var PriceSpecification */
-            $priceSpecification = $this->context->currentLocale->getPriceSpecification($currency->iso_code);
-            /* @var NumberSymbolList */
-            $symbolList = $priceSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN);
+        /* @var PriceSpecification */
+        $priceSpecification = $this->context->currentLocale->getPriceSpecification($this->context->currency->iso_code);
 
-            $symbol = [
-                $symbolList->getDecimal(),
-                $symbolList->getGroup(),
-                $symbolList->getList(),
-                $symbolList->getPercentSign(),
-                $symbolList->getMinusSign(),
-                $symbolList->getPlusSign(),
-                $symbolList->getExponential(),
-                $symbolList->getSuperscriptingExponent(),
-                $symbolList->getPerMille(),
-                $symbolList->getInfinity(),
-                $symbolList->getNaN(),
-            ];
+        /* @var NumberSymbolList */
+        $symbolList = $priceSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN);
 
-            return array_merge(
-                ['symbol' => $symbol],
-                $priceSpecification->toArray()
-            );
-        }
-
-        // Default symbol configuration
         $symbol = [
-            '.',
-            ',',
-            ';',
-            '%',
-            '-',
-            '+',
-            'E',
-            '×',
-            '‰',
-            '∞',
-            'NaN',
+            $symbolList->getDecimal(),
+            $symbolList->getGroup(),
+            $symbolList->getList(),
+            $symbolList->getPercentSign(),
+            $symbolList->getMinusSign(),
+            $symbolList->getPlusSign(),
+            $symbolList->getExponential(),
+            $symbolList->getSuperscriptingExponent(),
+            $symbolList->getPerMille(),
+            $symbolList->getInfinity(),
+            $symbolList->getNaN(),
         ];
-        // The property `$precision` exists only from PS 1.7.6. On previous versions, all prices have 2 decimals
-        $precision = isset($currency->precision) ? $currency->precision : 2;
-        $formats = explode(';', $currency->format);
-        if (count($formats) > 1) {
-            $positivePattern = $formats[0];
-            $negativePattern = $formats[1];
-        } else {
-            $positivePattern = $currency->format;
-            $negativePattern = $currency->format;
-        }
 
-        return [
-            'positivePattern' => $positivePattern,
-            'negativePattern' => $negativePattern,
-            'symbol' => $symbol,
-            'maxFractionDigits' => $precision,
-            'minFractionDigits' => $precision,
-            'groupingUsed' => true,
-            'primaryGroupSize' => 3,
-            'secondaryGroupSize' => 3,
-            'currencyCode' => $currency->iso_code,
-            'currencySymbol' => $currency->sign,
-        ];
+        return array_merge(
+            ['symbol' => $symbol],
+            $priceSpecification->toArray()
+        );
     }
 }

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -25,6 +25,7 @@ use Configuration;
 use Context;
 use Db;
 use Group;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Manufacturer;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -73,6 +74,13 @@ class BlockTest extends MockeryTestCase
 
         Configuration::setStaticExpectations($mock);
 
+        // Mock locale
+        $locale = Mockery::mock(Locale::class);
+        $locale->shouldReceive('getPriceSpecification')
+            ->with('EUR')
+            ->andReturn($this->getPriceSpecificationMock());
+        
+        // Mock context
         $this->contextMock = Mockery::mock(Context::class);
         $this->contextMock->shop = new stdClass();
         $this->contextMock->shop->id = 1;
@@ -87,7 +95,9 @@ class BlockTest extends MockeryTestCase
         $this->contextMock->currency->id = 4;
         $this->contextMock->customer = new stdClass();
         $this->contextMock->customer->id_default_group = 5;
+        $this->contextMock->currentLocale = $locale;
 
+        // Add context getter
         $this->contextMock->shouldReceive('getContext')
             ->andReturn($this->contextMock);
         Context::setStaticExpectations($this->contextMock);
@@ -1177,5 +1187,39 @@ class BlockTest extends MockeryTestCase
             AND id_shop = 1
             GROUP BY `type`, id_value ORDER BY position ASC')
             ->andReturn($result);
+    }
+
+    private function getPriceSpecificationMock()
+    {
+        // Mock symbols
+        $symbolList = Mockery::mock(SymbolList::class);
+        $symbolList->shouldReceive('getDecimal')->andReturn('.');
+        $symbolList->shouldReceive('getGroup')->andReturn(',');
+        $symbolList->shouldReceive('getList')->andReturn(';');
+        $symbolList->shouldReceive('getPercentSign')->andReturn('%');
+        $symbolList->shouldReceive('getMinusSign')->andReturn('-');
+        $symbolList->shouldReceive('getPlusSign')->andReturn('+');
+        $symbolList->shouldReceive('getExponential')->andReturn('E');
+        $symbolList->shouldReceive('getSuperscriptingExponent')->andReturn('×');
+        $symbolList->shouldReceive('getPerMille')->andReturn('‰');
+        $symbolList->shouldReceive('getInfinity')->andReturn('∞');
+        $symbolList->shouldReceive('getNaN')->andReturn('NaN');
+
+        // Mock specification of prices
+        $priceSpecification = Mockery::mock(PriceSpecification::class);
+        $priceSpecification->shouldReceive('getSymbolsByNumberingSystem')->andReturn($symbolList);
+        $priceSpecification->shouldReceive('toArray')->andReturn([
+            'currencyCode' => 'EUR',
+            'currencySymbol' => '€',
+            'positivePattern' => '##,##',
+            'negativePattern' => '##,##',
+            'maxFractionDigits' => 2,
+            'minFractionDigits' => 2,
+            'groupingUsed' => true,
+            'primaryGroupSize' => 3,
+            'secondaryGroupSize' => 3,
+        ]);
+
+        return $priceSpecification;
     }
 }

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -25,7 +25,6 @@ use Configuration;
 use Context;
 use Db;
 use Group;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Manufacturer;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -34,6 +33,7 @@ use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters\Block;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\Filters\Provider;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use Shop;
@@ -79,7 +79,7 @@ class BlockTest extends MockeryTestCase
         $locale->shouldReceive('getPriceSpecification')
             ->with('EUR')
             ->andReturn($this->getPriceSpecificationMock());
-        
+
         // Mock context
         $this->contextMock = Mockery::mock(Context::class);
         $this->contextMock->shop = new stdClass();

--- a/tests/php/FacetedSearch/Mock/Locale.php
+++ b/tests/php/FacetedSearch/Mock/Locale.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization;
+
+class Locale
+{
+    public const NUMBERING_SYSTEM_LATIN = 'latn';
+}

--- a/tests/php/FacetedSearch/MockProxy.php
+++ b/tests/php/FacetedSearch/MockProxy.php
@@ -17,7 +17,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
-
 class MockProxy
 {
     protected static $mock;

--- a/tests/php/FacetedSearch/MockProxy.php
+++ b/tests/php/FacetedSearch/MockProxy.php
@@ -17,6 +17,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
 class MockProxy
 {
     protected static $mock;

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -4,6 +4,7 @@
 require __DIR__ . '/../../vendor/autoload.php';
 
 require_once __DIR__ . '/FacetedSearch/MockProxy.php';
+require_once __DIR__ . '/FacetedSearch/Mock/Locale.php';
 require_once __DIR__ . '/FacetedSearch/Mock/Filter.php';
 require_once __DIR__ . '/FacetedSearch/Mock/Facet.php';
 require_once __DIR__ . '/FacetedSearch/Interface/WidgetInterface.php';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | New take on https://github.com/PrestaShop/ps_facetedsearch/pull/784 - to remove code that is used only in tests. We always have this method available now. When getting price specifications, there was a condition that checkes if price specs can be retrieved in the "new way", since 1.7.6, `if (isset($this->context->currentLocale) && method_exists($this->context->currentLocale, 'getPriceSpecification')) {`, or if it should return some hardcoded fallback specifications. Because the minimum supported version is 1.7.6, this condition is no longer needed and the hardcoded price specs below were used only in tests.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Just install it and see that price filter works fine in FO. :-) 
| Sponsor company   | TRENDO s.r.o.