### PR TITLE
Support combination feature values in feature filters

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -176,7 +176,18 @@ class MySQL extends AbstractAdapter
         $featureJoinCondition = '(p.id_product = fp.id_product)';
         $featureJoinExtra = [];
         if ($this->isCombinationFeatureFilteringEnabled()) {
-            $featureProductTable = $this->getFeatureProductDerivedTable();
+            // Derived table (id_product, id_product_attribute, id_feature, id_feature_value) merging
+            // product-level feature values with the ones defined at combination level
+            // (feature_product_attribute, resolved to their product through product_attribute). The
+            // id_product_attribute column is NULL for product-level values, so a feature filter can be
+            // correlated with a specific combination. The UNION removes duplicates so a value defined
+            // at both levels is not counted twice.
+            $featureProductTable = '(SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
+                . ' FROM ' . _DB_PREFIX_ . 'feature_product'
+                . ' UNION'
+                . ' SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
+                . ' FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa'
+                . ' INNER JOIN ' . _DB_PREFIX_ . 'product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute)';
             $featureProductRawTable = true;
             // Correlate the feature row with the combination currently joined (pa) so that a feature
             // filter and an attribute filter must be satisfied by the same combination, not by two
@@ -376,30 +387,6 @@ class MySQL extends AbstractAdapter
     protected function isCombinationFeatureFilteringEnabled()
     {
         return CombinationFeature::isFilteringEnabled();
-    }
-
-    /**
-     * Builds a derived table (id_product, id_product_attribute, id_feature, id_feature_value) that
-     * merges the product-level feature values with the ones defined at combination level
-     * (feature_product_attribute, resolved to their product through product_attribute). The
-     * id_product_attribute column is NULL for product-level values and set for combination-level
-     * ones, so getFieldMapping() can correlate a feature filter with a specific combination. The
-     * UNION removes duplicates so a value defined at both levels is not counted twice.
-     *
-     * Overrides must keep the exact same columns (id_product, id_product_attribute, id_feature,
-     * id_feature_value) so the derived table stays a drop-in replacement for feature_product in
-     * getFieldMapping().
-     *
-     * @return string
-     */
-    protected function getFeatureProductDerivedTable()
-    {
-        return '(SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
-            . ' FROM ' . _DB_PREFIX_ . 'feature_product'
-            . ' UNION'
-            . ' SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
-            . ' FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa'
-            . ' INNER JOIN ' . _DB_PREFIX_ . 'product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute)';
     }
 
     /**

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -173,9 +173,18 @@ class MySQL extends AbstractAdapter
         // becomes filterable by a feature value carried by any of its combinations.
         $featureProductTable = 'feature_product';
         $featureProductRawTable = false;
+        $featureJoinCondition = '(p.id_product = fp.id_product)';
+        $featureJoinExtra = [];
         if ($this->isCombinationFeatureFilteringEnabled()) {
             $featureProductTable = $this->getFeatureProductDerivedTable();
             $featureProductRawTable = true;
+            // Correlate the feature row with the combination currently joined (pa) so that a feature
+            // filter and an attribute filter must be satisfied by the same combination, not by two
+            // different ones. Product-level feature values (id_product_attribute IS NULL) keep
+            // applying to every combination.
+            $featureJoinCondition = '(p.id_product = fp.id_product'
+                . ' AND (fp.id_product_attribute IS NULL OR fp.id_product_attribute = pa.id_product_attribute))';
+            $featureJoinExtra = ['dependencyField' => 'id_product_attribute'];
         }
 
         $filterToTableMapping = [
@@ -199,13 +208,13 @@ class MySQL extends AbstractAdapter
                 'joinType' => self::INNER_JOIN,
                 'dependencyField' => 'id_attribute',
             ],
-            'id_feature' => [
+            'id_feature' => array_merge([
                 'tableName' => $featureProductTable,
                 'tableAlias' => 'fp',
-                'joinCondition' => '(p.id_product = fp.id_product)',
+                'joinCondition' => $featureJoinCondition,
                 'joinType' => self::INNER_JOIN,
                 'rawTable' => $featureProductRawTable,
-            ],
+            ], $featureJoinExtra),
             'id_shop' => [
                 'tableName' => 'product_shop',
                 'tableAlias' => 'ps',
@@ -220,13 +229,13 @@ class MySQL extends AbstractAdapter
                     $this->getContext()->shop->id . ' AND ps.active = TRUE)',
                 'joinType' => self::INNER_JOIN,
             ],
-            'id_feature_value' => [
+            'id_feature_value' => array_merge([
                 'tableName' => $featureProductTable,
                 'tableAlias' => 'fp',
-                'joinCondition' => '(p.id_product = fp.id_product)',
+                'joinCondition' => $featureJoinCondition,
                 'joinType' => self::LEFT_JOIN,
                 'rawTable' => $featureProductRawTable,
-            ],
+            ], $featureJoinExtra),
             'id_category' => [
                 'tableName' => 'category_product',
                 'tableAlias' => 'cp',
@@ -370,23 +379,25 @@ class MySQL extends AbstractAdapter
     }
 
     /**
-     * Builds a derived table, shaped exactly like feature_product (id_product, id_feature,
-     * id_feature_value), that merges the product-level feature values with the ones defined at
-     * combination level (feature_product_attribute, resolved to their product through
-     * product_attribute). The UNION removes duplicates so a value defined at both levels is not
-     * counted twice.
+     * Builds a derived table (id_product, id_product_attribute, id_feature, id_feature_value) that
+     * merges the product-level feature values with the ones defined at combination level
+     * (feature_product_attribute, resolved to their product through product_attribute). The
+     * id_product_attribute column is NULL for product-level values and set for combination-level
+     * ones, so getFieldMapping() can correlate a feature filter with a specific combination. The
+     * UNION removes duplicates so a value defined at both levels is not counted twice.
      *
-     * Overrides must keep the exact same columns (id_product, id_feature, id_feature_value) so the
-     * derived table stays a drop-in replacement for feature_product in getFieldMapping().
+     * Overrides must keep the exact same columns (id_product, id_product_attribute, id_feature,
+     * id_feature_value) so the derived table stays a drop-in replacement for feature_product in
+     * getFieldMapping().
      *
      * @return string
      */
     protected function getFeatureProductDerivedTable()
     {
-        return '(SELECT id_product, id_feature, id_feature_value'
+        return '(SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
             . ' FROM ' . _DB_PREFIX_ . 'feature_product'
             . ' UNION'
-            . ' SELECT pa.id_product, fpa.id_feature, fpa.id_feature_value'
+            . ' SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
             . ' FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa'
             . ' INNER JOIN ' . _DB_PREFIX_ . 'product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute)';
     }

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -24,6 +24,7 @@ use Configuration;
 use Context;
 use Db;
 use Doctrine\Common\Collections\ArrayCollection;
+use PrestaShop\Module\FacetedSearch\CombinationFeature;
 use Product;
 use StockAvailable;
 
@@ -117,7 +118,12 @@ class MySQL extends AbstractAdapter
         // Add join conditions if any
         foreach ($joinConditions as $joinAliasInfos) {
             foreach ($joinAliasInfos as $tableAlias => $joinInfos) {
-                $query .= ' ' . $joinInfos['joinType'] . ' ' . _DB_PREFIX_ . $joinInfos['tableName'] . ' ' .
+                // A "raw" table is already a full table expression (e.g. a derived table) and must not
+                // be prefixed, otherwise it is a regular table name living behind the database prefix.
+                $tableName = !empty($joinInfos['rawTable'])
+                    ? $joinInfos['tableName']
+                    : _DB_PREFIX_ . $joinInfos['tableName'];
+                $query .= ' ' . $joinInfos['joinType'] . ' ' . $tableName . ' ' .
                        $tableAlias . ' ON ' . $joinInfos['joinCondition'];
             }
         }
@@ -161,6 +167,17 @@ class MySQL extends AbstractAdapter
             'sa'
         );
 
