### PR TITLE
List a product on the page of every supplier it is associated with

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -220,6 +220,15 @@ class MySQL extends AbstractAdapter
                 'joinCondition' => '(p.id_product = cp.id_product)',
                 'joinType' => self::INNER_JOIN,
             ],
+            // The supplier page lists every product associated with the supplier, and that
+            // association lives in product_supplier. Without this mapping the filter falls back to
+            // p.id_supplier, which only holds the default supplier of the product.
+            'id_supplier' => [
+                'tableName' => 'product_supplier',
+                'tableAlias' => 'psup',
+                'joinCondition' => '(p.id_product = psup.id_product)',
+                'joinType' => self::INNER_JOIN,
+            ],
             'manufacturer_name' => [
                 'tableName' => 'manufacturer',
                 'tableAlias' => 'm',

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -330,6 +330,22 @@ class MySQLTest extends MockeryTestCase
     }
 
     /**
+     * A product is listed on the page of every supplier it is associated with, and that association
+     * lives in product_supplier. Filtering on the product's own id_supplier column would only match
+     * the default supplier.
+     */
+    public function testGetQueryWithSupplierFilterUsesTheAssociationTable()
+    {
+        $this->adapter->setSelectFields(['id_product']);
+        $this->adapter->addFilter('id_supplier', [7], '=');
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p INNER JOIN ps_product_supplier psup ON (p.id_product = psup.id_product) WHERE psup.id_supplier=\'7\' ORDER BY p.id_product DESC',
+            $this->adapter->getQuery()
+        );
+    }
+
+    /**
      * @dataProvider getManyOperationsFilters
      */
     public function testGetQueryWithManyOperationsFilters($fields, $operationsFilter, $expected)


### PR DESCRIPTION
Fixes PrestaShop/PrestaShop#41531

### Problem

A product associated with several suppliers through the product's Suppliers tab only appears on the front-office page of the supplier marked as default. The association written to `product_supplier` is ignored.

`Search::initSearch()` filters the supplier page with `addFilter('id_supplier', ...)`, but `id_supplier` has no entry in `MySQL::getFieldMapping()`. Fields absent from that map are resolved against the base product table, so the condition becomes `p.id_supplier`, which holds only the default supplier:

```sql
SELECT p.id_product FROM ps_product p WHERE p.id_supplier='7' ORDER BY p.id_product DESC
```

### Fix

Map `id_supplier` to `product_supplier`, the table the association actually lives in:

```sql
SELECT p.id_product FROM ps_product p
  INNER JOIN ps_product_supplier psup ON (p.id_product = psup.id_product)
  WHERE psup.id_supplier='7' ORDER BY p.id_product DESC
```

Both queries are the real output of `MySQLTest`, before and after.

### Why the join is safe

`product_supplier` holds a row per product, combination and supplier, so a join can repeat a product. Both consumers already collapse that:

- the listing groups by product - `Search.php` calls `addGroupBy('id_product')`, and so does `Filters\Products`,
- the counts use `COUNT(DISTINCT p.id_product)` in `valueCount()`, which `count()` delegates to.

The mapping also cannot affect other pages: `computeJoinConditions()` builds joins only from the select fields and the filter keys in use, so the join appears only when `id_supplier` is actually filtered, which is the supplier controller. `psup` is used as the alias because `ps` is already taken by `product_shop`.

### Tests

`MySQLTest::testGetQueryWithSupplierFilterUsesTheAssociationTable` asserts the generated SQL. Reverting only `src/Adapter/MySQL.php` fails it with the `p.id_supplier` query above. The full suite passes: 101 tests, 933 assertions.

php-cs-fixer with `.php_cs.dist` reports nothing to fix. I could not run PHPStan locally - it is not in the module's `vendor/`, it comes from the shared `php-ci/phpstan` action - so that one is left to CI. The change is a literal array entry, so there is little for it to chew on.
