### PR TITLE
Add option for AND checkboxes to feature filter

### DIFF
--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -426,6 +426,34 @@ class MySQL extends AbstractAdapter
     }
 
     /**
+     * Build a feature value condition without multiplying rows in the product query.
+     *
+     * @param array $values
+     *
+     * @return string
+     */
+    private function computeFeatureValueExistsCondition(array $values)
+    {
+        // Use equality for one value and IN for multiple OR values.
+        if (count($values) === 1) {
+            $valueCondition = '=' . $this->getJoinedEscapedValue(', ', $values);
+        } else {
+            $valueCondition = ' IN (' . $this->getJoinedEscapedValue(', ', $values) . ')';
+        }
+
+        // Match values assigned directly to the product.
+        $productFeatureCondition = 'EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value' . $valueCondition . ')';
+        if (!$this->isCombinationFeatureFilteringEnabled()) {
+            return $productFeatureCondition;
+        }
+
+        // Match combination values against the same combination row used by attribute filters.
+        $combinationFeatureCondition = 'EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa_filter WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value' . $valueCondition . ')';
+
+        return '(' . $productFeatureCondition . ' OR ' . $combinationFeatureCondition . ')';
+    }
+
+    /**
      * Compute the orderby fields, adding the proper alias that will be added to the final query
      *
      * @param array $filterToTableMapping
@@ -702,6 +730,12 @@ class MySQL extends AbstractAdapter
             foreach ($filterOperations as $operations) {
                 $conditions = [];
                 foreach ($operations as $idx => $operation) {
+                    // Filter feature values through EXISTS so the main query keeps one row per current relation.
+                    if ($operation[0] === 'id_feature_value' && (empty($operation[2]) || $operation[2] === '=')) {
+                        $conditions[] = $this->computeFeatureValueExistsCondition($operation[1]);
+                        continue;
+                    }
+
                     $selectAlias = 'p';
                     $values = $operation[1];
                     if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
@@ -818,6 +852,15 @@ class MySQL extends AbstractAdapter
         foreach ($this->getOperationsFilters() as $filterOperations) {
             foreach ($filterOperations as $operations) {
                 foreach ($operations as $idx => $operation) {
+                    // Feature value operations use EXISTS and only combination values require the shared combination join.
+                    if ($operation[0] === 'id_feature_value' && (empty($operation[2]) || $operation[2] === '=')) {
+                        if ($this->isCombinationFeatureFilteringEnabled()) {
+                            $this->addJoinConditions($joinList, $filterToTableMapping['id_product_attribute'], $filterToTableMapping);
+                        }
+
+                        continue;
+                    }
+
                     if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         if ($idx !== 0 || $operationIdx !== 0) {
@@ -1020,6 +1063,21 @@ class MySQL extends AbstractAdapter
 
         $operationsFilters = clone $initialPopulation->getOperationsFilters();
         foreach ($operationsFilters as $operationName => $operations) {
+            // Feature EXISTS filters already restrict product membership in the initial population.
+            $containsOnlyFeatureValueOperations = true;
+            foreach ($operations as $operationGroup) {
+                foreach ($operationGroup as $operation) {
+                    if ($operation[0] !== 'id_feature_value') {
+                        $containsOnlyFeatureValueOperations = false;
+                        break 2;
+                    }
+                }
+            }
+
+            if ($containsOnlyFeatureValueOperations) {
+                continue;
+            }
+
             $this->addOperationsFilter(
                 $operationName,
                 $operations

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -426,34 +426,6 @@ class MySQL extends AbstractAdapter
     }
 
     /**
-     * Build a feature value condition without multiplying rows in the product query.
-     *
-     * @param array $values
-     *
-     * @return string
-     */
-    private function computeFeatureValueExistsCondition(array $values)
-    {
-        // Use equality for one value and IN for multiple OR values.
-        if (count($values) === 1) {
-            $valueCondition = '=' . $this->getJoinedEscapedValue(', ', $values);
-        } else {
-            $valueCondition = ' IN (' . $this->getJoinedEscapedValue(', ', $values) . ')';
-        }
-
-        // Match values assigned directly to the product.
-        $productFeatureCondition = 'EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value' . $valueCondition . ')';
-        if (!$this->isCombinationFeatureFilteringEnabled()) {
-            return $productFeatureCondition;
-        }
-
-        // Match combination values against the same combination row used by attribute filters.
-        $combinationFeatureCondition = 'EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'feature_product_attribute fpa_filter WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value' . $valueCondition . ')';
-
-        return '(' . $productFeatureCondition . ' OR ' . $combinationFeatureCondition . ')';
-    }
-
-    /**
      * Compute the orderby fields, adding the proper alias that will be added to the final query
      *
      * @param array $filterToTableMapping
@@ -730,12 +702,6 @@ class MySQL extends AbstractAdapter
             foreach ($filterOperations as $operations) {
                 $conditions = [];
                 foreach ($operations as $idx => $operation) {
-                    // Filter feature values through EXISTS so the main query keeps one row per current relation.
-                    if ($operation[0] === 'id_feature_value' && (empty($operation[2]) || $operation[2] === '=')) {
-                        $conditions[] = $this->computeFeatureValueExistsCondition($operation[1]);
-                        continue;
-                    }
-
                     $selectAlias = 'p';
                     $values = $operation[1];
                     if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
@@ -852,15 +818,6 @@ class MySQL extends AbstractAdapter
         foreach ($this->getOperationsFilters() as $filterOperations) {
             foreach ($filterOperations as $operations) {
                 foreach ($operations as $idx => $operation) {
-                    // Feature value operations use EXISTS and only combination values require the shared combination join.
-                    if ($operation[0] === 'id_feature_value' && (empty($operation[2]) || $operation[2] === '=')) {
-                        if ($this->isCombinationFeatureFilteringEnabled()) {
-                            $this->addJoinConditions($joinList, $filterToTableMapping['id_product_attribute'], $filterToTableMapping);
-                        }
-
-                        continue;
-                    }
-
                     if ($this->requiresMappedTableForFilter($operation[0], $filterToTableMapping)) {
                         $joinMapping = $filterToTableMapping[$operation[0]];
                         if ($idx !== 0 || $operationIdx !== 0) {
@@ -1063,21 +1020,6 @@ class MySQL extends AbstractAdapter
 
         $operationsFilters = clone $initialPopulation->getOperationsFilters();
         foreach ($operationsFilters as $operationName => $operations) {
-            // Feature EXISTS filters already restrict product membership in the initial population.
-            $containsOnlyFeatureValueOperations = true;
-            foreach ($operations as $operationGroup) {
-                foreach ($operationGroup as $operation) {
-                    if ($operation[0] !== 'id_feature_value') {
-                        $containsOnlyFeatureValueOperations = false;
-                        break 2;
-                    }
-                }
-            }
-
-            if ($containsOnlyFeatureValueOperations) {
-                continue;
-            }
-
             $this->addOperationsFilter(
                 $operationName,
                 $operations

--- a/src/Filters/Block.php
+++ b/src/Filters/Block.php
@@ -823,7 +823,10 @@ class Block
         $idFeature = $filter['id_value'];
         $filteredSearchAdapter = null;
 
-        if (!empty($selectedFilters['id_feature'])) {
+        // Keep current selections while counting additional values for an AND feature facet.
+        if ((int) (isset($filter['filter_type']) ? $filter['filter_type'] : Converter::WIDGET_TYPE_CHECKBOX) !== Converter::WIDGET_TYPE_CHECKBOX_AND
+            && !empty($selectedFilters['id_feature'])
+        ) {
             foreach ($selectedFilters['id_feature'] as $key => $selectedFilter) {
                 if ($key == $idFeature) {
                     $filteredSearchAdapter = $this->searchAdapter->getFilteredSearchAdapter('with_features_' . $idFeature);

--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -38,6 +38,7 @@ class Converter
     const WIDGET_TYPE_RADIO = 1;
     const WIDGET_TYPE_DROPDOWN = 2;
     const WIDGET_TYPE_SLIDER = 3;
+    const WIDGET_TYPE_CHECKBOX_AND = 4;
 
     const TYPE_ATTRIBUTE_GROUP = 'id_attribute_group';
     const TYPE_AVAILABILITY = 'availability';
@@ -208,6 +209,10 @@ class Converter
 
             switch ((int) $filterBlock['filter_type']) {
                 case self::WIDGET_TYPE_CHECKBOX:
+                    $facet->setMultipleSelectionAllowed(true);
+                    $facet->setWidgetType('checkbox');
+                    break;
+                case self::WIDGET_TYPE_CHECKBOX_AND:
                     $facet->setMultipleSelectionAllowed(true);
                     $facet->setWidgetType('checkbox');
                     break;
@@ -406,6 +411,13 @@ class Converter
                             ) {
                                 $searchFilters['id_feature'][$feature['id_feature']][] = $featureValue['id_feature_value'];
                             }
+                        }
+
+                        // Preserve the configured match mode for selected feature values.
+                        if ((int) $filter['filter_type'] === self::WIDGET_TYPE_CHECKBOX_AND
+                            && !empty($searchFilters['id_feature'][$feature['id_feature']])
+                        ) {
+                            $searchFilters['id_feature_operator'][$feature['id_feature']] = 'and';
                         }
                     }
                     break;

--- a/src/Product/Search.php
+++ b/src/Product/Search.php
@@ -164,8 +164,24 @@ class Search
 
             switch ($key) {
                 case 'id_feature':
-                    $operationsFilter = [];
                     foreach ($filterValues as $featureId => $filterValue) {
+                        // Require every selected value when the feature uses AND checkboxes.
+                        if (isset($selectedFilters['id_feature_operator'][$featureId])
+                            && $selectedFilters['id_feature_operator'][$featureId] === 'and'
+                        ) {
+                            $operations = [];
+                            foreach (array_unique($filterValue) as $idFeatureValue) {
+                                $operations[] = ['id_feature_value', [(int) $idFeatureValue]];
+                            }
+
+                            $this->getSearchAdapter()->addOperationsFilter(
+                                'with_features_' . $featureId,
+                                [$operations]
+                            );
+                            continue;
+                        }
+
+                        // Match any selected value for regular feature checkboxes.
                         $this->getSearchAdapter()->addOperationsFilter(
                             'with_features_' . $featureId,
                             [[['id_feature_value', $filterValue]]]

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -94,6 +94,48 @@ class MySQLTest extends MockeryTestCase
         $this->assertContains('ORDER BY ISNULL(MIN(IF(cp.id_category = 6, cp.position, NULL))) ASC, MIN(IF(cp.id_category = 6, cp.position, NULL)) ASC, p.id_product DESC', $query);
     }
 
+    /**
+     * An AND feature facet asks for every selected value at once. Each value becomes its own
+     * operation in a single group, and the adapter joins feature_product once per operation so a
+     * product only survives if it carries all of them. Reusing one join would compare a single row
+     * against several values and always return nothing.
+     */
+    public function testGetQueryWithFeatureValueAndFilterJoinsOncePerValue()
+    {
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->addOperationsFilter('with_features_1', [[
+            ['id_feature_value', [10]],
+            ['id_feature_value', [20]],
+        ]]);
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p'
+            . ' LEFT JOIN ps_feature_product fp ON (p.id_product = fp.id_product)'
+            . ' LEFT JOIN ps_feature_product fp_1 ON (p.id_product = fp_1.id_product)'
+            . ' WHERE ((fp.id_feature_value=10 AND fp_1.id_feature_value=20))'
+            . ' ORDER BY p.id_product DESC',
+            $this->adapter->getQuery()
+        );
+    }
+
+    /**
+     * A regular feature facet matches any of the selected values, so they stay in one operation
+     * and one join.
+     */
+    public function testGetQueryWithFeatureValueOrFilterJoinsOnce()
+    {
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->addOperationsFilter('with_features_1', [[['id_feature_value', [10, 20]]]]);
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p'
+            . ' LEFT JOIN ps_feature_product fp ON (p.id_product = fp.id_product)'
+            . ' WHERE ((fp.id_feature_value IN (10, 20)))'
+            . ' ORDER BY p.id_product DESC',
+            $this->adapter->getQuery()
+        );
+    }
+
     public function testGetEmptyQuery()
     {
         $this->assertEquals(
@@ -159,49 +201,20 @@ class MySQLTest extends MockeryTestCase
         $adapter->addOperationsFilter('with_features_3', [[['id_feature_value', [11]]]]);
         $adapter->addOperationsFilter('with_attributes_1', [[['id_attribute', [7]]]]);
 
-        // Product feature values match globally, while combination feature values and attributes are
-        // correlated with the same product_attribute (pa) row.
+        // Both the feature (fp) and the attribute (pac) joins are correlated with the same
+        // product_attribute (pa) row, so the two filters must be satisfied by the same combination.
         $this->assertEquals(
             'SELECT  FROM ps_product p'
             . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
+            . ' LEFT JOIN (SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
+            . ' FROM ps_feature_product'
+            . ' UNION SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
+            . ' FROM ps_feature_product_attribute fpa'
+            . ' INNER JOIN ps_product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute) fp'
+            . ' ON (p.id_product = fp.id_product'
+            . ' AND (fp.id_product_attribute IS NULL OR fp.id_product_attribute = pa.id_product_attribute))'
             . ' LEFT JOIN ps_product_attribute_combination pac_1 ON (pa.id_product_attribute = pac_1.id_product_attribute)'
-            . ' WHERE (((EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
-            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=11)'
-            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
-            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=11))))'
-            . ' AND ((pac_1.id_attribute=7))'
-            . ' ORDER BY p.id_product DESC',
-            $adapter->getQuery()
-        );
-    }
-
-    public function testCombinationFeatureAndFilterUsesExistsOnTheSameCombination()
-    {
-        $adapter = new class() extends MySQL {
-            protected function isCombinationFeatureFilteringEnabled()
-            {
-                return true;
-            }
-        };
-
-        // Require both selected values at product level or on the same combination row.
-        $adapter->addSelectField('id_product');
-        $adapter->addOperationsFilter('with_features_3', [[
-            ['id_feature_value', [11]],
-            ['id_feature_value', [12]],
-        ]]);
-
-        $this->assertEquals(
-            'SELECT p.id_product FROM ps_product p'
-            . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
-            . ' WHERE (((EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
-            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=11)'
-            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
-            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=11))'
-            . ' AND (EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
-            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=12)'
-            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
-            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=12))))'
+            . ' WHERE ((fp.id_feature_value=11)) AND ((pac_1.id_attribute=7))'
             . ' ORDER BY p.id_product DESC',
             $adapter->getQuery()
         );