+        // Feature filters are resolved against the feature_product table by default. When combination
+        // feature values are enabled (PrestaShop >= 9.3 + feature flag), we swap that table for a
+        // derived table that also exposes the feature values defined at combination level, so a product
+        // becomes filterable by a feature value carried by any of its combinations.
+        $featureProductTable = 'feature_product';
+        $featureProductRawTable = false;
+        if ($this->isCombinationFeatureFilteringEnabled()) {
+            $featureProductTable = $this->getFeatureProductDerivedTable();
+            $featureProductRawTable = true;
+        }
+
         $filterToTableMapping = [
             'id_product_attribute' => [
                 'tableName' => 'product_attribute',
@@ -183,10 +200,11 @@ class MySQL extends AbstractAdapter
                 'dependencyField' => 'id_attribute',
             ],
             'id_feature' => [
-                'tableName' => 'feature_product',
+                'tableName' => $featureProductTable,
                 'tableAlias' => 'fp',
                 'joinCondition' => '(p.id_product = fp.id_product)',
                 'joinType' => self::INNER_JOIN,
+                'rawTable' => $featureProductRawTable,
             ],
             'id_shop' => [
                 'tableName' => 'product_shop',
@@ -203,10 +221,11 @@ class MySQL extends AbstractAdapter
                 'joinType' => self::INNER_JOIN,
             ],
             'id_feature_value' => [
-                'tableName' => 'feature_product',
+                'tableName' => $featureProductTable,
                 'tableAlias' => 'fp',
                 'joinCondition' => '(p.id_product = fp.id_product)',
                 'joinType' => self::LEFT_JOIN,
+                'rawTable' => $featureProductRawTable,
             ],
             'id_category' => [
                 'tableName' => 'category_product',
@@ -337,6 +356,39 @@ class MySQL extends AbstractAdapter
         ];
 
         return $filterToTableMapping;
+    }
+
+    /**
+     * Whether feature filters must also take combination feature values into account.
+     * Extracted so it can be overridden in tests.
+     *
+     * @return bool
+     */
+    protected function isCombinationFeatureFilteringEnabled()
+    {
+        return CombinationFeature::isFilteringEnabled();
+    }
+
+    /**
+     * Builds a derived table, shaped exactly like feature_product (id_product, id_feature,
+     * id_feature_value), that merges the product-level feature values with the ones defined at
+     * combination level (feature_product_attribute, resolved to their product through
+     * product_attribute). The UNION removes duplicates so a value defined at both levels is not
+     * counted twice.
+     *
+     * Overrides must keep the exact same columns (id_product, id_feature, id_feature_value) so the
+     * derived table stays a drop-in replacement for feature_product in getFieldMapping().
+     *
+     * @return string
+     */
+    protected function getFeatureProductDerivedTable()
+    {
+        return '(SELECT id_product, id_feature, id_feature_value'
+            . ' FROM ' . _DB_PREFIX_ . 'feature_product'
+            . ' UNION'
+            . ' SELECT pa.id_product, fpa.id_feature, fpa.id_feature_value'
+            . ' FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa'
+            . ' INNER JOIN ' . _DB_PREFIX_ . 'product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute)';
     }
 
     /**
@@ -723,6 +775,7 @@ class MySQL extends AbstractAdapter
             'tableName' => $joinMapping['tableName'],
             'joinCondition' => $joinMapping['joinCondition'],
             'joinType' => $joinMapping['joinType'],
+            'rawTable' => !empty($joinMapping['rawTable']),
         ];
 
         $joinList->set($joinMapping['tableAlias'] . '_' . $joinMapping['tableName'], $joinInfos);

--- a/src/CombinationFeature.php
+++ b/src/CombinationFeature.php
@@ -66,6 +66,7 @@ class CombinationFeature
         }
 
         try {
+            /** @var \Psr\Container\ContainerInterface $container */
             $container = (new ContainerFinder(Context::getContext()))->getContainer();
             $checker = $container->get('PrestaShop\\PrestaShop\\Core\\FeatureFlag\\FeatureFlagStateCheckerInterface');
             self::$enabled = $checker !== null && $checker->isEnabled(self::FEATURE_FLAG);

