### PR TITLE
Apply out-of-stock-last ordering on search result pages

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -208,6 +208,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_ATTRIBUTE_ANCHOR_SEPARATOR', '-');
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
+            Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', 0);
@@ -249,6 +250,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_CATEGORY_DEPTH');
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
+        Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
         Configuration::deleteByName('PS_LAYERED_FILTER_FEATURE_VALUES_USE_POSITION');
 
@@ -723,6 +725,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_CATEGORY_DEPTH', (int) Tools::getValue('ps_layered_filter_category_depth'));
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
+            Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last_search'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
@@ -822,6 +825,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'limit_warning' => $this->displayLimitPostWarning(21 + count($attributeGroups) * 3 + count($features) * 3),
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
+            'show_out_of_stock_last_search' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -36,6 +36,21 @@ class MySQL extends AbstractAdapter
     const TYPE = 'MySQL';
 
     /**
+     * Pushes out-of-stock products last on category, manufacturer and the other listings.
+     *
+     * @var string
+     */
+    const CONFIG_SHOW_OUT_OF_STOCK_LAST = 'PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST';
+
+    /**
+     * Same behaviour on search result pages. Kept separate because search ranks by relevance,
+     * so a merchant can want availability first in listings without changing search.
+     *
+     * @var string
+     */
+    const CONFIG_SHOW_OUT_OF_STOCK_LAST_SEARCH = 'PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH';
+
+    /**
      * @var string
      */
     const LEFT_JOIN = 'LEFT JOIN';
@@ -476,8 +491,17 @@ class MySQL extends AbstractAdapter
          * to order products by their position in the search results we got from the core, with inverted order
          */
         if ($orderField == 'p.position' && !empty($this->getInitialPopulation()->getFilters()['id_product']['='][0])) {
-            return 'FIELD(p.id_product,' . implode(',', $this->getInitialPopulation()->getFilters()['id_product']['='][0]) . ') ' .
+            $orderField = 'FIELD(p.id_product,' . implode(',', $this->getInitialPopulation()->getFilters()['id_product']['='][0]) . ') ' .
             ($this->getOrderDirection() === 'asc' ? 'DESC' : 'ASC');
+
+            // Search keeps relevance as the primary signal, so it has its own setting rather than
+            // following the one used by category and other listings below. When it is off, the
+            // relevance order is returned untouched.
+            return $this->computeShowLast(
+                $orderField,
+                $filterToTableMapping,
+                self::CONFIG_SHOW_OUT_OF_STOCK_LAST_SEARCH
+            );
         }
 
         // Alter order by field and add some products to the end of the list, if required
@@ -495,14 +519,16 @@ class MySQL extends AbstractAdapter
      *
      * @param string $orderField
      * @param array $filterToTableMapping
+     * @param string $configurationKey setting that enables the behaviour, so search pages can be
+     *                                 driven by their own one
      *
      * @return string
      */