@@ -475,33 +488,6 @@ class MySQLTest extends MockeryTestCase
 
         $this->assertEquals(
             $expected,
-            $this->adapter->getQuery()
-        );
-    }
-
-    public function testGetQueryWithFeatureValueOrFilterUsesExists()
-    {
-        // Match any selected feature value without joining feature rows into the product query.
-        $this->adapter->addSelectField('id_product');
-        $this->adapter->addOperationsFilter('with_features_1', [[['id_feature_value', [10, 20]]]]);
-
-        $this->assertEquals(
-            'SELECT p.id_product FROM ps_product p WHERE ((EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value IN (10, 20)))) ORDER BY p.id_product DESC',
-            $this->adapter->getQuery()
-        );
-    }
-
-    public function testGetQueryWithFeatureValueAndFilterUsesMultipleExistsConditions()
-    {
-        // Require every selected feature value without multiplying product rows through joins.
-        $this->adapter->addSelectField('id_product');
-        $this->adapter->addOperationsFilter('with_features_1', [[
-            ['id_feature_value', [10]],
-            ['id_feature_value', [20]],
-        ]]);
-
-        $this->assertEquals(
-            'SELECT p.id_product FROM ps_product p WHERE ((EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=10) AND EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=20))) ORDER BY p.id_product DESC',
             $this->adapter->getQuery()
         );
     }

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -159,20 +159,49 @@ class MySQLTest extends MockeryTestCase
         $adapter->addOperationsFilter('with_features_3', [[['id_feature_value', [11]]]]);
         $adapter->addOperationsFilter('with_attributes_1', [[['id_attribute', [7]]]]);
 
