### PR TITLE
Assign language to the facets template so theme overrides can read it

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -301,9 +301,28 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             return '';
         }
 
+        $language = $this->module->getContext()->language;
+
         $this->module->getContext()->smarty->assign(
             [
                 'show_quantities' => Configuration::get('PS_LAYERED_SHOW_QTIES'),
+                // Provide the language to the template so theme overrides can read it (e.g. the
+                // Hummingbird slider uses {$language.is_rtl} for the slider direction). It must be
+                // an ARRAY, mirroring the global `language` the front controller assigns (via
+                // ObjectPresenter), because the template accesses it with Smarty array syntax
+                // ({$language.is_rtl}); passing the Language object would make that a fatal
+                // "Cannot use object of type Language as array". (#41846)
+                'language' => [
+                    'id' => (int) $language->id,
+                    'name' => $language->name,
+                    'iso_code' => $language->iso_code,
+                    'locale' => $language->locale,
+                    'language_code' => $language->language_code,
+                    'active' => $language->active,
+                    'is_rtl' => $language->is_rtl,
+                    'date_format_lite' => $language->date_format_lite,
+                    'date_format_full' => $language->date_format_full,
+                ],
                 'facets' => $facetsVar,
                 'js_enabled' => $this->module->isAjax(),
                 'displayedFacets' => $displayedFacets,

--- a/tests/php/FacetedSearch/Product/SearchProviderTest.php
+++ b/tests/php/FacetedSearch/Product/SearchProviderTest.php
@@ -115,6 +115,16 @@ class SearchProviderTest extends MockeryTestCase
     {
         $this->database = Mockery::mock(Db::class);
         $this->context = Mockery::mock(Context::class);
+        $this->context->language = Mockery::mock(\Language::class);
+        $this->context->language->id = 1;
+        $this->context->language->name = 'English (English)';
+        $this->context->language->iso_code = 'en';
+        $this->context->language->locale = 'en-US';
+        $this->context->language->language_code = 'en-us';
+        $this->context->language->active = true;
+        $this->context->language->is_rtl = false;
+        $this->context->language->date_format_lite = 'Y-m-d';
+        $this->context->language->date_format_full = 'Y-m-d H:i:s';
         $this->converter = Mockery::mock(Converter::class);
         $this->serializer = Mockery::mock(URLSerializer::class);
         $this->facetCollection = Mockery::mock(FacetCollection::class);
@@ -181,6 +191,17 @@ class SearchProviderTest extends MockeryTestCase
             ->with(
                 [
                     'show_quantities' => true,
+                    'language' => [
+                        'id' => 1,
+                        'name' => 'English (English)',
+                        'iso_code' => 'en',
+                        'locale' => 'en-US',
+                        'language_code' => 'en-us',
+                        'active' => true,
+                        'is_rtl' => false,
+                        'date_format_lite' => 'Y-m-d',
+                        'date_format_full' => 'Y-m-d H:i:s',
+                    ],
                     'facets' => [
                         [
                             'filters' => [],
@@ -240,6 +261,17 @@ class SearchProviderTest extends MockeryTestCase
             ->with(
                 [
                     'show_quantities' => true,
+                    'language' => [
+                        'id' => 1,
+                        'name' => 'English (English)',
+                        'iso_code' => 'en',
+                        'locale' => 'en-US',
+                        'language_code' => 'en-us',
+                        'active' => true,
+                        'is_rtl' => false,
+                        'date_format_lite' => 'Y-m-d',
+                        'date_format_full' => 'Y-m-d H:i:s',
+                    ],
                     'facets' => [
                         [
                             'displayed' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `renderFacets()` never assigned `language` to Smarty, so theme overrides that read it (Hummingbird's price/weight slider uses `{$language.is_rtl}` for `data-slider-direction`) get a null `language` and Smarty raises "offset on value of type null". This assigns the context language alongside the other facet variables.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#41846
| How to test?      | See below.
| Sponsor company   |

### Description

`SearchProvider::renderFacets()` assigns the facet variables to Smarty but never assigns `language`. Themes that override `facets.tpl` and reference the language break as a result: the Hummingbird price/weight slider uses `{$language.is_rtl}` to set `data-slider-direction`, so on that theme `$language` is `null` and Smarty raises:

```
Trying to access array offset on value of type null
```

in `facets.tpl.php` (around line 491), which breaks the faceted-search block (reported on the `develop` PrestaShop branch with the Hummingbird theme).

The fix assigns the context language alongside the other facet variables so the template — and any theme override — can read it safely. The default (classic) theme is unaffected because it does not reference `$language` in this template.

### How to test

1. Use the Hummingbird theme with the faceted search module on a category page.
2. Before the fix: the price/weight slider block triggers the Smarty `offset on value of type null` error.
3. After the fix: the facets block renders with no error and the slider direction resolves from the shop language.

Unit test: `SearchProviderTest` asserts `renderFacets()` now assigns `language` (3 tests, 40 assertions, green; reverting the source change makes the test fail).