### PR TITLE
Optimize performance of product listing

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -556,6 +556,28 @@ class MySQL extends AbstractAdapter
     }
 
     /**
+     * Check whether a field must be read from its mapped table when used in a filter condition.
+     *
+     * Aggregated fields are exposed by the derived product table as an aggregate
+     * (SUM(sa.quantity) as quantity), which is not interchangeable with the row level value a
+     * WHERE condition compares against. They always have to be read from their mapped table,
+     * otherwise the filter silently changes meaning.
+     *
+     * @param string $fieldName
+     * @param array $filterToTableMapping
+     *
+     * @return bool
+     */
+    private function requiresMappedTableForFilter($fieldName, array $filterToTableMapping)
+    {
+        if (isset($filterToTableMapping[$fieldName]['aggregateFunction'])) {
+            return true;
+        }
+
+        return $this->requiresMappedTable($fieldName, $filterToTableMapping);
+    }
+
+    /**
      * Add alias to table field name
      *
      * @param string $fieldName
@@ -620,7 +642,7 @@ class MySQL extends AbstractAdapter
                 foreach ($operations as $idx => $operation) {
                     $selectAlias = 'p';
                     $values = $operation[1];
-                    if ($this->requiresMappedTable($operation[0], $filterToTableMapping)) {
+                    if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         // If index is not the first, append to the table alias for
                         // multi join
@@ -649,7 +671,7 @@ class MySQL extends AbstractAdapter
 
         foreach ($this->getFilters() as $filterName => $filterContent) {
             $selectAlias = 'p';
-            if ($this->requiresMappedTable($filterName, $filterToTableMapping)) {
+            if ($this->requiresMappedTableForFilter($filterName, $filterToTableMapping)) {
                 $joinMapping = $filterToTableMapping[$filterName];
                 $selectAlias = $joinMapping['tableAlias'];
                 $filterName = isset($joinMapping['fieldName']) ? $joinMapping['fieldName'] : $filterName;
@@ -728,13 +750,13 @@ class MySQL extends AbstractAdapter
         $joinList = new ArrayCollection();
 
         $this->addJoinList($joinList, $this->getSelectFields(), $filterToTableMapping);
-        $this->addJoinList($joinList, $this->getFilters()->getKeys(), $filterToTableMapping);
+        $this->addJoinList($joinList, $this->getFilters()->getKeys(), $filterToTableMapping, true);
 
         $operationIdx = 0;
         foreach ($this->getOperationsFilters() as $filterOperations) {
             foreach ($filterOperations as $operations) {
                 foreach ($operations as $idx => $operation) {
-                    if ($this->requiresMappedTable($operation[0], $filterToTableMapping)) {
+                    if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         if ($idx !== 0 || $operationIdx !== 0) {
                             // Index is not the first, append index to tableAlias on joinCondition
@@ -774,10 +796,12 @@ class MySQL extends AbstractAdapter
      * @param array|ArrayCollection $list
      * @param array $filterToTableMapping
      */