-        // Both the feature (fp) and the attribute (pac) joins are correlated with the same
-        // product_attribute (pa) row, so the two filters must be satisfied by the same combination.
+        // Product feature values match globally, while combination feature values and attributes are
+        // correlated with the same product_attribute (pa) row.
         $this->assertEquals(
             'SELECT  FROM ps_product p'
             . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
-            . ' LEFT JOIN (SELECT id_product, NULL AS id_product_attribute, id_feature, id_feature_value'
-            . ' FROM ps_feature_product'
-            . ' UNION SELECT pa.id_product, pa.id_product_attribute, fpa.id_feature, fpa.id_feature_value'
-            . ' FROM ps_feature_product_attribute fpa'
-            . ' INNER JOIN ps_product_attribute pa ON pa.id_product_attribute = fpa.id_product_attribute) fp'
-            . ' ON (p.id_product = fp.id_product'
-            . ' AND (fp.id_product_attribute IS NULL OR fp.id_product_attribute = pa.id_product_attribute))'
             . ' LEFT JOIN ps_product_attribute_combination pac_1 ON (pa.id_product_attribute = pac_1.id_product_attribute)'
-            . ' WHERE ((fp.id_feature_value=11)) AND ((pac_1.id_attribute=7))'
+            . ' WHERE (((EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
+            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=11)'
+            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
+            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=11))))'
+            . ' AND ((pac_1.id_attribute=7))'
+            . ' ORDER BY p.id_product DESC',
+            $adapter->getQuery()
+        );
+    }
+
+    public function testCombinationFeatureAndFilterUsesExistsOnTheSameCombination()
+    {
+        $adapter = new class() extends MySQL {
+            protected function isCombinationFeatureFilteringEnabled()
+            {
+                return true;
+            }
+        };
+
+        // Require both selected values at product level or on the same combination row.
+        $adapter->addSelectField('id_product');
+        $adapter->addOperationsFilter('with_features_3', [[
+            ['id_feature_value', [11]],
+            ['id_feature_value', [12]],
+        ]]);
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p'
+            . ' LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product)'
+            . ' WHERE (((EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
+            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=11)'
+            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
+            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=11))'
+            . ' AND (EXISTS (SELECT 1 FROM ps_feature_product fp_filter'
+            . ' WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=12)'
+            . ' OR EXISTS (SELECT 1 FROM ps_feature_product_attribute fpa_filter'
+            . ' WHERE fpa_filter.id_product_attribute = pa.id_product_attribute AND fpa_filter.id_feature_value=12))))'
             . ' ORDER BY p.id_product DESC',
             $adapter->getQuery()
         );