-    protected function computeShowLast($orderField, $filterToTableMapping)
+    protected function computeShowLast($orderField, $filterToTableMapping, $configurationKey = self::CONFIG_SHOW_OUT_OF_STOCK_LAST)
     {
         // allow only if feature is enabled & it is main product list query (caller ensures $orderField is non-empty)
         if ($this->getInitialPopulation() === null
-            || !Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST')
+            || !Configuration::get($configurationKey)
         ) {
             return $orderField;
         }

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -67,7 +67,67 @@ class MySQLTest extends MockeryTestCase
         $configurationMock->shouldReceive('get')
             ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST')
             ->andReturn(0);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH')
+            ->andReturn(0);
         Configuration::setStaticExpectations($configurationMock);
+    }
+
+    /**
+     * Search ranks by relevance, so it has its own setting. Enabling the listing setting alone must
+     * leave a search page exactly as it was: the relevance order and nothing else.
+     */
+    public function testGetQueryLeavesSearchUntouchedWhenOnlyTheListingSettingIsEnabled()
+    {
+        $configurationMock = Mockery::mock(Configuration::class);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST')
+            ->andReturn(true);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH')
+            ->andReturn(false);
+        Configuration::setStaticExpectations($configurationMock);
+
+        $this->adapter->addFilter('id_product', [1, 2, 3], '=');
+        $this->adapter->useFiltersAsInitialPopulation();
+        $this->adapter->setOrderField('position');
+        $this->adapter->setOrderDirection('asc');
+
+        $query = $this->adapter->getQuery();
+
+        $this->assertContains('FIELD(p.id_product,1,2,3) DESC', $query);
+        $this->assertNotContains('IFNULL(p.quantity, 0) <= 0', $query, 'The listing setting must not reach search results.');
+    }
+
+    /**
+     * With the search setting on, unavailable products go last on search too, and relevance is kept
+     * as the ordering within each availability group.
+     */
+    public function testGetQueryAppliesOutOfStockLastOnSearchWhenTheSearchSettingIsEnabled()
+    {
+        $configurationMock = Mockery::mock(Configuration::class);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST')
+            ->andReturn(false);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH')
+            ->andReturn(true);
+        Configuration::setStaticExpectations($configurationMock);
+
+        $productMock = Mockery::namedMock(Product::class);
+        $productMock->shouldReceive('isAvailableWhenOutOfStock')
+            ->with(2)
+            ->andReturn(false);
+
+        $this->adapter->addFilter('id_product', [1, 2, 3], '=');
+        $this->adapter->useFiltersAsInitialPopulation();
+        $this->adapter->setOrderField('position');
+        $this->adapter->setOrderDirection('asc');
+
+        $query = $this->adapter->getQuery();
+
+        $this->assertContains('IFNULL(p.quantity, 0) <= 0', $query);
+        $this->assertContains('FIELD(p.id_product,1,2,3) DESC', $query);
     }
 
     /**

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -266,6 +266,24 @@
 	  </div>
 	</div>
 
+	<div class="form-group">
+	  <label class="col-lg-3 control-label">{l s='Show unavailable, out of stock last on search results' d='Modules.Facetedsearch.Admin'}</label>
+	  <div class="col-lg-9">
+		<span class="switch prestashop-switch fixed-width-lg">
+		  <input type="radio" name="ps_layered_filter_show_out_of_stock_last_search" id="ps_layered_filter_show_out_of_stock_last_search_on" value="1"{if $show_out_of_stock_last_search} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_show_out_of_stock_last_search_on" class="radioCheck">
+			<i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+		  </label>
+		  <input type="radio" name="ps_layered_filter_show_out_of_stock_last_search" id="ps_layered_filter_show_out_of_stock_last_search_off" value="0"{if !$show_out_of_stock_last_search} checked="checked"{/if}/>
+		  <label for="ps_layered_filter_show_out_of_stock_last_search_off" class="radioCheck">
+			<i class="color_danger"></i> {l s='No' d='Admin.Global'}
+		  </label>
+		  <a class="slide-button btn"></a>
+		</span>
+		<p class="help-block">{l s='Search results are ordered by relevance. Enable this to push unavailable products to the end there as well.' d='Modules.Facetedsearch.Admin'}</p>
+	  </div>
+	</div>
+
   <div class="form-group">
     <label class="col-lg-3 control-label">{l s='Use Jquery UI slider' d='Modules.Facetedsearch.Admin'}</label>
     <div class="col-lg-9">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | On search result pages the "show out of stock last" behaviour was never applied, while category, manufacturer and the other listings get it. Search results are ordered by relevance, which `Adapter\MySQL::computeOrderByField()` builds as a `FIELD(p.id_product, ...)` list from the product pool returned by the core search, and that branch **returned early**, before `computeShowLast()` was reached. Following the discussion below, search does not simply inherit the listing setting: it ranks by relevance rather than by browsing, so it gets **its own** setting, `PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST_SEARCH`. A merchant can keep unavailable products last while browsing without changing what a search for a specific product returns, and the existing `PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST` no longer affects search at all. Relevance is preserved within each availability group: the `FIELD()` ordering is applied after the in-stock split, so the most relevant available product leads and a relevant unavailable one drops below it rather than losing its place.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/ps_facetedsearch#1236.
| How to test?      | The new setting is "Show unavailable, out of stock last on search results" in the module configuration, and it defaults to **off**, so nothing changes until it is enabled. Two unit tests cover it in `MySQLTest`: `testGetQueryLeavesSearchUntouchedWhenOnlyTheListingSettingIsEnabled` asserts that turning the listing setting on leaves a search query as pure relevance (`FIELD(p.id_product,1,2,3) DESC`, and no `IFNULL(p.quantity, 0) <= 0`), and `testGetQueryAppliesOutOfStockLastOnSearchWhenTheSearchSettingIsEnabled` asserts that the new setting adds the out-of-stock-last clause while keeping the relevance ordering. Manually: enable only the new setting, run a storefront search returning both in- and out-of-stock products, and check unavailable ones move to the end; with only the old setting on, search is unchanged while category listings still order by availability.
| Sponsor company   |

The generated `ORDER BY` for a search query, by setting:

```
listing setting only : ORDER BY FIELD(p.id_product,1,2,3) DESC
search setting on    : ORDER BY IFNULL(p.quantity, 0) <= 0, IFNULL(p.quantity, 0) <= 0 AND FIELD(sa.out_of_stock, 1) DESC, FIELD(p.id_product,1,2,3) DESC
```

No upgrade script is needed: the key defaults to `0` on install and `Configuration::get()` returns a false-y value when it is absent, so shops upgrading without it behave exactly as they do today.