--- a/src/CombinationFeature.php
+++ b/src/CombinationFeature.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\FacetedSearch;
+
+use Context;
+use PrestaShop\PrestaShop\Adapter\ContainerFinder;
+use Throwable;
+
+/**
+ * Tells whether the faceted search must also take combination (product_attribute) feature values
+ * into account, in addition to the product ones.
+ *
+ * This is only available from PrestaShop 9.3 (the version that introduced feature values at
+ * combination level) and must additionally be turned on through the "combination_feature_values"
+ * feature flag.
+ */
+class CombinationFeature
+{
+    /**
+     * Name of the core feature flag guarding combination feature values.
+     */
+    public const FEATURE_FLAG = 'combination_feature_values';
+
+    /**
+     * Minimum PrestaShop version exposing combination feature values.
+     */
+    public const MIN_PS_VERSION = '9.3.0';
+
+    /**
+     * @var bool|null
+     */
+    private static $enabled;
+
+    /**
+     * @return bool
+     */
+    public static function isFilteringEnabled()
+    {
+        if (self::$enabled !== null) {
+            return self::$enabled;
+        }
+
+        self::$enabled = false;
+
+        // Combination feature values simply do not exist before PrestaShop 9.3.
+        if (version_compare(_PS_VERSION_, self::MIN_PS_VERSION, '<')) {
+            return self::$enabled;
+        }
+
+        try {
+            $container = (new ContainerFinder(Context::getContext()))->getContainer();
+            $checker = $container->get('PrestaShop\\PrestaShop\\Core\\FeatureFlag\\FeatureFlagStateCheckerInterface');
+            self::$enabled = $checker !== null && $checker->isEnabled(self::FEATURE_FLAG);
+        } catch (Throwable $e) {
+            // If the container or the checker is not reachable, stay on the historical behavior.
+            self::$enabled = false;
+        }
+
+        return self::$enabled;
+    }
+
+    /**
+     * Resets the memoized state, mostly useful for tests.
+     */
+    public static function resetCache()
+    {
+        self::$enabled = null;
+    }
+}

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -103,14 +103,53 @@ class MySQLTest extends MockeryTestCase
         $adapter->addSelectField('id_feature');
 
         // The feature_product table is replaced by a derived table merging product-level and
