### PR TITLE
Convert selected price and weight filters to floats

### DIFF
--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -243,7 +243,7 @@ class Block
         );
 
         list($priceBlock['min'], $priceBlock['max']) = $this->searchAdapter->getInitialPopulation()->getMinMaxPriceValue();
-        $priceBlock['value'] = !empty($selectedFilters['price']) ? $selectedFilters['price'] : null;
+        $priceBlock['value'] = !empty($selectedFilters['price']) ? array_map('floatval', $selectedFilters['price']) : null;
 
         $this->restorePriceAndWeightFilters(
             $this->searchAdapter->getInitialPopulation(),
@@ -337,7 +337,7 @@ class Block
             return [];
         }
 
-        $weightBlock['value'] = !empty($selectedFilters['weight']) ? $selectedFilters['weight'] : null;
+        $weightBlock['value'] = !empty($selectedFilters['weight']) ? array_map('floatval', $selectedFilters['weight']) : null;
 
         $this->restorePriceAndWeightFilters(
             $this->searchAdapter->getInitialPopulation(),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Following the critical security issue https://github.com/PrestaShop/ps_facetedsearch/security/advisories/GHSA-m5f5-28qr-9g9r , I think we can improve the validation of inputs price and weight forks by converting filters to floats. It prevents any serialized string injection (even if it's already neutralized by previous fixes).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?      | Just slide the price and weight range of the faceted search module
| Sponsor company   | @202ecommerce
