### PR TITLE
Sort filter values in a locale aware way

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -574,6 +574,51 @@ class Converter
      */
     private function sortFiltersByLabel(Filter $a, Filter $b)
     {
+        $collator = $this->getLabelCollator();
+        if ($collator !== null) {
+            $comparison = $collator->compare($a->getLabel(), $b->getLabel());
+            // compare() returns false on malformed UTF-8; fall back rather than feed
+            // usort() a value that casts to "equal".
+            if ($comparison !== false) {
+                return $comparison;
+            }
+        }
+
         return strnatcasecmp($a->getLabel(), $b->getLabel());
+    }
+
+    /**
+     * Collator for the language currently in context, or null when one cannot be built
+     * (intl extension missing, or no locale configured) and natural sorting is used instead.
+     *
+     * Held per locale in a static so a usort() pass does not rebuild it on every comparison.
+     *
+     * @return \Collator|null
+     */
+    private function getLabelCollator()
+    {
+        static $collators = [];
+
+        if (!class_exists('Collator')) {
+            return null;
+        }
+
+        $locale = isset($this->context->language->locale) ? $this->context->language->locale : '';
+        if ($locale === '') {
+            return null;
+        }
+
+        if (!array_key_exists($locale, $collators)) {
+            $collator = collator_create($locale);
+            if ($collator !== null) {
+                // Case insensitive, as strnatcasecmp was, but accent and locale aware.
+                $collator->setStrength(\Collator::SECONDARY);
+                // Keep the natural ordering of embedded numbers (e.g. 2 before 10).
+                $collator->setAttribute(\Collator::NUMERIC_COLLATION, \Collator::ON);
+            }
+            $collators[$locale] = $collator;
+        }
+
+        return $collators[$locale];
     }
 }

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -110,6 +110,51 @@ class ConverterTest extends MockeryTestCase
         );
     }
 
+    /**
+     * Filter labels are sorted again when the facets are built, so the ordering a visitor sees is
+     * the one decided here. Czech sorts "Č" as a letter of its own, after every "C" word and
+     * before "Z"; comparing bytes puts it after the whole ASCII alphabet instead.
+     *
+     * @see https://github.com/PrestaShop/ps_facetedsearch/issues/1201
+     */
+    public function testGetFacetsFromFilterBlocksSortsLabelsLocaleAware()
+    {
+        if (!class_exists('Collator')) {
+            $this->markTestSkipped('The intl extension is required for locale aware sorting.');
+        }
+
+        $this->contextMock->language->locale = 'cs-CZ';
+
+        $facets = $this->converter->getFacetsFromFilterBlocks([
+            [
+                'type_lite' => 'id_feature',
+                'type' => 'id_feature',
+                'id_key' => '2',
+                'name' => 'Property',
+                'url_name' => null,
+                'meta_title' => null,
+                'values' => [
+                    1 => ['nbr' => '1', 'name' => 'Zelená', 'url_name' => null, 'meta_title' => null],
+                    2 => ['nbr' => '1', 'name' => 'Červená', 'url_name' => null, 'meta_title' => null],
+                    3 => ['nbr' => '1', 'name' => 'Černá', 'url_name' => null, 'meta_title' => null],
+                    4 => ['nbr' => '1', 'name' => 'Bílá', 'url_name' => null, 'meta_title' => null],
+                ],
+                'filter_show_limit' => '0',
+                'filter_type' => '0',
+            ],
+        ]);
+
+        $labels = [];
+        foreach ($facets[0]->getFilters() as $filter) {
+            $labels[] = $filter->getLabel();
+        }
+
+        $this->assertSame(
+            ['Bílá', 'Černá', 'Červená', 'Zelená'],
+            $labels
+        );
+    }
+
     public function facetsProvider()
     {
         return [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Filter values were ordered with `strnatcasecmp()`, which compares strings byte by byte. Multi-byte accented characters (Czech `č`, `š`, `ř`, …) therefore sorted **after every plain ASCII letter** instead of next to their base letter, so e.g. `Černá` landed at the bottom of the list. The sort now uses a `Collator` built from the current language locale, with secondary strength (case-insensitive, as `strnatcasecmp` was) and numeric collation (keeping the natural `2`-before-`10` ordering). It falls back to `strnatcasecmp()` when the `intl` extension is unavailable, when the language has no locale, and when `Collator::compare()` returns `false` on malformed UTF-8. The sort lives in `Filters\Converter::sortFiltersByLabel()`, which is where the displayed order is decided: the converter rebuilds the values as `Filter` objects and re-sorts them, so ordering them earlier in `Filters\Block` was discarded. Doing it here also covers every filter type sorted by label rather than features alone.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/ps_facetedsearch#1201.
| How to test?      | A unit test is included (`ConverterTest::testGetFacetsFromFilterBlocksSortsLabelsLocaleAware`): with locale `cs-CZ`, a feature whose values are `Zelená, Červená, Černá, Bílá` comes back as `Bílá, Černá, Červená, Zelená`. Reverting only `src/Filters/Converter.php` turns it red with `Bílá, Zelená, Černá, Červená`, i.e. `Č` after the whole ASCII alphabet. Manually: create a feature with Czech accented values (`č`, `š`, `ř`, …), enable it as a filter, and check the storefront filter block — the values are now ordered per the language instead of pushing accented ones to the end.
| Sponsor company   |

Reported by @Hlavtox.
