### PR TITLE
Offer the Date added (Newest) sort on every product list

### DIFF
--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -131,14 +131,15 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             ),
         ];
 
-        if ($query->getQueryType() == 'new-products') {
-            $sortOrders[] = $sortDateAsc->setLabel(
-                $translator->trans('Date added, oldest to newest', [], 'Shop.Theme.Catalog')
-            );
-            $sortOrders[] = $sortDateDesc->setLabel(
-                $translator->trans('Date added, newest to oldest', [], 'Shop.Theme.Catalog')
-            );
-        }
+        // "Date added" ("Newest") is a core product-list sort per checkout/product-list UX research,
+        // useful on every list (category, manufacturer, supplier, search), not only the new-products
+        // page. It was previously restricted to the new-products query type.
+        $sortOrders[] = $sortDateAsc->setLabel(
+            $translator->trans('Date added, oldest to newest', [], 'Shop.Theme.Catalog')
+        );
+        $sortOrders[] = $sortDateDesc->setLabel(
+            $translator->trans('Date added, newest to oldest', [], 'Shop.Theme.Catalog')
+        );
 
         return $sortOrders;
     }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `SearchProvider::getAvailableSortOrders()` builds the `date_add` ("Date added" / newest) sort orders but only appends them when `$query->getQueryType() == 'new-products'`, so category, manufacturer, supplier and search lists never offer a "newest" sort. Sorting by newest is one of the core product-list sorts in UX research (https://baymard.com/blog/current-state-product-list-and-filtering, "64% don't allow all 4: Price, User Rating, Best-Selling, Newest"). This moves the two `date_add` sort orders out of the `new-products` special case so they are available on every product list; Sales stays the default sort, so only the option is added, and the new-products page is unchanged. Fixes #1268.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1268
| Sponsor company   |
| How to test?      | Open any category page: the sort dropdown now lists "Date added, oldest to newest" and "Date added, newest to oldest" alongside the existing options, and selecting the latter sorts by `product.date_add.desc`. Verified live on a 9.2 shop. `php-cs-fixer` clean; the change only relocates existing lines (no new symbols), and this module runs php-cs-fixer + PHPStan in CI (no PHPUnit job) — `getAvailableSortOrders()` is a private method not covered by the existing SearchProvider tests, which are unaffected.
