### PR TITLE
Align module on PrestaShop 8.2+: add 9.0.3 PHPStan job, fix errors and bump to 5.0.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -87,8 +87,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta_version: ['9.1.x', 'develop']
-        php_version: ['8.1', '8.5']
+        include:
+          # PrestaShop 9.0.x supports PHP 8.1 up to 8.4 (8.5 is not supported)
+          - { presta_version: '9.0.3', php_version: '8.1' }
+          - { presta_version: '9.0.3', php_version: '8.4' }
+          # PrestaShop 9.1.x and develop support PHP 8.1 up to 8.5
+          - { presta_version: '9.1.x', php_version: '8.1' }
+          - { presta_version: '9.1.x', php_version: '8.5' }
+          - { presta_version: 'develop', php_version: '8.1' }
+          - { presta_version: 'develop', php_version: '8.5' }
       fail-fast: false
     env:
       PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini
@@ -98,7 +105,7 @@ jobs:
         with:
           path: ${{ github.event.repository.name }}
 
-      - name: Prepare PHP env for PrestaShop 9.1.x and later (define constants before any bootstrap)
+      - name: Prepare PHP env for PrestaShop ${{ matrix.presta_version }} (define constants before any bootstrap)
         run: |
           mkdir -p ${{ github.event.repository.name }}/.phpstan-php-ini
           {

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[4.0.3]]></version>
+    <version><![CDATA[5.0.0]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -618,7 +618,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
                 // Associate shops in case of multistore
                 if (isset($_POST['checkBoxShopAsso_layered_filter'])) {
-                    foreach ($_POST['checkBoxShopAsso_layered_filter'] as $idShop => $row) {
+                    foreach (array_keys($_POST['checkBoxShopAsso_layered_filter']) as $idShop) {
                         $filterValues['shop_list'][] = (int) $idShop;
                     }
                 } else {
@@ -638,7 +638,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 }
 
                 // Add filters themselves
-                foreach ($_POST as $key => $value) {
+                foreach (array_keys($_POST) as $key) {
                     if (!preg_match('~^(?P<key>layered_selection_.*)(?<!_filter_)(?<!type)(?<!show_limit)$~', $key, $matches)) {
                         continue;
                     }
@@ -1051,7 +1051,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         ];
 
         // Add all stable controllers (except search)
-        foreach ($this->getSupportedControllers() as $controller_name => $data) {
+        foreach (array_keys($this->getSupportedControllers()) as $controller_name) {
             if ($controller_name != 'search') {
                 $filterData['controllers'][] = $controller_name;
             }
@@ -1146,7 +1146,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
             $filterData['shop_list'] = $shopList;
 
-            foreach ($c as $idCategory => $category) {
+            foreach (array_keys($c) as $idCategory) {
                 if (!in_array($idCategory, $filterData['categories'])) {
                     $filterData['categories'][] = $idCategory;
                 }
@@ -1185,7 +1185,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
                 // Attribute filter
                 if (is_array($attributeGroupsById) && count($attributeGroupsById) > 0) {
-                    foreach ($a as $kAttribute => $attribute) {
+                    foreach (array_keys($a) as $kAttribute) {
                         if (!isset($doneCategories[(int) $idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]])) {
                             $filterData['layered_selection_ag_' . (int) $attributeGroupsById[(int) $kAttribute]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
                             $doneCategories[(int) $idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]] = true;
@@ -1196,7 +1196,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
 
                 // Features filter
                 if (is_array($featuresById) && count($featuresById) > 0) {
-                    foreach ($f as $kFeature => $feature) {
+                    foreach (array_keys($f) as $kFeature) {
                         if (!isset($doneCategories[(int) $idCategory]['f' . (int) $featuresById[(int) $kFeature]])) {
                             $filterData['layered_selection_feat_' . (int) $featuresById[(int) $kFeature]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
                             $doneCategories[(int) $idCategory]['f' . (int) $featuresById[(int) $kFeature]] = true;

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -403,7 +403,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $shopList = Shop::getShops(false, null, true);
 
         foreach ($shopList as $idShop) {
-            $currencyList = Currency::getCurrencies(false, true);
+            $currencyList = Currency::getCurrencies(false, true, true);
 
             $minPrice = [];
             $maxPrice = [];

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -403,7 +403,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $shopList = Shop::getShops(false, null, true);
 
         foreach ($shopList as $idShop) {
-            $currencyList = Currency::getCurrencies(false, true, new Shop($idShop));
+            $currencyList = Currency::getCurrencies(false, true);
 
             $minPrice = [];
             $maxPrice = [];
@@ -741,15 +741,17 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $this->context->smarty->assign('uri', $this->getPathUri());
 
         // Assign assets
+        /** @var AdminController $controller */
+        $controller = $this->context->controller;
         if (file_exists(_PS_ROOT_DIR_ . '/js/vendor/Sortable.min.js')) {
-            $this->context->controller->addJS(_PS_JS_DIR_ . 'vendor/Sortable.min.js');
+            $controller->addJS(_PS_JS_DIR_ . 'vendor/Sortable.min.js');
         } else {
-            if (method_exists($this->context->controller, 'addJquery')) {
-                $this->context->controller->addJS(_PS_JS_DIR_ . 'jquery/plugins/jquery.sortable.js');
+            if (method_exists($controller, 'addJquery')) {
+                $controller->addJS(_PS_JS_DIR_ . 'jquery/plugins/jquery.sortable.js');
             }
         }
-        $this->context->controller->addJS($this->_path . 'views/dist/back.js');
-        $this->context->controller->addCSS($this->_path . 'views/dist/back.css');
+        $controller->addJS($this->_path . 'views/dist/back.js');
+        $controller->addCSS($this->_path . 'views/dist/back.css');
 
         // Render screen for adding new template
         if (Tools::getValue('add_new_filters_template')) {
@@ -969,12 +971,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             }
             $filters_templates[$k]['controllers'] = implode(', ', $tmp);
 
-            // Format date for different core versions. Since 8.0, it has only two arguments.
-            if (version_compare(_PS_VERSION_, '8.0.0', '>=')) {
-                $filters_templates[$k]['date_add'] = Tools::displayDate($v['date_add'], true);
-            } else {
-                $filters_templates[$k]['date_add'] = Tools::displayDate($v['date_add'], null, true);
-            }
+            $filters_templates[$k]['date_add'] = Tools::displayDate($v['date_add'], true);
         }
 
         return $filters_templates;

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -96,7 +96,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '4.0.3';
+        $this->version = '5.0.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -107,7 +107,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         $this->displayName = $this->trans('Faceted search', [], 'Modules.Facetedsearch.Admin');
         $this->description = $this->trans('Filter your catalog to help visitors picture the category tree and browse your store easily.', [], 'Modules.Facetedsearch.Admin');
         $this->psLayeredFullTree = (int) Configuration::get('PS_LAYERED_FULL_TREE');
-        $this->ps_versions_compliancy = ['min' => '8.1.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '8.2.0', 'max' => _PS_VERSION_];
 
         $this->hookDispatcher = new HookDispatcher($this);
 

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -57,4 +57,19 @@ abstract class AbstractHook
     {
         return static::AVAILABLE_HOOKS;
     }
+
+    /**
+     * Context::$controller is typed as the PHPStan-opaque LegacyControllerContext on
+     * PrestaShop 9.x, which prevents static resolution of legacy AdminController members
+     * such as the $default_form_language property. This returns it with a concrete type.
+     *
+     * @return \AdminController
+     */
+    protected function getAdminController()
+    {
+        /** @var \AdminController $controller */
+        $controller = $this->context->controller;
+
+        return $controller;
+    }
 }

--- a/src/Hook/Attribute.php
+++ b/src/Hook/Attribute.php
@@ -168,7 +168,7 @@ class Attribute extends AbstractHook
 
         $this->context->smarty->assign([
             'languages' => Language::getLanguages(false),
-            'default_form_language' => (int) $this->context->controller->default_form_language,
+            'default_form_language' => (int) $this->getAdminController()->default_form_language,
             'values' => $values,
         ]);
 

--- a/src/Hook/AttributeGroup.php
+++ b/src/Hook/AttributeGroup.php
@@ -180,7 +180,7 @@ class AttributeGroup extends AbstractHook
 
         $this->context->smarty->assign([
             'languages' => Language::getLanguages(false),
-            'default_form_language' => (int) $this->context->controller->default_form_language,
+            'default_form_language' => (int) $this->getAdminController()->default_form_language,
             'values' => $values,
             'is_indexable' => (bool) $isIndexable,
         ]);

--- a/src/Hook/Feature.php
+++ b/src/Hook/Feature.php
@@ -162,7 +162,7 @@ class Feature extends AbstractHook
 
         $this->context->smarty->assign([
             'languages' => Language::getLanguages(false),
-            'default_form_language' => (int) $this->context->controller->default_form_language,
+            'default_form_language' => (int) $this->getAdminController()->default_form_language,
             'values' => $values,
             'is_indexable' => (bool) $isIndexable,
         ]);

--- a/src/Hook/FeatureValue.php
+++ b/src/Hook/FeatureValue.php
@@ -180,7 +180,7 @@ class FeatureValue extends AbstractHook
 
         $this->context->smarty->assign([
             'languages' => Language::getLanguages(false),
-            'default_form_language' => (int) $this->context->controller->default_form_language,
+            'default_form_language' => (int) $this->getAdminController()->default_form_language,
             'values' => $values,
         ]);
 

--- a/src/Hook/ProductSearch.php
+++ b/src/Hook/ProductSearch.php
@@ -83,14 +83,16 @@ class ProductSearch extends AbstractHook
         }
 
         // Assign assets
+        /** @var \FrontController $controller */
+        $controller = $this->context->controller;
         if ((bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER')) {
-            $this->context->controller->addJqueryUi('ui.slider');
+            $controller->addJqueryUi('ui.slider');
         }
-        $this->context->controller->registerStylesheet(
+        $controller->registerStylesheet(
             'facetedsearch_front',
             '/modules/ps_facetedsearch/views/dist/front.css'
         );
-        $this->context->controller->registerJavascript(
+        $controller->registerJavascript(
             'facetedsearch_front',
             '/modules/ps_facetedsearch/views/dist/front.js',
             ['position' => 'bottom', 'priority' => 100]

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -600,7 +600,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
         }
 
         foreach ($params as $key => $param) {
-            if (null === $param || '' === $param) {
+            if ('' === $param) {
                 unset($params[$key]);
             }
         }

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -376,7 +376,7 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
         $displayedFacets = [];
         $activeFilters = [];
-        foreach ($facetsVar as $idx => $facet) {
+        foreach ($facetsVar as $facet) {
             // Remove undisplayed facets
             if (!empty($facet['displayed'])) {
                 $displayedFacets[] = $facet;

--- a/tests/php/phpstan/phpstan-8.2.x.neon
+++ b/tests/php/phpstan/phpstan-8.2.x.neon
@@ -1,9 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
-    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
-    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
-    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'

--- a/tests/php/phpstan/phpstan-9.0.3.neon
+++ b/tests/php/phpstan/phpstan-9.0.3.neon
@@ -1,0 +1,15 @@
+includes:
+	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
+
+parameters:
+  ignoreErrors:
+    - '#Access to property \$default_form_language on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Call to method addJqueryUi\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Call to method registerStylesheet\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
+    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
+    - '#Call to method addJS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Call to method addCSS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
+    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
+    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'

--- a/tests/php/phpstan/phpstan-9.0.3.neon
+++ b/tests/php/phpstan/phpstan-9.0.3.neon
@@ -1,15 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Access to property \$default_form_language on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addJqueryUi\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerStylesheet\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
-    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
-    - '#Call to method addJS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addCSS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
-    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'

--- a/tests/php/phpstan/phpstan-9.1.x.neon
+++ b/tests/php/phpstan/phpstan-9.1.x.neon
@@ -1,15 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Access to property \$default_form_language on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addJqueryUi\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerStylesheet\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
-    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
-    - '#Call to method addJS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addCSS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
-    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'

--- a/tests/php/phpstan/phpstan-develop.neon
+++ b/tests/php/phpstan/phpstan-develop.neon
@@ -1,15 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Access to property \$default_form_language on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addJqueryUi\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerStylesheet\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#3 \$groupBy of static method CurrencyCore\:\:getCurrencies\(\) expects bool, Shop given\.#'
-    - '#Strict comparison using === between null and mixed will always evaluate to false\.#'
-    - '#Call to method addJS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method addCSS\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Parameter \#2 \$full of static method ToolsCore\:\:displayDate\(\) expects bool, null given\.#'
-    - '#Static method ToolsCore\:\:displayDate\(\) invoked with 3 parameters, 1-2 required\.#'


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Align the module on PrestaShop 8.2+: add a 9.0.3 PHPStan job, fix PHPStan errors instead of suppressing them, bump the module to 5.0.0
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#41648
| Sponsor company   | ~
| How to test?      | The "PHP tests" workflow must stay green, including the new PHPStan jobs for PrestaShop 9.0.3 (PHP 8.1 & 8.4). None of the neon configs contain any `ignoreErrors` anymore.

### 1. Add the missing PrestaShop 9.0.x PHPStan coverage

The PHPStan matrix only covered `8.2.x`, `9.1.x` and `develop` — there was no job for **PrestaShop 9.0.x**, unlike the other modules aligned under Epic #41648. This adds a `9.0.3` job (PHP 8.1 & 8.4 — 8.5 is unsupported on 9.0.x) by switching the `phpstan` job matrix to an explicit `include` list, plus its `tests/php/phpstan/phpstan-9.0.3.neon` config.

### 2. Fix the PHPStan errors instead of suppressing them

Every `ignoreErrors` entry is removed from **all** neon configs (`8.2.x`, `9.0.3`, `9.1.x` and `develop`); the underlying issues are fixed in code:

- **`Currency::getCurrencies()`** (`ps_facetedsearch.php`) — a `new Shop($idShop)` object was passed as the 3rd `bool $groupBy` parameter. `getCurrencies()` already scopes on the current shop, so the bogus argument is dropped (no behaviour change — the object only forced `groupBy` on, a no-op once currencies are scoped to a single shop).
- **`Tools::displayDate()`** (`ps_facetedsearch.php`) — removed the dead `else` branch using the legacy 3-argument signature; it targeted PrestaShop < 8.0 while the module now requires `>= 8.2`, so it was unreachable.
- **`LegacyControllerContext` calls** (`ps_facetedsearch.php`, `src/Hook/ProductSearch.php`, `src/Hook/AbstractHook.php` + the 4 admin form hooks) — on PrestaShop 9.x `Context::$controller` is typed as the PHPStan-opaque `LegacyControllerContext`, hiding legacy controller members (`addJS`/`addCSS`/`addJqueryUi`/`registerStylesheet`/`registerJavascript` and the `$default_form_language` property). They are now accessed through a concretely-typed `FrontController`/`AdminController` (local `@var` for the front, a small `getAdminController()` helper in `AbstractHook` for the back office).
- **Dead strict comparison** (`src/Product/SearchProvider.php`) — in `updateQueryString()`, `$params` is filled by `parse_str()` (never null) and the preceding loop already strips null values, so the `null === $param` test was dead code and is removed.

### 3. Align minimum compatibility on PrestaShop 8.2+ and bump the version

`ps_versions_compliancy` minimum is raised from `8.1.0` to **`8.2.0`**, matching what the CI actually verifies (the shared PHPStan action targets 8.2+). The module version is bumped accordingly to **5.0.0** (major, since dropping 8.1 support is a BC break). `BC breaks: yes` for that reason.

### 4. Minor cleanup

Dropped a few unused `foreach` value/index variables flagged by static analysis (iterating with `array_keys()` where only the key is used).