-    private function addJoinList(ArrayCollection $joinList, $list, array $filterToTableMapping)
+    private function addJoinList(ArrayCollection $joinList, $list, array $filterToTableMapping, $forFilter = false)
     {
         foreach ($list as $field) {
-            if ($this->requiresMappedTable($field, $filterToTableMapping)) {
+            if ($forFilter
+                ? $this->requiresMappedTableForFilter($field, $filterToTableMapping)
+                : $this->requiresMappedTable($field, $filterToTableMapping)) {
                 $joinMapping = $filterToTableMapping[$field];
                 $this->addJoinConditions($joinList, $joinMapping, $filterToTableMapping);
             }

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -95,6 +95,9 @@ class MySQL extends AbstractAdapter
         // Prepare mapping for joined tables
         $filterToTableMapping = $this->getFieldMapping();
 
+        // Expose only base product fields required by the outer query from the initial population.
+        $this->addRequiredInitialPopulationFields($filterToTableMapping);
+
         // Process and generate all fields for the SQL query below
         $orderField = $this->computeOrderByField($filterToTableMapping);
         $selectFields = $this->computeSelectFields($filterToTableMapping);
@@ -226,6 +229,7 @@ class MySQL extends AbstractAdapter
                 'fieldName' => 'name',
                 'joinCondition' => '(p.id_manufacturer = m.id_manufacturer)',
                 'joinType' => self::LEFT_JOIN,
+                'requiredProductFields' => ['id_manufacturer'],
             ],
             'name' => [
                 'tableName' => 'product_lang',
@@ -380,8 +384,14 @@ class MySQL extends AbstractAdapter
             return $orderField;
         }
 
-        // If we have an initial population, add the field into initial population selects, so we can use it in the outer query for sorting
-        if ($this->getInitialPopulation() !== null) {
+        // Expose sortable fields from the initial population when their mapped value has a stable output name.
+        if ($this->getInitialPopulation() !== null
+            && $orderField !== 'price'
+            && (
+                !isset($filterToTableMapping[$orderField]['fieldName'])
+                || isset($filterToTableMapping[$orderField]['fieldAlias'])
+            )
+        ) {
             $this->getInitialPopulation()->addSelectField($orderField);
         }
 
@@ -435,6 +445,9 @@ class MySQL extends AbstractAdapter
             return $orderField;
         }
 
+        // Aggregate stock quantity only when stock-aware ordering is requested.
+        $this->getInitialPopulation()->addSelectField('quantity');
+
         $this->addSelectField('out_of_stock');
 
         // order by out-of-stock last
@@ -470,6 +483,79 @@ class MySQL extends AbstractAdapter
     }
 
     /**
+     * Add base product fields referenced by the outer query to its derived product table.
+     *
+     * Fields backed by mapped tables remain in the outer query so their joins are only added
+     * to the facet or result query that actually needs them.
+     *
+     * @param array $filterToTableMapping
+     */
+    private function addRequiredInitialPopulationFields(array $filterToTableMapping)
+    {
+        if ($this->getInitialPopulation() === null) {
+            return;
+        }
+
+        // Collect fields used by SELECT, GROUP BY and regular filters in the outer query.
+        $requiredFields = array_merge(
+            $this->getSelectFields()->toArray(),
+            $this->getGroupFields()->toArray(),
+            $this->getFilters()->getKeys()
+        );
+        if ($this->getOrderField() !== '' && $this->getOrderField() !== 'price') {
+            $requiredFields[] = $this->getOrderField();
+        }
+
+        // Include fields referenced by compound operation filters.
+        foreach ($this->getOperationsFilters() as $filterOperations) {
+            foreach ($filterOperations as $operations) {
+                foreach ($operations as $operation) {
+                    $requiredFields[] = $operation[0];
+                }
+            }
+        }
+
+        foreach (array_unique($requiredFields) as $fieldName) {
+            // Add plain product fields directly to the derived product table.
+            if (!ctype_alnum(str_replace('_', '', $fieldName))) {
+                continue;
+            }
+
+            if (!array_key_exists($fieldName, $filterToTableMapping)) {
+                $this->getInitialPopulation()->addSelectField($fieldName);
+                continue;
+            }
+
+            // Expose explicitly declared product fields required by an outer mapped join.
+            if (isset($filterToTableMapping[$fieldName]['requiredProductFields'])) {
+                foreach ($filterToTableMapping[$fieldName]['requiredProductFields'] as $requiredProductField) {
+                    $this->getInitialPopulation()->addSelectField($requiredProductField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check whether a field must be read from its mapped table instead of the initial population.
+     *
+     * @param string $fieldName
+     * @param array $filterToTableMapping
+     *
+     * @return bool
+     */
+    private function requiresMappedTable($fieldName, array $filterToTableMapping)
+    {
+        if (!array_key_exists($fieldName, $filterToTableMapping)) {
+            return false;
+        }
+
+        // Reuse a stable field alias already exposed by the derived product table.
+        return $this->getInitialPopulation() === null
+            || !$this->getInitialPopulation()->getSelectFields()->contains($fieldName)
+            || (isset($filterToTableMapping[$fieldName]['fieldName']) && !isset($filterToTableMapping[$fieldName]['fieldAlias']));
+    }
+
+    /**
      * Add alias to table field name
      *
      * @param string $fieldName
@@ -479,15 +565,7 @@ class MySQL extends AbstractAdapter
      */
     protected function computeFieldName($fieldName, $filterToTableMapping, $sortByField = false)
     {
-        if (array_key_exists($fieldName, $filterToTableMapping)
-            && (
-                // If the requested order field is in the result, no need to change tableAlias
-                // unless a fieldName key exists
-                isset($filterToTableMapping[$fieldName]['fieldName'])
-                || $this->getInitialPopulation() === null
-                || !$this->getInitialPopulation()->getSelectFields()->contains($fieldName)
-            )
-        ) {
+        if ($this->requiresMappedTable($fieldName, $filterToTableMapping)) {
             $joinMapping = $filterToTableMapping[$fieldName];
             $fieldName = $joinMapping['tableAlias'] . '.' . (isset($joinMapping['fieldName']) ? $joinMapping['fieldName'] : $fieldName);
             if ($sortByField === false) {
@@ -542,7 +620,7 @@ class MySQL extends AbstractAdapter
                 foreach ($operations as $idx => $operation) {
                     $selectAlias = 'p';
                     $values = $operation[1];
-                    if (array_key_exists($operation[0], $filterToTableMapping)) {
+                    if ($this->requiresMappedTable($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         // If index is not the first, append to the table alias for
                         // multi join
@@ -571,7 +649,7 @@ class MySQL extends AbstractAdapter
 
         foreach ($this->getFilters() as $filterName => $filterContent) {
             $selectAlias = 'p';
-            if (array_key_exists($filterName, $filterToTableMapping)) {
+            if ($this->requiresMappedTable($filterName, $filterToTableMapping)) {
                 $joinMapping = $filterToTableMapping[$filterName];
                 $selectAlias = $joinMapping['tableAlias'];
                 $filterName = isset($joinMapping['fieldName']) ? $joinMapping['fieldName'] : $filterName;
@@ -656,7 +734,7 @@ class MySQL extends AbstractAdapter
         foreach ($this->getOperationsFilters() as $filterOperations) {
             foreach ($filterOperations as $operations) {
                 foreach ($operations as $idx => $operation) {
-                    if (array_key_exists($operation[0], $filterToTableMapping)) {
+                    if ($this->requiresMappedTable($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         if ($idx !== 0 || $operationIdx !== 0) {
                             // Index is not the first, append index to tableAlias on joinCondition
@@ -681,7 +759,7 @@ class MySQL extends AbstractAdapter
 
         $this->addJoinList($joinList, $this->getGroupFields()->getKeys(), $filterToTableMapping);
 
-        if (array_key_exists($this->getOrderField(), $filterToTableMapping)) {
+        if ($this->requiresMappedTable($this->getOrderField(), $filterToTableMapping)) {
             $joinMapping = $filterToTableMapping[$this->getOrderField()];
             $this->addJoinConditions($joinList, $joinMapping, $filterToTableMapping);
         }
@@ -699,7 +777,7 @@ class MySQL extends AbstractAdapter
     private function addJoinList(ArrayCollection $joinList, $list, array $filterToTableMapping)
     {
         foreach ($list as $field) {
-            if (array_key_exists($field, $filterToTableMapping)) {
+            if ($this->requiresMappedTable($field, $filterToTableMapping)) {
                 $joinMapping = $filterToTableMapping[$field];
                 $this->addJoinConditions($joinList, $joinMapping, $filterToTableMapping);
             }
@@ -749,7 +827,7 @@ class MySQL extends AbstractAdapter
                 continue;
             }
 
-            if (array_key_exists($values, $filterToTableMapping)) {
+            if ($this->requiresMappedTable($values, $filterToTableMapping)) {
                 $joinMapping = $filterToTableMapping[$values];
                 $groupFields[$key] = $joinMapping['tableAlias'] . '.' . $values;
             } else {
@@ -815,20 +893,8 @@ class MySQL extends AbstractAdapter
         // Initial population has no ORDER BY
         $this->setOrderField('');
 
-        // We add basic select fields we will need to matter what
-        $this->setSelectFields(
-            [
-                'id_product',
-                'id_manufacturer',
-                'quantity',
-                'condition',
-                'weight',
-                'price',
-                'sales',
-                'on_sale',
-                'date_add',
-            ]
-        );
+        // Keep the base product population narrow until an outer query requests more fields.
+        $this->setSelectFields(['id_product']);
 
         // Clone it, add it to initial population
         $this->initialPopulation = clone $this;

--- a/src/Filters/DataAccessor.php
+++ b/src/Filters/DataAccessor.php
@@ -73,7 +73,8 @@ class DataAccessor
         }
 
         if (!isset($this->attributes[$idLang][$idAttributeGroup])) {
-            $this->attributes[$idLang] = [$idAttributeGroup => []];
+            // Initialize only the requested attribute group without discarding other cached groups for the language.
+            $this->attributes[$idLang][$idAttributeGroup] = [];
             $tempAttributes = $this->database->executeS(
                 'SELECT DISTINCT a.`id_attribute`, ' .
                 'a.`color`, ' .
@@ -190,7 +191,8 @@ class DataAccessor
     public function getFeatureValues($idFeature, $idLang)
     {
         if (!isset($this->featureValues[$idLang][$idFeature])) {
-            $this->featureValues[$idLang] = [$idFeature => []];
+            // Initialize only the requested feature without discarding other cached features for the language.
+            $this->featureValues[$idLang][$idFeature] = [];
             $tempFeatureValues = $this->database->executeS(
                 'SELECT v.*, vl.*, ' .
                 'IF(lifvlv.`url_name` IS NULL OR lifvlv.`url_name` = "", NULL, lifvlv.`url_name`) AS url_name, ' .

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -446,6 +446,44 @@ class MySQLTest extends MockeryTestCase
         );
     }
 
+    /**
+     * Once "out of stock last" ordering exposes quantity in the initial population, that column
+     * holds SUM(sa.quantity). A filter on quantity must still be read from the stock table,
+     * otherwise it silently compares against the aggregate instead of the row value.
+     */
+    public function testGetQueryFiltersQuantityOnStockTableWhenInitialPopulationExposesAggregate()
+    {
+        $configurationMock = Mockery::mock(Configuration::class);
+        $configurationMock->shouldReceive('get')
+            ->with('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST')
+            ->andReturn(true);
+        Configuration::setStaticExpectations($configurationMock);
+
+        $productMock = Mockery::namedMock(Product::class);
+        $productMock->shouldReceive('isAvailableWhenOutOfStock')
+            ->with(2)
+            ->andReturn(true);
+
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->useFiltersAsInitialPopulation();
+        $this->adapter->setOrderField('position');
+        $this->adapter->setOrderDirection('desc');
+
+        // Ordering pulls quantity into the initial population as SUM(sa.quantity) as quantity
+        $this->adapter->getQuery();
+
+        $filteredAdapter = $this->adapter->getFilteredSearchAdapter(Search::STOCK_MANAGEMENT_FILTER);
+        $filteredAdapter->addOperationsFilter(
+            Search::STOCK_MANAGEMENT_FILTER,
+            [[['quantity', [0], '<=']]]
+        );
+
+        $this->assertContains(
+            'WHERE ((sa.quantity<=0))',
+            $filteredAdapter->getQuery()
+        );
+    }
+
     public function testGetQueryWithComputeShowLastEnabledAndDenyOrderOutOfStockProducts()
     {
         $configurationMock = Mockery::mock(Configuration::class);

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -207,7 +207,7 @@ class MySQLTest extends MockeryTestCase
         $dbInstanceMock = Mockery::mock(Db::class);
         $dbInstanceMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT p.id_product, p.weight, COUNT(DISTINCT p.id_product) c FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product)) p GROUP BY p.weight')
+            ->with('SELECT p.id_product, p.weight, COUNT(DISTINCT p.id_product) c FROM (SELECT p.id_product, p.weight FROM ps_product p) p GROUP BY p.weight')
             ->andReturn(
                 [
                     [
@@ -244,7 +244,7 @@ class MySQLTest extends MockeryTestCase
         $dbInstanceMock = Mockery::mock(Db::class);
         $dbInstanceMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT p.id_product, p.weight, COUNT(DISTINCT p.id_product) c FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product) WHERE ((sa.quantity>=0))) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) WHERE ((sa.quantity>=0)) GROUP BY p.weight')
+            ->with('SELECT p.id_product, p.weight, COUNT(DISTINCT p.id_product) c FROM (SELECT p.id_product, p.weight FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) WHERE ((sa.quantity>=0))) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) WHERE ((sa.quantity>=0)) GROUP BY p.weight')
             ->andReturn(
                 [
                     [
@@ -391,7 +391,7 @@ class MySQLTest extends MockeryTestCase
         $this->adapter->setOrderDirection('asc');
 
         $this->assertEquals(
-            'SELECT p.id_product FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add, m.name FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product) LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer)) p LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer) ORDER BY m.name ASC, p.id_product DESC',
+            'SELECT p.id_product FROM (SELECT p.id_product, p.id_manufacturer FROM ps_product p) p LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer) ORDER BY m.name ASC, p.id_product DESC',
             $this->adapter->getQuery()
         );
     }
@@ -404,7 +404,20 @@ class MySQLTest extends MockeryTestCase
         $this->adapter->setOrderDirection('desc');
 
         $this->assertEquals(
-            'SELECT p.id_product FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add, cp.position FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product)) p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) ORDER BY p.position DESC, p.id_product DESC',
+            'SELECT p.id_product FROM (SELECT p.id_product, cp.position FROM ps_product p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product)) p ORDER BY p.position DESC, p.id_product DESC',
+            $this->adapter->getQuery()
+        );
+    }
+
+    public function testGetQueryWithSalesOrderFieldAndInitialPopulation()
+    {
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->useFiltersAsInitialPopulation();
+        $this->adapter->setOrderField('sales');
+        $this->adapter->setOrderDirection('desc');
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM (SELECT p.id_product, psales.quantity as sales FROM ps_product p LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product)) p ORDER BY p.sales DESC, p.id_product DESC',
             $this->adapter->getQuery()
         );
     }
@@ -428,7 +441,7 @@ class MySQLTest extends MockeryTestCase
         $this->adapter->setOrderDirection('desc');
 
         $this->assertEquals(
-            'SELECT p.id_product, sa.out_of_stock FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add, cp.position FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product)) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) ORDER BY IFNULL(p.quantity, 0) <= 0, IFNULL(p.quantity, 0) <= 0 AND FIELD(sa.out_of_stock, 0) ASC, p.position DESC, p.id_product DESC',
+            'SELECT p.id_product, sa.out_of_stock FROM (SELECT p.id_product, cp.position, SUM(sa.quantity) as quantity FROM ps_product p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute)) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) ORDER BY IFNULL(p.quantity, 0) <= 0, IFNULL(p.quantity, 0) <= 0 AND FIELD(sa.out_of_stock, 0) ASC, p.position DESC, p.id_product DESC',
             $this->adapter->getQuery()
         );
     }
@@ -452,7 +465,7 @@ class MySQLTest extends MockeryTestCase
         $this->adapter->setOrderDirection('desc');
 
         $this->assertEquals(
-            'SELECT p.id_product, sa.out_of_stock FROM (SELECT p.id_product, p.id_manufacturer, SUM(sa.quantity) as quantity, p.condition, p.weight, p.price, psales.quantity as sales, p.on_sale, p.date_add, cp.position FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) LEFT JOIN ps_product_sale psales ON (psales.id_product = p.id_product) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product)) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) ORDER BY IFNULL(p.quantity, 0) <= 0, IFNULL(p.quantity, 0) <= 0 AND FIELD(sa.out_of_stock, 1) DESC, p.position DESC, p.id_product DESC',
+            'SELECT p.id_product, sa.out_of_stock FROM (SELECT p.id_product, cp.position, SUM(sa.quantity) as quantity FROM ps_product p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute)) p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) ORDER BY IFNULL(p.quantity, 0) <= 0, IFNULL(p.quantity, 0) <= 0 AND FIELD(sa.out_of_stock, 1) DESC, p.position DESC, p.id_product DESC',
             $this->adapter->getQuery()
         );
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Optimizes the SQL query of the module - the initial population of products to only add fields if they are required. It reduced the load time in profiler by average of 40 ms on all of my listings, you can try and you should get same results. Next, fixes a small issue where DataAcccessor cached values were wiped, but this did not bring measurable performance benefit, maybe it would be visible in some cases I did not try.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.

### Performance measurement on combination heavy page

| Load | Default      | PR 1303      |
|------|-------------:|-------------:|
| 1    | 398 ms       | 220 ms       |
| 2    | 395 ms       | 239 ms       |
| 3    | 434 ms       | 220 ms       |
| 4    | 388 ms       | 228 ms       |
| 5    | 376 ms       | 226 ms       |
| 6    | 383 ms       | 217 ms       |
| 7    | 424 ms       | 221 ms       |
| 8    | 387 ms       | 224 ms       |
| 9    | 397 ms       | 221 ms       |
| 10   | 404 ms       | 222 ms       |
| **Average** | **398,6 ms** | **223,8 ms** |
| **Rows**    | **55 923 840** | **1 997 280** |