### PR TITLE
product price indexation omit country

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -210,7 +210,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', 0);
-            Configuration::updateValue('PS_LAYERED_OMIT_COUNTRIES', 0);
+            Configuration::updateValue('PS_LAYERED_INDEX_COUNTRIES', 1);
 
             $this->psLayeredFullTree = 1;
 
@@ -401,7 +401,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
         }
 
-        $omit_countries = (bool) Configuration::get('PS_LAYERED_OMIT_COUNTRIES');
+        $index_countries = (bool) Configuration::get('PS_LAYERED_INDEX_COUNTRIES');
 
         $shopList = Shop::getShops(false, null, true);
 
@@ -424,19 +424,19 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 'LEFT JOIN `' . _DB_PREFIX_ . 'tax` t ON (t.id_tax = tr.id_tax AND t.active = 1) ' .
                 'JOIN `' . _DB_PREFIX_ . 'country` c ON (tr.id_country=c.id_country AND c.active = 1) ' .
                 'WHERE id_product = ' . (int) $idProduct . ' ' .
-                ($omit_countries ? 'AND c.id_country = ' . (int) Configuration::get('PS_COUNTRY_DEFAULT') : '') . ' ' .
+                ($index_countries ? '' : 'AND c.id_country = 0 ') .
                 'GROUP BY id_product, tr.id_country'
             );
 
             if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                if ($omit_countries) {
-                    $shopCountries = [[
-                        'id_country' => (int) Configuration::get('PS_COUNTRY_DEFAULT'),
-                        'active' => 1,
-                        'iso_code' => Country::getIsoById((int) Configuration::get('PS_COUNTRY_DEFAULT')),
-                    ]];
-                } else {
+                if ($index_countries) {
                     $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+                } else {
+                    $shopCountries = [[
+                        'id_country' => 0,
+                        'active' => 1,
+                        'iso_code' => '',
+                    ]];
                 }
 
                 $taxCountries = array_filter($shopCountries, function ($country) {
@@ -457,7 +457,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 WHERE id_product = ' . (int) $idProduct . ' AND id_shop IN (0,' . (int) $idShop . ')'
             );
 
-            if ($omit_countries) {
+            if ($index_countries) {
                 $countries = [['id_country' => (int) Configuration::get('PS_COUNTRY_DEFAULT')]];
             } else {
                 $countries = Country::getCountries($this->getContext()->language->id, true, false, false);
@@ -731,7 +731,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
-            Configuration::updateValue('PS_LAYERED_OMIT_COUNTRIES', (int) Tools::getValue('ps_layered_omit_countries'));
+            Configuration::updateValue('PS_LAYERED_INDEX_COUNTRIES', (int) Tools::getValue('ps_layered_index_countries'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -831,7 +831,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
             'add_new_filters_template_link' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1]),
-            'omit_countries' => Configuration::get('PS_LAYERED_OMIT_COUNTRIES'),
+            'index_countries' => (bool) Configuration::get('PS_LAYERED_INDEX_COUNTRIES'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -210,6 +210,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', 0);
+            Configuration::updateValue('PS_LAYERED_OMIT_COUNTRIES', 0);
 
             $this->psLayeredFullTree = 1;
 
@@ -400,6 +401,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
         }
 
+        $omit_countries = (bool) Configuration::get('PS_LAYERED_OMIT_COUNTRIES');
+
         $shopList = Shop::getShops(false, null, true);
 
         foreach ($shopList as $idShop) {
@@ -421,11 +424,21 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 'LEFT JOIN `' . _DB_PREFIX_ . 'tax` t ON (t.id_tax = tr.id_tax AND t.active = 1) ' .
                 'JOIN `' . _DB_PREFIX_ . 'country` c ON (tr.id_country=c.id_country AND c.active = 1) ' .
                 'WHERE id_product = ' . (int) $idProduct . ' ' .
+                ($omit_countries ? 'AND c.id_country = ' . (int) Configuration::get('PS_COUNTRY_DEFAULT') : '') . ' ' .
                 'GROUP BY id_product, tr.id_country'
             );
 
             if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+                if ($omit_countries) {
+                    $shopCountries = [[
+                        'id_country' => (int) Configuration::get('PS_COUNTRY_DEFAULT'),
+                        'active' => 1,
+                        'iso_code' => Country::getIsoById((int) Configuration::get('PS_COUNTRY_DEFAULT')),
+                    ]];
+                } else {
+                    $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+                }
+
                 $taxCountries = array_filter($shopCountries, function ($country) {
                     return $country['active'];
                 });
@@ -444,7 +457,12 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 WHERE id_product = ' . (int) $idProduct . ' AND id_shop IN (0,' . (int) $idShop . ')'
             );
 
-            $countries = Country::getCountries($this->getContext()->language->id, true, false, false);
+            if ($omit_countries) {
+                $countries = [['id_country' => (int) Configuration::get('PS_COUNTRY_DEFAULT')]];
+            } else {
+                $countries = Country::getCountries($this->getContext()->language->id, true, false, false);
+            }
+
             foreach ($countries as $country) {
                 $idCountry = $country['id_country'];
 
@@ -713,6 +731,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
+            Configuration::updateValue('PS_LAYERED_OMIT_COUNTRIES', (int) Tools::getValue('ps_layered_omit_countries'));
 
             $this->psLayeredFullTree = (int) Tools::getValue('ps_layered_full_tree');
 
@@ -812,6 +831,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
             'add_new_filters_template_link' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1]),
+            'omit_countries' => Configuration::get('PS_LAYERED_OMIT_COUNTRIES'),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -201,6 +201,14 @@ class MySQL extends AbstractAdapter
             $featureJoinExtra = ['dependencyField' => 'id_product_attribute'];
         }
 
+        $omit_countries = (bool) Configuration::get('PS_LAYERED_OMIT_COUNTRIES');
+
+        if (!$omit_countries) {
+            $countryCondition = ' AND psi.id_country = ' . $this->getContext()->country->id;
+        } else {
+            $countryCondition = ' AND psi.id_country = ' . (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        }
+
         $filterToTableMapping = [
             'id_product_attribute' => [
                 'tableName' => 'product_attribute',
@@ -329,28 +337,28 @@ class MySQL extends AbstractAdapter
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
                 'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                $this->getContext()->currency->id . $countryCondition . ')',
                 'joinType' => self::INNER_JOIN,
             ],
             'price_max' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
                 'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                $this->getContext()->currency->id . $countryCondition . ')',
                 'joinType' => self::INNER_JOIN,
             ],
             'range_start' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
                 'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                $this->getContext()->currency->id . $countryCondition . ')',
                 'joinType' => self::INNER_JOIN,
             ],
             'range_end' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
                 'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                $this->getContext()->currency->id . $countryCondition . ')',
                 'joinType' => self::INNER_JOIN,
             ],
             'id_group' => [

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -201,12 +201,12 @@ class MySQL extends AbstractAdapter
             $featureJoinExtra = ['dependencyField' => 'id_product_attribute'];
         }
 