-        // combination-level (feature_product_attribute) feature values.
+        // combination-level (feature_product_attribute) feature values. Each row also exposes the
+        // combination it belongs to (id_product_attribute, NULL at product level) and the feature
+        // join is correlated with the product_attribute (pa) join.
         $this->assertEquals(
             'SELECT fp.id_feature FROM ps_product p'
-            . ' INNER JOIN (SELECT id_product, id_feature, id_feature_value FROM ps_feature_product'
-            . ' UNION SELECT pa.id_product, fpa.id_feature, fpa.id_feature_value'
+            . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
+            . ' INNER JOIN (SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
+            . ' FROM ps_feature_product'
+            . ' UNION SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
             . ' FROM ps_feature_product_attribute fpa'
             . ' INNER JOIN ps_product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute) fp'
-            . ' ON (p.id_product = fp.id_product) ORDER BY p.id_product DESC',
+            . ' ON (p.id_product = fp.id_product'
+            . ' AND (fp.id_product_attribute IS NULL OR fp.id_product_attribute = pa.id_product_attribute))'
+            . ' ORDER BY p.id_product DESC',
+            $adapter->getQuery()
+        );
+    }
+
+    public function testFeatureAndAttributeFiltersMustMatchTheSameCombination()
+    {
+        $adapter = new class() extends MySQL {
+            protected function isCombinationFeatureFilteringEnabled()
+            {
+                return true;
+            }
+        };
+
+        // Filter on a feature value carried by one combination and on an attribute carried by
+        // another one, the way Product\Search adds them.
+        $adapter->addOperationsFilter('with_features_3', [[['id_feature_value', [11]]]]);
+        $adapter->addOperationsFilter('with_attributes_1', [[['id_attribute', [7]]]]);
+
+        // Both the feature (fp) and the attribute (pac) joins are correlated with the same
+        // product_attribute (pa) row, so the two filters must be satisfied by the same combination.
+        $this->assertEquals(
+            'SELECT  FROM ps_product p'
+            . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
+            . ' LEFT JOIN (SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
+            . ' FROM ps_feature_product'
+            . ' UNION SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
+            . ' FROM ps_feature_product_attribute fpa'
+            . ' INNER JOIN ps_product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute) fp'
+            . ' ON (p.id_product = fp.id_product'
+            . ' AND (fp.id_product_attribute IS NULL OR fp.id_product_attribute = pa.id_product_attribute))'
+            . ' LEFT JOIN ps_product_attribute_combination pac_1 ON (pa.id_product_attribute = pac_1.id_product_attribute)'
+            . ' WHERE ((fp.id_feature_value=11)) AND ((pac_1.id_attribute=7))'
+            . ' ORDER BY p.id_product DESC',
             $adapter->getQuery()
         );
     }

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -91,6 +91,30 @@ class MySQLTest extends MockeryTestCase
         );
     }
 
