### PR TITLE
fix: apply price post-filtering before counting and pagination

### DIFF
--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -86,6 +86,9 @@ class Products
         // Get full list of matching products
         $fullProductList = $this->searchAdapter->execute();
 
+        // Run post filter
+        $this->pricePostFiltering($fullProductList, $selectedFilters);
+
         // Count them
         $totalProductCount = count($fullProductList);
 
@@ -99,9 +102,6 @@ class Products
             ($page - 1) * $productsPerPage,
             $productsPerPage
         );
-
-        // And run post filter
-        $this->pricePostFiltering($finalProductList, $selectedFilters);
 
         return [
             'products' => $finalProductList,


### PR DESCRIPTION
The price post-filter recomputes each product's real price for the current customer group and drops the ones outside the requested range. It ran after array_slice(), so the total and page count kept their pre-filter values and a whole page could end up empty while the listing announced dozens of results.

Applying it to the full result list keeps the count, the pagination and the rendered products consistent.

| Questions         | Answers                                                                                                                                                 
  | ----------------- | -------------------------------------------------------                                                                                                 
  | Description?      | The price post-filter runs after pagination, so the announced total and page count don't match the products actually rendered : a filtered page can come back empty. Moving it before the count fixes both. Reproduced on PrestaShop 8.2.7 with ps_facetedsearch `dev`.                                                                
  | Type?             | bug fix                                                                                                                                                 
  | BC breaks?        | no                                                                                                                                                      
  | Deprecations?     | no                                                                                                                                                      
  | Fixed ticket?     | #1280                                                                                                                                                    
  | How to test?      | See below.                                                                                                                                              
  | Sponsor company   | iomedia

### Problem                                                                                                                                                                   
                                                                                                                                                                                
`Products::getProductByFilters()` builds the result list in this order:                                                                                                       
                                                                                                                                                                                
  1. SQL query against `ps_layered_price_index`, which stores, per product, the **envelope** of prices across all customer groups and specific prices;                          
  2. `count()` : the total shown to the customer;                                                                                                                               
  3. `array_slice()` : the current page;                                                                                                                                        
  4. `pricePostFiltering()` : recomputes each product's real price for the current customer group via `Product::getPriceStatic()` and drops the ones outside the requested range.                                                                                                                                                                        
                                                                                                                                                                                
Step 4 only ever sees the current page, and it runs after the count. So the total and the page count keep their pre-filter values while the grid is silently shortened. On a shop where several groups have a discount, the indexed envelope is much wider than any single visitor's real price, and a whole page can be emptied: the listing announces "62 results / 6 pages" and renders nothing.                                                                                                                                       
                                                                                                                                                                                
The same slice is also used to decide what page 2 contains, so products dropped on page 1 are never shown at all, they are not pushed to the next page.                      
                                                                                                                                                                                
  ### Fix                                                                                                                                                                       
                                                                                                                                                                                
  Apply the post-filter to the full result list, before counting and slicing.                                                                                                   
                                                                                                                                                                                
  ### How to test                                                                                                                                                               
                                                                                                                                                                                
  1. PrestaShop 8.x with demo data, `ps_facetedsearch` enabled with a price filter on a category.                                                                               
  2. Customers > Groups > *Customer* — set a 25% discount. This widens every product's indexed price range.                                                                     
  3. Module configuration > rebuild the price index (or run `ps_facetedsearch-price-indexer.php`).                                                                              
  4. As a **guest**, open the category and pick a price range that sits below most products' public prices, e.g. the lower half of the slider.                                  
                                                                                                                                                                                
Before: the header announces a large number of results across several pages, while the grid shows few or no products; summing the products across all pages never reaches the announced total.                                                                                                                                                              
                                                                                                                                                                                
After: the announced total equals the number of products actually reachable across the pages, every page is full except the last, and no product appears twice or goes missing.                                                                                                                                                                      
                                                                                                                                                                                
  ### Trade-off                                                                                                                                                                 
                                                                                                                                                                                
  `Product::getPriceStatic()` now runs for every product whose indexed range straddles a filter bound, instead of only those on the current page. It is only reached when a price filter is active, only for straddling products, and `getPriceStatic()` has a static cache, but on a large catalogue with wide group discounts this is more work per request than before. It seemed preferable to a listing that reports numbers it cannot deliver.