-        $omit_countries = (bool) Configuration::get('PS_LAYERED_OMIT_COUNTRIES');
+        $index_countries = (bool) Configuration::get('PS_LAYERED_INDEX_COUNTRIES');
 
-        if (!$omit_countries) {
-            $countryCondition = ' AND psi.id_country = ' . $this->getContext()->country->id;
-        } else {
+        if (!$index_countries) {
             $countryCondition = ' AND psi.id_country = ' . (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        } else {
+            $countryCondition = ' AND psi.id_country = 0';
         }
 
         $filterToTableMapping = [
@@ -380,17 +380,17 @@ class MySQL extends AbstractAdapter
                 'tableName' => 'specific_price',
                 'tableAlias' => 'sp',
                 'joinCondition' => '(
-                    sp.id_product = p.id_product AND 
-                    sp.id_shop IN (0, ' . $this->getContext()->shop->id . ') AND 
-                    sp.id_currency IN (0, ' . $this->getContext()->currency->id . ') AND 
-                    sp.id_country IN (0, ' . $this->getContext()->country->id . ') AND 
-                    sp.id_group IN (0, ' . $this->getContext()->customer->id_default_group . ') AND 
+                    sp.id_product = p.id_product AND
+                    sp.id_shop IN (0, ' . $this->getContext()->shop->id . ') AND
+                    sp.id_currency IN (0, ' . $this->getContext()->currency->id . ') AND
+                    sp.id_country IN (0, ' . $this->getContext()->country->id . ') AND
+                    sp.id_group IN (0, ' . $this->getContext()->customer->id_default_group . ') AND
                     sp.from_quantity = 1 AND
                     sp.reduction > 0 AND
                     sp.id_customer = 0 AND
-                    sp.id_cart = 0 AND 
-                    (sp.from = \'0000-00-00 00:00:00\' OR \'' . date('Y-m-d H:i:s') . '\' >= sp.from) AND 
-                    (sp.to = \'0000-00-00 00:00:00\' OR \'' . date('Y-m-d H:i:s') . '\' <= sp.to) 
+                    sp.id_cart = 0 AND
+                    (sp.from = \'0000-00-00 00:00:00\' OR \'' . date('Y-m-d H:i:s') . '\' >= sp.from) AND
+                    (sp.to = \'0000-00-00 00:00:00\' OR \'' . date('Y-m-d H:i:s') . '\' <= sp.to)
                 )',
                 'joinType' => self::LEFT_JOIN,
             ],

--- a/upgrade/upgrade-4.0.4.php
+++ b/upgrade/upgrade-4.0.4.php
@@ -26,5 +26,7 @@ function upgrade_module_4_0_4(Ps_Facetedsearch $module)
     // Change data column to longtext
     Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'layered_filter_block` CHANGE `data` `data` LONGTEXT NULL;');
 
+    Configuration::updateValue('PS_LAYERED_INDEX_COUNTRIES', 1);
+
     return true;
 }

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -216,6 +216,28 @@
 	</div>
 
 	<div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='Index prices by countries' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_filter_index_countries" id="ps_layered_filter_index_countries_on" value="1"{if $index_countries} checked="checked"{/if}>
+		  <label for="ps_layered_filter_index_countries_on" class="radioCheck">
+			<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_filter_index_countries" id="ps_layered_filter_index_countries_off" value="0"{if !$index_countries} checked="checked"{/if}>
+		  <label for="ps_layered_filter_index_countries_off" class="radioCheck">
+			<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+	  </div>
+	  <div class="col-lg-9 col-lg-offset-3">
+      <div class="help-block">
+        {l s='Index prices by countries option allows you to enable or disable the indexing of prices for different countries in the layered navigation filters. Turn this off when you do not need country-specific pricing.' d='Modules.Facetedsearch.Admin'}
+      </div>
+    </div>
+	</div>
+
+	<div class="form-group">
 	  <label class="col-lg-3 control-label">{l s='Use tax to filter price' d='Modules.Facetedsearch.Admin'}</label>
 	  <div class="col-lg-9">
 		<span class="switch prestashop-switch fixed-width-lg">
@@ -289,7 +311,7 @@
   </div>
 
 	<div class="form-group">
-		<label class="control-label col-lg-3">{l s='Default filter template for new categories' d='Modules.Facetedsearch.Admin'}</label>				
+		<label class="control-label col-lg-3">{l s='Default filter template for new categories' d='Modules.Facetedsearch.Admin'}</label>
 		<div class="col-lg-9">
 			<select class="form-control fixed-width-xxl" name="ps_layered_default_category_template" id="ps_layered_default_category_template">
 				<option value="0" {if empty($default_category_template)} selected="selected" {/if}>{l s='None' d='Admin.Global'}</option>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Indexing product prices creates a large number of entries in the database, making the table very large. In many cases, however, some data can be omitted, for example, if you only want to include one country in the index.<br>With this fix, instead of writing prices for every country, only the price for the shop's default country is written to the index table.
| Type?             | improvement / new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | 

This is a example for 14.000 products:

<img width="693" height="317" alt="Screenshot 2026-05-04 124629" src="https://github.com/user-attachments/assets/b35b2259-7302-4a9d-84dc-3b239155a281" />
<img width="1013" height="1009" alt="Screenshot 2026-05-04 124713" src="https://github.com/user-attachments/assets/b9bf2b56-ea16-4897-bd6d-9fe16f93cbcb" />

And here after the fix:
<img width="760" height="282" alt="Screenshot 2026-05-04 132008" src="https://github.com/user-attachments/assets/50b9904d-0ec0-4af3-9ab1-d18bff134d9c" />

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