@@ -446,6 +475,33 @@ class MySQLTest extends MockeryTestCase
 
         $this->assertEquals(
             $expected,
+            $this->adapter->getQuery()
+        );
+    }
+
+    public function testGetQueryWithFeatureValueOrFilterUsesExists()
+    {
+        // Match any selected feature value without joining feature rows into the product query.
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->addOperationsFilter('with_features_1', [[['id_feature_value', [10, 20]]]]);
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p WHERE ((EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value IN (10, 20)))) ORDER BY p.id_product DESC',
+            $this->adapter->getQuery()
+        );
+    }
+
+    public function testGetQueryWithFeatureValueAndFilterUsesMultipleExistsConditions()
+    {
+        // Require every selected feature value without multiplying product rows through joins.
+        $this->adapter->addSelectField('id_product');
+        $this->adapter->addOperationsFilter('with_features_1', [[
+            ['id_feature_value', [10]],
+            ['id_feature_value', [20]],
+        ]]);
+
+        $this->assertEquals(
+            'SELECT p.id_product FROM ps_product p WHERE ((EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=10) AND EXISTS (SELECT 1 FROM ps_feature_product fp_filter WHERE fp_filter.id_product = p.id_product AND fp_filter.id_feature_value=20))) ORDER BY p.id_product DESC',
             $this->adapter->getQuery()
         );
     }

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -31,6 +31,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
 use PrestaShop\Module\FacetedSearch\Definition\Availability;
 use PrestaShop\Module\FacetedSearch\Filters\Block;
