### PR TITLE
Add options to keep single-value facets visible

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -208,6 +208,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', 1);
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', 0);
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', 0);
+            Configuration::updateValue('PS_LAYERED_SHOW_SINGLE_ATTRIBUTE_GROUP', 0);
+            Configuration::updateValue('PS_LAYERED_SHOW_SINGLE_MANUFACTURER', 0);
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', 1);
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', 0);
 
@@ -247,6 +249,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         Configuration::deleteByName('PS_LAYERED_FILTER_PRICE_ROUNDING');
         Configuration::deleteByName('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST');
         Configuration::deleteByName('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY');
+        Configuration::deleteByName('PS_LAYERED_SHOW_SINGLE_ATTRIBUTE_GROUP');
+        Configuration::deleteByName('PS_LAYERED_SHOW_SINGLE_MANUFACTURER');
 
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_category');
         $this->getDatabase()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'layered_filter');
@@ -711,6 +715,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             Configuration::updateValue('PS_LAYERED_FILTER_PRICE_ROUNDING', (int) Tools::getValue('ps_layered_filter_price_rounding'));
             Configuration::updateValue('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST', (int) Tools::getValue('ps_layered_filter_show_out_of_stock_last'));
             Configuration::updateValue('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY', (int) Tools::getValue('ps_layered_filter_by_default_category'));
+            Configuration::updateValue('PS_LAYERED_SHOW_SINGLE_ATTRIBUTE_GROUP', (int) Tools::getValue('ps_layered_show_single_attribute_group'));
+            Configuration::updateValue('PS_LAYERED_SHOW_SINGLE_MANUFACTURER', (int) Tools::getValue('ps_layered_show_single_manufacturer'));
             Configuration::updateValue('PS_USE_JQUERY_UI_SLIDER', (int) Tools::getValue('ps_use_jquery_ui_slider'));
             Configuration::updateValue('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE', (int) Tools::getValue('ps_layered_default_category_template'));
 
@@ -809,6 +815,8 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             'price_use_rounding' => (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_ROUNDING'),
             'show_out_of_stock_last' => (bool) Configuration::get('PS_LAYERED_FILTER_SHOW_OUT_OF_STOCK_LAST'),
             'filter_by_default_category' => (bool) Configuration::get('PS_LAYERED_FILTER_BY_DEFAULT_CATEGORY'),
+            'show_single_attribute_group' => (bool) Configuration::get('PS_LAYERED_SHOW_SINGLE_ATTRIBUTE_GROUP'),
+            'show_single_manufacturer' => (bool) Configuration::get('PS_LAYERED_SHOW_SINGLE_MANUFACTURER'),
             'use_jquery_ui_slider' => (bool) Configuration::get('PS_USE_JQUERY_UI_SLIDER'),
             'default_category_template' => Configuration::get('PS_LAYERED_DEFAULT_CATEGORY_TEMPLATE'),
         ]);

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -553,6 +553,9 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
      */
     private function hideUselessFacets(array $facets, $totalProducts)
     {
+        $showSingleAttributeGroup = (bool) Configuration::get('PS_LAYERED_SHOW_SINGLE_ATTRIBUTE_GROUP');
+        $showSingleManufacturer = (bool) Configuration::get('PS_LAYERED_SHOW_SINGLE_MANUFACTURER');
+
         foreach ($facets as $facet) {
             // If the facet is a slider type, we hide it ONLY if the MIN and MAX value match
             if ($facet->getWidgetType() === 'slider') {
@@ -582,6 +585,20 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
                     count($facet->getFilters()) === 1
                     && $totalFacetProducts < $totalProducts
                     && $usefulFiltersCount > 0
+                )
+                ||
+                // Keep single-value attribute groups visible when enabled in the module settings
+                (
+                    $showSingleAttributeGroup
+                    && $usefulFiltersCount === 1
+                    && $facet->getType() === 'attribute_group'
+                )
+                ||
+                // Keep the single-value manufacturer facet visible when enabled in the module settings
+                (
+                    $showSingleManufacturer
+                    && $usefulFiltersCount === 1
+                    && $facet->getType() === 'manufacturer'
                 )
                 ||
                 // If there is only one filter, but it's availability or extras filter - we want this one to be displayed all the time

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -284,6 +284,50 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <label class="col-lg-3 control-label">{l s='Display attribute groups when only one value is available' d='Modules.Facetedsearch.Admin'}</label>
+    <div class="col-lg-9">
+      <span class="switch prestashop-switch fixed-width-lg">
+        <input type="radio" name="ps_layered_show_single_attribute_group" id="ps_layered_show_single_attribute_group_on" value="1"{if $show_single_attribute_group} checked="checked"{/if}>
+        <label for="ps_layered_show_single_attribute_group_on" class="radioCheck">
+          <i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+        </label>
+        <input type="radio" name="ps_layered_show_single_attribute_group" id="ps_layered_show_single_attribute_group_off" value="0"{if !$show_single_attribute_group} checked="checked"{/if}>
+        <label for="ps_layered_show_single_attribute_group_off" class="radioCheck">
+          <i class="color_danger"></i> {l s='No' d='Admin.Global'}
+        </label>
+        <a class="slide-button btn"></a>
+      </span>
+    </div>
+    <div class="col-lg-9 col-lg-offset-3">
+      <div class="help-block">
+        {l s='Keep attribute group facets such as Size or Color visible when filtering leaves only one available value.' d='Modules.Facetedsearch.Admin'}
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="col-lg-3 control-label">{l s='Display brands when only one value is available' d='Modules.Facetedsearch.Admin'}</label>
+    <div class="col-lg-9">
+      <span class="switch prestashop-switch fixed-width-lg">
+        <input type="radio" name="ps_layered_show_single_manufacturer" id="ps_layered_show_single_manufacturer_on" value="1"{if $show_single_manufacturer} checked="checked"{/if}>
+        <label for="ps_layered_show_single_manufacturer_on" class="radioCheck">
+          <i class="color_success"></i> {l s='Yes' d='Admin.Global'}
+        </label>
+        <input type="radio" name="ps_layered_show_single_manufacturer" id="ps_layered_show_single_manufacturer_off" value="0"{if !$show_single_manufacturer} checked="checked"{/if}>
+        <label for="ps_layered_show_single_manufacturer_off" class="radioCheck">
+          <i class="color_danger"></i> {l s='No' d='Admin.Global'}
+        </label>
+        <a class="slide-button btn"></a>
+      </span>
+    </div>
+    <div class="col-lg-9 col-lg-offset-3">
+      <div class="help-block">
+        {l s='Keep the Brand facet visible when filtering leaves only one available brand.' d='Modules.Facetedsearch.Admin'}
+      </div>
+    </div>
+  </div>
+
 	<div class="form-group">
 		<label class="control-label col-lg-3">{l s='Default filter template for new categories' d='Modules.Facetedsearch.Admin'}</label>				
 		<div class="col-lg-9">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Add options to keep single-value facets visible
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | See bellow
| Sponsor company   | @Touxten 

_How to test_

1. Go to Faceted Search → Configure.
2. Enable both new options.
3. Filter a category until only one product remains.
4. Check that:
   - Attribute groups such as Size and Color remain visible.
   - The Brand filter remains visible.
5. Disable each option and verify that its corresponding filter disappears.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
