### PR TITLE
fix: re-check price for product whose indexed range exceeds the filter

### DIFF
--- a/src/Filters/Products.php
+++ b/src/Filters/Products.php
@@ -170,8 +170,8 @@ class Products
     ) {
         /* for this case, price could be out of range, so we need to compute the real price */
         foreach ($matchingProductList as $key => $product) {
-            if (($product['price_min'] < (int) $priceFilter['min'] && $product['price_max'] > (int) $priceFilter['min'])
-                || ($product['price_max'] > (int) $priceFilter['max'] && $product['price_min'] < (int) $priceFilter['max'])
+            if ($product['price_min'] < $priceFilter['min']
+                || $product['price_max'] > $priceFilter['max']
             ) {
                 $price = Product::getPriceStatic($product['id_product'], $psLayeredFilterPriceUsetax);
                 if ($psLayeredFilterPriceRounding) {


### PR DESCRIPTION
The SQL selects products with inclusive bounds (price_min <= max), while the straddle test used a strict comparison (price_min < max). A product whose indexed price_min lands exactly on the requested upper bound therefore escaped the re-check and stayed in the listing at its real price, outside the range. The mirror case exists on the lower bound.

The extra clause is unnecessary: a re-check is needed exactly when the indexed envelope is not fully contained in the requested range, since a contained envelope guarantees the real price is in range. Also drop the int casts, which truncated non-integer bounds before comparison.

| Questions | Answers 
| ----------------- | ------------------------------------------------------- 
| Description?| A product whose indexed `price_min` lands exactly on the requested upper bound escapes the price re-check and stays in the listing at its real price, outside the range. The SQL selects with inclusive bounds while the straddle test uses a strict comparison.
| Type? | bug fix 
| BC breaks?| no
| Deprecations? | no
| Fixed ticket? | Fixes #1282
| How to test?| See below.
| Sponsor company | iomedia

### How to test

1. PrestaShop 8.x, `ps_facetedsearch` enabled with a price filter on a category.
2. Give the *Customer* group a discount (Customers > Groups) so products get a wide indexed range.
3. Rebuild the price index (module configuration, or `ps_facetedsearch-price-indexer.php`).
4. Pick a product, read its `price_min` in `ps_layered_price_index`, and browse the category **as a guest** with a price filter whose **upper bound equals that exact value**.

Before: the product is listed even though its real price is well above the bound. Any neighbouring bound excludes it correctly — only the one landing on `price_min` triggers it.

After: it is excluded, and it still shows up under the ranges that actually contain its price.
