### PR TITLE
Align CI/CD with PrestaShop issue #41648

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,9 +8,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: PHP syntax checker 7.1
-        uses: prestashop/github-action-php-lint/7.1@master
-
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master
 
@@ -35,6 +32,9 @@ jobs:
       - name: PHP syntax checker 8.4
         uses: prestashop/github-action-php-lint/8.4@master
 
+      - name: PHP syntax checker 8.5
+        uses: prestashop/github-action-php-lint/8.5@master
+
   # Check the PHP code follow the coding standards
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta_version: ['8.1.7', '8.2.x']
+        presta_version: ['8.2.x']
         php_version: ['7.4', '8.1']
       fail-fast: false
     env:
@@ -126,7 +126,7 @@ jobs:
           coverage: xdebug
 
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v6
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder

--- a/tests/php/phpstan/phpstan-1.7.7.x.neon
+++ b/tests/php/phpstan/phpstan-1.7.7.x.neon
@@ -1,8 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Parameter \#1 \$string of method PrestaShop\\Module\\FacetedSearch\\URLSerializer\:\:unserialize\(\) expects string, array given.#'
-    - '#Parameter \#1 \$master of static method DbCore\:\:getInstance\(\) expects bool, int given.#'
-    - '#Parameter \#1 \$value of method ControllerCore\:\:ajaxRender\(\) expects null, string given.#'

--- a/tests/php/phpstan/phpstan-1.7.8.x.neon
+++ b/tests/php/phpstan/phpstan-1.7.8.x.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Parameter \#1 \$master of static method DbCore\:\:getInstance\(\) expects bool, int given.#'

--- a/tests/php/phpstan/phpstan-8.1.7.neon
+++ b/tests/php/phpstan/phpstan-8.1.7.neon
@@ -1,9 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
-    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
-    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
-    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Aligns the module's CI/CD workflows with the conventions defined in [PrestaShop/PrestaShop#41648](https://github.com/PrestaShop/PrestaShop/issues/41648), using [blockreassurance](https://github.com/PrestaShop/blockreassurance) as the reference module.
| Type?             | improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | see below
| Sponsor company   | Creabilis.com

### Changes

**PHP Linter** (`.github/workflows/php.yml`)
- Drop PHP 7.1 (no longer in scope)
- Add PHP 8.5

**PHPStan matrix (legacy job)**
- Remove PrestaShop `8.1.7` from matrix — only `8.2.x` is kept, matching the convention

**PHPUnit**
- Bump `actions/checkout` from `v3.1.0` to `v6` (consistency with other jobs)

**PHPStan configs** (`tests/php/phpstan/`)
- Remove obsolete configs: `phpstan-1.7.7.x.neon`, `phpstan-1.7.8.x.neon`, `phpstan-8.1.7.neon`

### Note

Dead-code cleanup for PrestaShop versions < 8.2 is not included here — it will be addressed in a separate PR as suggested by the issue.

## Test plan

- [ ] PHP linter job passes on PHP 7.2 → 8.5
- [ ] PHPStan (PHP 7.4 - 8.1) passes on PS 8.2.x
- [ ] PHPStan (PHP 8.1 - 8.5) passes on PS 9.1.x and develop
- [ ] PHPUnit job still runs successfully