### PR TITLE
Index product prices for every active shop country

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -424,18 +424,27 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 'GROUP BY id_product, tr.id_country'
             );
 
-            if (empty($taxRatesByCountry) || !Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
-                $taxCountries = array_filter($shopCountries, function ($country) {
-                    return $country['active'];
-                });
-                $taxRatesByCountry = array_map(function ($country) {
-                    return [
+            // When tax is not applied to indexed prices, drop the per-country tax rates entirely.
+            if (!Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
+                $taxRatesByCountry = [];
+            }
+
+            // Always index every active country of the shop. Countries that have no specific tax
+            // rule for this product (or when the "use tax" option is off) are indexed with a 0% rate.
+            // Without this, the price sort - an INNER JOIN on layered_price_index.id_country - returns
+            // no products at all for customers whose country was not indexed. This makes the
+            // with-tax-rules path consistent with the path already used for products without any tax
+            // rule. See https://github.com/PrestaShop/ps_facetedsearch/issues/1206
+            $indexedCountryIds = array_column($taxRatesByCountry, 'id_country');
+            $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+            foreach ($shopCountries as $country) {
+                if (!empty($country['active']) && !in_array($country['id_country'], $indexedCountryIds)) {
+                    $taxRatesByCountry[] = [
                         'rate' => 0,
                         'id_country' => $country['id_country'],
                         'iso_code' => $country['iso_code'],
                     ];
-                }, $taxCountries);
+                }
             }
 
             $productMinPrices = $this->getDatabase()->executeS(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | When a customer's country has no specific tax rule for a product, sorting search/listing results **by price** returned **0 products** for that customer, while every other sort worked. Root cause: `indexProductPrices()` computes prices for all countries but only **inserts** `layered_price_index` rows for the countries returned by the tax-rule query (`$taxRatesByCountry`) when `PS_LAYERED_FILTER_PRICE_USETAX` is on. The price sort joins that table with `INNER JOIN ... AND psi.id_country = <customer country>`, so a customer from a country that was never indexed matches no rows and gets an empty list. The fix indexes **every active shop country**: countries without a specific tax rule are indexed untaxed (0% rate) — exactly what the module already does for products that have no tax rule at all. Taxed countries keep their computed prices unchanged.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/ps_facetedsearch#1206.
| How to test?      | On a shop with at least two active countries where products have a tax rule for only one of them (e.g. FR), log in / set the context to the other country (e.g. US), open a listing and sort by price — before, the list is empty; after re-indexing prices, it shows the products. Verified on the default shop (active countries FR=8, US=21; products taxed for FR only): re-indexing product 1 keeps FR identical (`price_min=22.944, price_max=28.680`) and adds the US row untaxed (`price_min=19.120, price_max=23.900`), and the price-sort `INNER JOIN` on `id_country=21` now returns the product instead of nothing.
| Sponsor company   |

Verification (default shop, `PS_LAYERED_FILTER_PRICE_USETAX` on):

```
before:  layered_price_index for product 1 -> only id_country=8 (FR): 22.944 / 28.680
         price sort for US (id_country=21)  -> 0 products

after:   id_country=8  (FR): 22.944 / 28.680   (unchanged)
         id_country=21 (US): 19.120 / 23.900   (untaxed, newly indexed)
         price sort for US (id_country=21)  -> returns the product
```

`indexProductPrices()` is a private method on the module class (no unit-test harness covers it, like the rest of the indexer), so this was verified by re-indexing against a real database and diffing the rows, confirming the taxed-country prices are byte-identical. The index now covers active **shop** countries, with the same row shape the no-tax-rule path already produces.
