### PR TITLE
Harden range filter labels against malformed values

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -442,8 +442,14 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
 
             foreach ($facet->getFilters() as $filter) {
                 $filterValue = $filter->getValue();
-                $min = empty($filterValue[0]) ? $facet->getProperty('min') : $filterValue[0];
-                $max = empty($filterValue[1]) ? $facet->getProperty('max') : $filterValue[1];
+                $min = $this->getNumericRangeBoundary(
+                    isset($filterValue[0]) ? $filterValue[0] : null,
+                    $facet->getProperty('min')
+                );
+                $max = $this->getNumericRangeBoundary(
+                    isset($filterValue[1]) ? $filterValue[1] : null,
+                    $facet->getProperty('max')
+                );
                 if ($facet->getType() === 'weight') {
                     $unit = Configuration::get('PS_WEIGHT_UNIT');
                     $filter->setLabel(
@@ -466,6 +472,27 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                 }
             }
         }
+    }
+
+    /**
+     * Keep range labels resilient to malformed facet values coming from the URL.
+     *
+     * @param mixed $value
+     * @param mixed $fallback
+     *
+     * @return int|float|string
+     */
+    private function getNumericRangeBoundary($value, $fallback)
+    {
+        if (is_scalar($value) && is_numeric($value)) {
+            return $value;
+        }
+
+        if (is_scalar($fallback) && is_numeric($fallback)) {
+            return $fallback;
+        }
+
+        return 0;
     }
 
     /**

--- a/tests/php/FacetedSearch/Product/SearchProviderTest.php
+++ b/tests/php/FacetedSearch/Product/SearchProviderTest.php
@@ -411,4 +411,14 @@ class SearchProviderTest extends MockeryTestCase
             )
         );
     }
+
+    public function testNumericRangeBoundaryFallsBackWhenValueIsMalformed()
+    {
+        $method = new \ReflectionMethod(SearchProvider::class, 'getNumericRangeBoundary');
+        $method->setAccessible(true);
+
+        $this->assertSame('12.50', $method->invoke($this->provider, '12.50', '1'));
+        $this->assertSame('1', $method->invoke($this->provider, '<a><a><a><a><a>', '1'));
+        $this->assertSame(0, $method->invoke($this->provider, '<a><a><a><a><a>', '<b>'));
+    }
 }


### PR DESCRIPTION
## What

This PR makes range filter label generation resilient to malformed range values coming from the faceted search URL.

`SearchProvider::labelRangeFilters()` currently passes active range values directly to `formatNumber()` / `formatPrice()`. If a crafted URL provides a non-numeric range boundary, for example an HTML-like string, PrestaShop can throw a localization/decimal parsing exception while rendering category facets.

The change adds a small numeric boundary guard: valid numeric scalar values are preserved, invalid values fall back to the facet min/max, and a final `0` fallback is used only if both values are invalid.

## Why

This prevents category/listing pages from failing when bots or malicious requests submit malformed price/weight range boundaries.

## Tests

- `php -l src/Product/SearchProvider.php`
- `php -l tests/php/FacetedSearch/Product/SearchProviderTest.php`
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --no-interaction --dry-run --diff --config=.php_cs.dist src/Product/SearchProvider.php tests/php/FacetedSearch/Product/SearchProviderTest.php`
- Live validation on a PrestaShop 8 production/stage install: malformed `q=Prezzo-<a><a><a><a><a>-100` AJAX category requests now return HTTP 200 and valid rendered products/facets instead of throwing `cannot be interpreted as a number`.

Note: the full legacy PHPUnit 5 suite could not run in my local environment because it is incompatible with PHP 8.1 (`Cannot acquire reference to $GLOBALS`).