+use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
@@ -854,6 +855,29 @@ class BlockTest extends MockeryTestCase
                 [
                 ]
             )
+        );
+    }
+
+    public function testAndFeatureCountsKeepCurrentFeatureSelection()
+    {
+        // Keep the selected feature filter in the initial population for AND facet counts.
+        $this->mockFeatures([]);
+        $this->mockLayeredCategory([[
+            'type' => 'id_feature',
+            'id_value' => 1,
+            'filter_type' => Converter::WIDGET_TYPE_CHECKBOX_AND,
+        ]]);
+
+        $filteredAdapter = Mockery::mock(MySQL::class)->makePartial();
+        $filteredAdapter->resetAll();
+        $this->adapterMock->shouldReceive('getFilteredSearchAdapter')
+            ->with()
+            ->once()
+            ->andReturn($filteredAdapter);
+
+        $this->assertEquals(
+            ['filters' => []],
+            $this->block->getFilterBlock(10, ['id_feature' => [1 => [10, 20]]])
         );
     }
 

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -31,6 +31,7 @@ use PrestaShop\Module\FacetedSearch\Filters\Provider;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\Filter;
+use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use Shop;
 use stdClass;
 
@@ -92,6 +93,63 @@ class ConverterTest extends MockeryTestCase
             $this->converter->getFacetsFromFilterBlocks(
                 []
             )
