### PR TITLE
Cache the per-shop country lookups during price indexation

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -396,6 +396,11 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     public function indexProductPrices($idProduct, $smart = true)
     {
         static $groups = null;
+        // Both country lookups below are loop invariant but sit inside the per-product path, so a
+        // full re-index repeated them once per product per shop. Neither is cached in core: both are
+        // plain executeS() calls. Held here like $groups above, for the life of the request.
+        static $shopCountries = [];
+        static $countries = [];
 
         if ($groups === null) {
             $groups = $this->getDatabase()->executeS('SELECT id_group FROM `' . _DB_PREFIX_ . 'group_reduction`');
@@ -440,8 +445,11 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
             // with-tax-rules path consistent with the path already used for products without any tax
             // rule. See https://github.com/PrestaShop/ps_facetedsearch/issues/1206
             $indexedCountryIds = array_column($taxRatesByCountry, 'id_country');
-            $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
-            foreach ($shopCountries as $country) {
+            $shopCountriesKey = (int) $idShop . '-' . (int) $this->getContext()->language->id;
+            if (!isset($shopCountries[$shopCountriesKey])) {
+                $shopCountries[$shopCountriesKey] = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
+            }
+            foreach ($shopCountries[$shopCountriesKey] as $country) {
                 if (!empty($country['active']) && !in_array($country['id_country'], $indexedCountryIds)) {
                     $taxRatesByCountry[] = [
                         'rate' => 0,
@@ -457,8 +465,11 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 WHERE id_product = ' . (int) $idProduct . ' AND id_shop IN (0,' . (int) $idShop . ')'
             );
 
-            $countries = Country::getCountries($this->getContext()->language->id, true, false, false);
-            foreach ($countries as $country) {
+            $countriesKey = (int) $this->getContext()->language->id;
+            if (!isset($countries[$countriesKey])) {
+                $countries[$countriesKey] = Country::getCountries($countriesKey, true, false, false);
+            }
+            foreach ($countries[$countriesKey] as $country) {
                 $idCountry = $country['id_country'];
 
                 // Get price by currency & country, without reduction!


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Follow-up to @kpodemski's review note on #1261. `indexProductPrices()` runs once per product, and inside its per-shop loop it called `Country::getCountriesByIdShop()` and, a few lines below, `Country::getCountries()`. Neither is cached in core - both are plain `executeS()` calls with joins - so a full re-index repeated both once per product per shop. The first of the two became unconditional in #1261 (before that it only ran when a product had no tax rule), which is the regression that was flagged; the second was already there. Both results depend only on the shop and the language, so they are now held in statics for the life of the request, keyed on exactly that, the same way `$groups` already is a few lines above. Opened as a draft, as agreed on #1261.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Follow-up to PrestaShop/ps_facetedsearch#1261 (review note, no separate issue).
| How to test?      | Re-index prices (module configuration, "Index all missing prices" / a full re-index) and count the two lookups, or read the numbers below. Correctness is checked by comparing the `layered_price_index` table before and after: it must be identical, since only the number of times the country list is fetched changes. On a default 9.2 shop with 19 products and 2 shops, `getCountriesByIdShop` goes from 38 calls to 2 and `getCountries` from 38 to 1, with a byte identical index.
| Sponsor company   |

Measured on a real 9.2 install (19 products, 2 shops, 2 active countries), instrumenting both call sites and running a full re-index of every product:

```
before:  products=19  getCountriesByIdShop_calls=38  getCountries_calls=38
after:   products=19  getCountriesByIdShop_calls=2   getCountries_calls=1
```

2 and 1 are the expected cardinalities: one lookup per shop-and-language, one per language. The `layered_price_index` rows produced by the two runs are identical (38 rows, same values), so this only removes repeated queries.

The saving scales with the catalogue rather than with this shop: a re-index of N products across S shops did 2 x N x S of these queries and now does S + 1.
