### PR TITLE
Always dispatch actionFacetedSearchFilters hook

### DIFF
--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -130,6 +130,18 @@ class Search
         // Adds filters that specific for this controller
         $this->addControllerSpecificFilters();
 
+        // Let modules add their own filters to the adapter. This is dispatched here, after the
+        // controller specific filters, rather than inside addControllerSpecificFilters() because
+        // that method has early returns (e.g. an already selected "Categories" facet) that would
+        // otherwise silently skip the hook and drop the module filters.
+        Hook::exec(
+            'actionFacetedSearchFilters',
+            [
+                'search' => $this,
+                'query' => $this->query,
+            ]
+        );
+
         // Add group by to remove duplicate values
         $this->getSearchAdapter()->addGroupBy('id_product');
 
@@ -451,14 +463,6 @@ class Search
                 empty($productPool) ? ['NULL'] : $productPool
             );
         }
-
-        Hook::exec(
-            'actionFacetedSearchFilters',
-            [
-                'search' => $this,
-                'query' => $this->query,
-            ]
-        );
     }
 
     /**

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -1192,4 +1192,28 @@ class SearchTest extends MockeryTestCase
         $this->search->addFilter('weight', [10, 20]);
         $this->search->addFilter('id_feature', [[10, 20]]);
     }
+
+    /**
+     * The actionFacetedSearchFilters hook must be dispatched even when a controller specific
+     * filter causes an early return inside addControllerSpecificFilters(): on a category query,
+     * selecting a "Categories" facet sets an id_category filter and used to skip the hook.
+     *
+     * @see https://github.com/PrestaShop/ps_facetedsearch/issues/1239
+     */
+    public function testInitSearchDispatchesFacetedSearchFiltersHookWithSelectedCategoryFacet()
+    {
+        $hookCalls = [];
+        $hookMock = Mockery::mock(Hook::class);
+        $hookMock->shouldReceive('exec')
+            ->andReturnUsing(function ($name) use (&$hookCalls) {
+                $hookCalls[] = $name;
+
+                return [];
+            });
+        Hook::setStaticExpectations($hookMock);
+
+        $this->search->initSearch(['category' => [[6]]]);
+
+        $this->assertContains('actionFacetedSearchFilters', $hookCalls);
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `actionFacetedSearchFilters` — the documented hook that lets a module add custom filters to the faceted-search adapter — was dispatched at the very end of `Search::addControllerSpecificFilters()` (`src/Product/Search.php`). That method contains several early `return` statements (category page when a "Categories" facet is already selected, `new-products` when a `date_add` filter is already set, `prices-drop` when a `reduction` filter is already set). Whenever one of those returns runs, the `Hook::exec()` line is never reached, so any module listening on `actionFacetedSearchFilters` is silently bypassed and its filters are dropped from the final product query. This is easy to miss because the hook works fine on plain category/manufacturer/supplier/search pages and on feature/attribute facets. Fix: move the `Hook::exec('actionFacetedSearchFilters', ...)` call out of `addControllerSpecificFilters()` and into `initSearch()`, right after `addControllerSpecificFilters()` — so it fires on every faceted query, while still running before the filters become the initial population.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/ps_facetedsearch#1239.
| How to test?      | A unit test is included (`SearchTest::testInitSearchDispatchesFacetedSearchFiltersHookWithSelectedCategoryFacet`): on a category query, `initSearch(['category' => [[6]]])` sets an `id_category` filter (triggering the early return), and the test asserts `actionFacetedSearchFilters` is still dispatched — red before this change, green after. Manually: register a module on `actionFacetedSearchFilters` that calls `$params['search']->getSearchAdapter()->addFilter('id_product', [1, 2, 3]);`, open a category page, then select a "Categories" facet — before, the custom filter disappears from the results; after, it is applied in both cases.
| Sponsor company   |
