### PR TITLE
Update the README compatibility line to PrestaShop 8.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Filter your catalog to help visitors picture the category tree and browse your s
 
 ## Compatibility
 
-PrestaShop: 1.7.6.0 or later
+PrestaShop: 8.2.0 or later
 
 ## Multistore compatibility
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | The README still advertises an old minimum PrestaShop version. `ps_versions_compliancy` was raised to `8.2.0` in the code during the Epic alignment, and the README was not updated with it. This is the version integrators read before installing, so it is worth keeping straight.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#41648
| How to test?      | Documentation only, nothing to test.
| Sponsor company   | @PrestaShopCorp