+        );
+    }
+
+    public function testAndCheckboxFacetUsesCheckboxWidget()
+    {
+        // Render the AND behavior as regular checkboxes on the storefront.
+        $facets = $this->converter->getFacetsFromFilterBlocks(
+            [
+                [
+                    'name' => 'Feature',
+                    'type' => Converter::TYPE_FEATURE,
+                    'id_key' => 1,
+                    'values' => [],
+                    'filter_show_limit' => 0,
+                    'filter_type' => Converter::WIDGET_TYPE_CHECKBOX_AND,
+                ],
+            ]
+        );
+
+        $this->assertSame('checkbox', $facets[0]->getWidgetType());
+        $this->assertTrue($facets[0]->isMultipleSelectionAllowed());
+    }
+
+    public function testCreateFacetedSearchFiltersPreservesFeatureAndOperator()
+    {
+        // Prepare one configured AND feature and two values received from the URL.
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')->andReturn(1);
+        $query->shouldReceive('getEncodedFacets')->andReturn('encoded-facets');
+
+        $provider = Mockery::mock(Provider::class);
+        $provider->shouldReceive('getFiltersForQuery')->with($query, 1)->andReturn([
+            ['type' => Converter::TYPE_FEATURE, 'id_value' => 5, 'filter_type' => Converter::WIDGET_TYPE_CHECKBOX_AND],
+        ]);
+
+        $urlSerializer = Mockery::mock(URLSerializer::class);
+        $urlSerializer->shouldReceive('unserialize')->with('encoded-facets')->andReturn([
+            'Material' => ['Steel', 'Glass'],
+        ]);
+
+        $dataAccessor = Mockery::mock(DataAccessor::class);
+        $dataAccessor->shouldReceive('getFeatures')->with(2)->andReturn([
+            5 => ['id_feature' => 5, 'name' => 'Material', 'url_name' => 'Material'],
+        ]);
+        $dataAccessor->shouldReceive('getFeatureValues')->with(5, 2)->andReturn([
+            ['id_feature_value' => 10, 'value' => 'Steel', 'url_name' => 'Steel'],
+            ['id_feature_value' => 20, 'value' => 'Glass', 'url_name' => 'Glass'],
+        ]);
+
+        $converter = new Converter($this->contextMock, $this->dbMock, $urlSerializer, $dataAccessor, $provider);
+
+        $this->assertEquals(
+            [
+                'id_feature' => [5 => [10, 20]],
+                'id_feature_operator' => [5 => 'and'],
+            ],
+            $converter->createFacetedSearchFiltersFromQuery($query)
         );
     }
 

--- a/tests/php/FacetedSearch/Product/SearchTest.php
+++ b/tests/php/FacetedSearch/Product/SearchTest.php
@@ -546,6 +546,27 @@ class SearchTest extends MockeryTestCase
         );
     }
 
