### PR TITLE
Remove annoying category behavior

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[4.0.2]]></version>
+    <version><![CDATA[4.0.3]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -96,7 +96,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '4.0.2';
+        $this->version = '4.0.3';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;

--- a/src/Hook/Category.php
+++ b/src/Hook/Category.php
@@ -28,7 +28,6 @@ class Category extends AbstractHook
     const AVAILABLE_HOOKS = [
         'actionCategoryAdd',
         'actionCategoryDelete',
-        'actionCategoryUpdate',
     ];
 
     /**
@@ -42,22 +41,6 @@ class Category extends AbstractHook
 
         // Flush filter block cache in all cases, so a new category shows up
         $this->module->invalidateLayeredFilterBlockCache();
-    }
-
-    /**
-     * Category update
-     *
-     * @param array $params
-     */
-    public function actionCategoryUpdate(array $params)
-    {
-        /*
-         * The category status might (active, inactive) have changed,
-         * we have to update the layered cache table structure.
-         */
-        if (isset($params['category']) && !$params['category']->active) {
-            $this->removeCategoryFromFilterTemplates((int) $params['category']->id);
-        }
     }
 
     /**

--- a/tests/php/FacetedSearch/HookDispatcherTest.php
+++ b/tests/php/FacetedSearch/HookDispatcherTest.php
@@ -47,7 +47,7 @@ class HookDispatcherTest extends MockeryTestCase
 
     public function testGetAvailableHooks()
     {
-        $this->assertCount(39, $this->dispatcher->getAvailableHooks());
+        $this->assertCount(38, $this->dispatcher->getAvailableHooks());
         $this->assertEquals(
             [
                 'actionAttributeGroupDelete',

--- a/tests/php/FacetedSearch/HookDispatcherTest.php
+++ b/tests/php/FacetedSearch/HookDispatcherTest.php
@@ -68,7 +68,6 @@ class HookDispatcherTest extends MockeryTestCase
                 'actionAfterUpdateAttributeGroupFormHandler',
                 'actionCategoryAdd',
                 'actionCategoryDelete',
-                'actionCategoryUpdate',
                 'actionProductPreferencesPageStockSave',
                 'displayLeftColumn',
                 'actionFeatureSave',

--- a/upgrade/upgrade-4.0.3.php
+++ b/upgrade/upgrade-4.0.3.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_0_3(Ps_Facetedsearch $module)
+{
+    return $module->unregisterHook('actionCategoryUpdate');
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | When you disable a category, faceted search automatically permanently removes it from all filter templates, for no reason. The category is disabled anyway, the query is not executed. The only thing this does is that you have to re-add this category like an idiot after you re-enable it. :-)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Disable category Men, enable category Men, see that filters are still there.
| Sponsor company   | 
