### PR TITLE
BestSellers from X days

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -160,6 +160,7 @@ class MySQL extends AbstractAdapter
             null,
             'sa'
         );
+        $BestSellersDays = (!Configuration::get('PS_BEST_SELLERS_DAYS')) ? '' : 'AND DATEDIFF(CURRENT_DATE(), psales.date_upd) <= ' . Configuration::get('PS_BEST_SELLERS_DAYS');
 
         $filterToTableMapping = [
             'id_product_attribute' => [
@@ -313,7 +314,7 @@ class MySQL extends AbstractAdapter
                 'tableAlias' => 'psales',
                 'fieldName' => 'quantity',
                 'fieldAlias' => 'sales',
-                'joinCondition' => '(psales.id_product = p.id_product)',
+                'joinCondition' => '(psales.id_product = p.id_product ' . $BestSellersDays . ')',
                 'joinType' => self::LEFT_JOIN,
             ],
             'reduction' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Allows to load BestSellers from last X days set by user. By default it loads all products sorted by sale. With this change displays products in a more dynamic way.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/pull/41283
| How to test?      | 
| Sponsor company   | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