+    public function testInitSearchWithFeatureAndCheckboxes()
+    {
+        // Store every selected value as an AND operation for the configured feature.
+        $this->search->initSearch(
+            [
+                'id_feature' => [10 => [1, 2, 2]],
+                'id_feature_operator' => [10 => 'and'],
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    ['id_feature_value', [1]],
+                    ['id_feature_value', [2]],
+                ],
+            ],
+            $this->search->getSearchAdapter()->getInitialPopulation()->getOperationsFilters()->get('with_features_10')
+        );
+    }
+
     public function testInitSearchWithManyAttributes()
     {
         $this->search->initSearch(

--- a/views/templates/admin/add.tpl
+++ b/views/templates/admin/add.tpl
@@ -357,6 +357,7 @@
                       <div class="col-lg-6">
                         <select name="layered_selection_feat_{(int)$feature['id_feature']}_filter_type">
                           <option value="0">{l s='Checkbox' d='Modules.Facetedsearch.Admin'}</option>
+                          <option value="4">{l s='Checkbox (AND)' d='Modules.Facetedsearch.Admin'}</option>
                           <option value="1">{l s='Radio button' d='Modules.Facetedsearch.Admin'}</option>
                           <option value="2">{l s='Drop-down list' d='Modules.Facetedsearch.Admin'}</option>
                         </select>

--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -197,6 +197,7 @@
                       <div class="col-lg-6">
                         <select name="layered_selection_feat_{(int)$feature['id_feature']}_filter_type">
                           <option value="0">{l s='Checkbox' d='Modules.Facetedsearch.Admin'}</option>
+                          <option value="4">{l s='Checkbox (AND)' d='Modules.Facetedsearch.Admin'}</option>
                           <option value="1">{l s='Radio button' d='Modules.Facetedsearch.Admin'}</option>
                           <option value="2">{l s='Drop-down list' d='Modules.Facetedsearch.Admin'}</option>
                         </select>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Feature filter used to work with joining X of feature tables over and over again. Refactored to a simple exists. Also, it allowed me to implement AND option for checkboxes. So, now you can easily setup filters with "Required features" of a product, like connectors on a PC for example.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.

## Performance comparsion on Shop 1 - [trendo.cz](https://www.trendo.cz/117-zvyhodnene-sety?q=Materi%C3%A1l+d%C5%99ezu-Granit/Typ+materi%C3%A1lu-Granital/Tvar+d%C5%99ezu-D%C5%99ezy+s+odkapem/Zp%C5%AFsob+mont%C3%A1%C5%BEe-Horn%C3%AD+%5C-+na+pracovn%C3%AD+desku/Typ+baterie-Granitov%C3%A1+s+vytahovac%C3%AD+koncovkou/P%C5%99esn%C3%BD+rozm%C4%9Br+%5C-+d%C3%A9lka+%28mm%29-780)

It takes about 400ms on profiling, 100 ms to execute the select query, [with the previous PR](https://github.com/PrestaShop/ps_facetedsearch/pull/1303).

With this PR on top, it takes about 350ms on profiling, 60 ms to execute the select query.

## Performance comparsion on shop 2 - [lacne-elektromotory.sk](https://www.lacne-elektromotory.sk/63-elektromotory?q=Nap%C3%A4tie+%28V%29-230+V/V%C3%BDkon+%28kW%29-0%2C12+kW-0%2C13+kW-0%2C18+kW-0%2C25+kW-0%2C29+kW-0%2C31+kW-0%2C37+kW-0%2C55+kW-0%2C75+kW-1%2C1+kW-1%2C5+kW-3+kW/Kostra-Hlin%C3%ADk/Vinutie+elektromotora-Meden%C3%A9)

| Load | PR 1303      | PR 1304      |
|------|-------------:|-------------:|
| 1    | 208 ms       | 177 ms       |
| 2    | 178 ms       | 170 ms       |
| 3    | 177 ms       | 175 ms       |
| 4    | 185 ms       | 179 ms       |
| 5    | 179 ms       | 176 ms       |
| 6    | 183 ms       | 182 ms       |
| 7    | 179 ms       | 175 ms       |
| 8    | 181 ms       | 173 ms       |
| 9    | 180 ms       | 181 ms       |
| 10   | 177 ms       | 192 ms       |
| **Average** | **182,7 ms** | **178 ms** |
| **Rows**    | **47 615 946** | **47 615 946** |

I would not call it a measurable performance benefit. SQL engine probably optimizes it most of the time.

### Screenshot
<img width="1362" height="875" alt="Snímek obrazovky 2026-08-28 005650" src="https://github.com/user-attachments/assets/4aacbed5-06dc-4007-89ce-5f8d53804dcd" />