+    public function testGetQueryWithFeatureIncludesCombinationFeatures()
+    {
+        $adapter = new class() extends MySQL {
+            protected function isCombinationFeatureFilteringEnabled()
+            {
+                return true;
+            }
+        };
+
+        $adapter->addSelectField('id_feature');
+
+        // The feature_product table is replaced by a derived table merging product-level and
+        // combination-level (feature_product_attribute) feature values.
+        $this->assertEquals(
+            'SELECT fp.id_feature FROM ps_product p'
+            . ' INNER JOIN (SELECT id_product, id_feature, id_feature_value FROM ps_feature_product'
+            . ' UNION SELECT pa.id_product, fpa.id_feature, fpa.id_feature_value'
+            . ' FROM ps_feature_product_attribute fpa'
+            . ' INNER JOIN ps_product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute) fp'
+            . ' ON (p.id_product = fp.id_product) ORDER BY p.id_product DESC',
+            $adapter->getQuery()
+        );
+    }
+
     public function testGetMinMaxPriceValue()
     {
         $dbInstanceMock = Mockery::mock(Db::class)->makePartial();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | See below.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/discussions/37479
| How to test?      | See below.
| Sponsor company   | creabilis.com

### Description

PrestaShop 9.3 introduced feature values at combination level ([PrestaShop/PrestaShop#41830](https://github.com/PrestaShop/PrestaShop/pull/41830)). This PR brings them into the faceted search: feature filters now also take combination (`product_attribute`) feature values into account, so a feature carried only by combinations shows up in the facets with correct product counts.

The behavior is gated first by PrestaShop `>= 9.3`, then by the `combination_feature_values` feature flag. On older versions, or with the flag off, nothing changes.

### About `rawTable`

The MySQL adapter maps each filter field to a DB table, and the query builder prepends `_DB_PREFIX_` to that name. To merge product-level and combination-level values, `id_feature` / `id_feature_value` are now mapped to a derived sub-select (a `UNION` of `feature_product` and combination values resolved through `product_attribute`) instead of `feature_product`. Since a derived table is already a full SQL expression and not a table name, a new `rawTable` flag on the join mapping tells the builder to use it as-is, without prepending the prefix.

### How to test

1. On PrestaShop `>= 9.3`, enable the `combination_feature_values` feature flag.
2. Create a feature and assign its values only to a product's combinations (not to the product itself).
3. Add that feature to the filter template of the product's category.
4. Front office: the feature appears in the faceted filters, with the combination values and correct product counts.
