### PR TITLE
Fix add, edit and delete filter template link without token

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -977,13 +977,13 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             $filters_templates[$k]['edit_link'] = $this->context->link->getAdminLink('AdminModules', true, [], [
                 'configure' => 'ps_facetedsearch',
                 'edit_filters_template' => 1,
-                'id_layered_filter' => (int) $v['id_layered_filter']
+                'id_layered_filter' => (int) $v['id_layered_filter'],
             ]);
 
             $filters_templates[$k]['remove_link'] = $this->context->link->getAdminLink('AdminModules', true, [], [
                 'configure' => 'ps_facetedsearch',
                 'deleteFilterTemplate' => 1,
-                'id_layered_filter' => (int) $v['id_layered_filter']
+                'id_layered_filter' => (int) $v['id_layered_filter'],
             ]);
         }
 

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -811,7 +811,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
-            'link' => $this->context->link,
+            'add_new_filters_template_link' => $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1]),
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');
@@ -973,6 +973,18 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             $filters_templates[$k]['controllers'] = implode(', ', $tmp);
 
             $filters_templates[$k]['date_add'] = Tools::displayDate($v['date_add'], true);
+
+            $filters_templates[$k]['edit_link'] = $this->context->link->getAdminLink('AdminModules', true, [], [
+                'configure' => 'ps_facetedsearch',
+                'edit_filters_template' => 1,
+                'id_layered_filter' => (int) $v['id_layered_filter']
+            ]);
+
+            $filters_templates[$k]['remove_link'] = $this->context->link->getAdminLink('AdminModules', true, [], [
+                'configure' => 'ps_facetedsearch',
+                'deleteFilterTemplate' => 1,
+                'id_layered_filter' => (int) $v['id_layered_filter']
+            ]);
         }
 
         return $filters_templates;

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -811,6 +811,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
+            'link' => $this->context->link
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -811,7 +811,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
-            'link' => $this->context->link
+            'link' => $this->context->link,
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/manage.tpl');

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -116,7 +116,9 @@
   {/if}
   {if empty($limit_warning)}
 	<div class="panel-footer">
-	  <a class="btn btn-default pull-right" href="{$current_url}&amp;add_new_filters_template=1"><i class="process-icon-plus"></i> {l s='Add new template' d='Modules.Facetedsearch.Admin'}</a>
+	  <a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1])|escape:'htmlall':'UTF-8'}">
+	    <i class="process-icon-plus"></i> {l s='Add new template' d='Modules.Facetedsearch.Admin'}
+	  </a>
 	</div>
   {/if}
 </div>

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -75,7 +75,13 @@
 				{if empty($limit_warning)}
 				  <div class="btn-group-action">
 					<div class="btn-group pull-right">
-					  <a href="{$current_url}&amp;edit_filters_template=1&amp;id_layered_filter={(int)$template['id_layered_filter']}" class="btn btn-default">
+					  <a class="btn btn-default"
+					    href="{$link->getAdminLink('AdminModules', true, [], [
+						  'configure' => 'ps_facetedsearch',
+						  'edit_filters_template' => 1,
+						  'id_layered_filter' => (int)$template['id_layered_filter']
+					    ])|escape:'htmlall':'UTF-8'}"
+					  >
 						<i class="icon-pencil"></i> {l s='Edit' d='Admin.Actions'}
 					  </a>
 					  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -83,8 +89,14 @@
 					  </button>
 					  <ul class="dropdown-menu">
 						<li>
-						  <a href="{$current_url}&amp;deleteFilterTemplate=1&amp;id_layered_filter={(int)$template['id_layered_filter']}"
-						     onclick="return confirm('{l s='Do you really want to delete this filter template?' d='Modules.Facetedsearch.Admin'}');">
+						  <a
+						    href="{$link->getAdminLink('AdminModules', true, [], [
+						      'configure' => 'ps_facetedsearch',
+						      'deleteFilterTemplate' => 1,
+						      'id_layered_filter' => (int)$template['id_layered_filter']
+					        ])|escape:'htmlall':'UTF-8'}"
+						    onclick="return confirm('{l s='Do you really want to delete this filter template?' d='Modules.Facetedsearch.Admin'}');"
+						  >
 							<i class="icon-trash"></i> {l s='Delete' d='Admin.Actions'}
 						  </a>
 						</li>

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -75,13 +75,7 @@
 				{if empty($limit_warning)}
 				  <div class="btn-group-action">
 					<div class="btn-group pull-right">
-					  <a class="btn btn-default"
-					    href="{$link->getAdminLink('AdminModules', true, [], [
-						  'configure' => 'ps_facetedsearch',
-						  'edit_filters_template' => 1,
-						  'id_layered_filter' => (int)$template['id_layered_filter']
-					    ])|escape:'htmlall':'UTF-8'}"
-					  >
+					  <a class="btn btn-default" href="{$template.edit_link|escape:'htmlall':'UTF-8'}">
 						<i class="icon-pencil"></i> {l s='Edit' d='Admin.Actions'}
 					  </a>
 					  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -90,11 +84,7 @@
 					  <ul class="dropdown-menu">
 						<li>
 						  <a
-						    href="{$link->getAdminLink('AdminModules', true, [], [
-						      'configure' => 'ps_facetedsearch',
-						      'deleteFilterTemplate' => 1,
-						      'id_layered_filter' => (int)$template['id_layered_filter']
-					        ])|escape:'htmlall':'UTF-8'}"
+						    href="{$template.remove_link|escape:'htmlall':'UTF-8'}"
 						    onclick="return confirm('{l s='Do you really want to delete this filter template?' d='Modules.Facetedsearch.Admin'}');"
 						  >
 							<i class="icon-trash"></i> {l s='Delete' d='Admin.Actions'}
@@ -116,7 +106,7 @@
   {/if}
   {if empty($limit_warning)}
 	<div class="panel-footer">
-	  <a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminModules', true, [], ['configure' => 'ps_facetedsearch', 'add_new_filters_template' => 1])|escape:'htmlall':'UTF-8'}">
+	  <a class="btn btn-default pull-right" href="{$add_new_filters_template_link|escape:'htmlall':'UTF-8'}">
 	    <i class="process-icon-plus"></i> {l s='Add new template' d='Modules.Facetedsearch.Admin'}
 	  </a>
 	</div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | After disabling BO tokens, links to add, edit or delete the filter template are broken because they were always added as NEXT parameters after the token that also added the beginning of the query string.<br><br>Before:<br>../modules/manage/action/configure/ps_facetedsearch&edit_filters_template=1&id_layered_filter=1<br><br>After:<br>../modules/manage/action/configure/ps_facetedsearch?edit_filters_template=1&id_layered_filter=1
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1228
| How to test?      | 1. Go to Advanced Parameters -> Security<br>2. Disable BO token<br>3. Go to the module<br>4. Try edit/remove any filter template
| Sponsor company   | 

Before:
<img width="1002" height="760" alt="obraz" src="https://github.com/user-attachments/assets/2b5776a0-b7ee-4655-956c-8d940cc52ed7" />



