### PR TITLE
feat: added 'actionFacetedSearchCacheKeyGeneration' hook

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\FacetedSearch\Product;
 
 use Configuration;
+use Hook;
 use PrestaShop\Module\FacetedSearch\Filters;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
@@ -258,6 +259,15 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         } elseif ($query->getQueryType() == 'supplier') {
             $filterKey .= $query->getIdSupplier();
         }
+
+        Hook::exec(
+            'actionFacetedSearchCacheKeyGeneration',
+            [
+                'filterKey' => &$filterKey,
+                'query' => $query,
+                'facetedSearchFilters' => &$facetedSearchFilters,
+            ]
+        );
 
         $filterHash = md5(
             sprintf(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | This PR adds the new hook `actionFacetedSearchCacheKeyGeneration`, which aims to improve integration with PR https://github.com/PrestaShop/ps_facetedsearch/pull/1170 since it did not take caching into account.<br/> The hook was suggested by @mathieuhen in this comment: https://github.com/PrestaShop/ps_facetedsearch/pull/1170#issuecomment-3589488196
| Type?             | improvement 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | 
| How to test?      | ⬇️ 
| Related PR | https://github.com/PrestaShop/ps_facetedsearch/pull/1170
| Sponsor company   | Codencode snc

---
### How to test? 
1.  Go to _Catalog > Attributes & Features > Features_
2. Create the feature **New feature**
3. Add the values **Feature 1** and **Feature 2** to the created feature
4. Assign the feature **New feature > Feature 1** to products ID **1** and **2**
5. Assign the feature **New feature > Feature 2** to products ID **6** and **7**
6. Install the module [cnc_sampleproductlisting.zip](https://github.com/user-attachments/files/23850370/cnc_sampleproductlisting.zip)
7. Go to _Modules > Module Manager > Faceted search_
8. In **Configuration**, ensure that **Enable cache system** is active
9. Edit the only existing template
10. In Pages using this template, select Product listing filters; in Filters, enable only **Feature: New feature**
11. Go to _Design > Theme & Logo > Choose Layouts_
12. For the pages **Product listing filters** and **Product listing filters 2**, select **Two Columns, small left column - Two columns with a small left column** and save
13. Access the configuration of the **cnc_sampleproductlisting** module
14. Open the displayed links
15. In the first link, you should see **Feature 1** in the filters; in the second, you should see **Feature 2**
16. Without this PR, you would instead see the same filter on both pages.
---
### Screenshot without PR
_In the two screenshots, you can see that the filters always show Feature 2 (CACHE ERROR)._

**List 1**
<img width="1903" height="898" alt="List 1 - without PR" src="https://github.com/user-attachments/assets/8e0c08cc-f205-4802-a949-76d02f1130c6" />
**List 2**
<img width="1903" height="547" alt="List 2 - without PR" src="https://github.com/user-attachments/assets/d78d5eb0-8723-4252-b561-31edf6d4a1ee" />

### Screenshot with PR
_In the two screenshots, you can see that the filters differ between the two pages._

**List 1**
<img width="1903" height="547" alt="List 1 - with PR" src="https://github.com/user-attachments/assets/80588c0d-e64b-4999-ab19-c159581690b6" />
**List 2**
<img width="1903" height="898" alt="List 2 - with PR" src="https://github.com/user-attachments/assets/3a7dbcce-1771-477c-8957-740b6468c44e" />

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
