### PR TITLE
Refactor price indexer, add group indexation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[5.0.0]]></version>
+    <version><![CDATA[5.1.0]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -365,7 +365,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
         } elseif ($cursor == 0) {
             $this->getDatabase()->execute(
                 'DELETE psi FROM `' . _DB_PREFIX_ . 'layered_price_index` psi ' .
-                'LEFT JOIN `' . _DB_PREFIX_ . 'product_shop` ps ON (ps.`id_product` = psi.`id_product` AND ps.`active` = 1 AND ps.`visibility` IN ("both", "catalog")) ' .
+                'LEFT JOIN `' . _DB_PREFIX_ . 'product_shop` ps ON (ps.`id_product` = psi.`id_product` AND ps.`id_shop` = psi.`id_shop` AND ps.`active` = 1 AND ps.`visibility` IN (\'both\', \'catalog\')) ' .
                 'WHERE ps.`id_product` IS NULL'
             );
         }

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -29,6 +29,7 @@ if (file_exists($autoloadPath)) {
 use PrestaShop\Module\FacetedSearch\Filters\Converter;
 use PrestaShop\Module\FacetedSearch\Filters\DataAccessor;
 use PrestaShop\Module\FacetedSearch\HookDispatcher;
+use PrestaShop\Module\FacetedSearch\Indexation\PriceIndexer;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class Ps_Facetedsearch extends Module implements WidgetInterface
@@ -51,22 +52,6 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
      * @var int
      */
     const LOCK_TEMPLATE_CREATION = 20000;
-
-    /**
-     * US iso code, used to prevent taxes usage while computing prices
-     *
-     * @var array
-     */
-    const ISO_CODE_TAX_FREE = [
-        'US',
-    ];
-
-    /**
-     * Number of digits for MySQL DECIMAL
-     *
-     * @var int
-     */
-    const DECIMAL_DIGITS = 6;
 
     /**
      * @var array List of controllers supported by this module
@@ -93,11 +78,16 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
      */
     private $hookDispatcher;
 
+    /**
+     * @var PriceIndexer
+     */
+    private $priceIndexer;
+
     public function __construct()
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '5.0.0';
+        $this->version = '5.1.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -369,8 +359,15 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
      */
     public function fullPricesIndexProcess($cursor = 0, $ajax = false, $smart = false)
     {
+        // Prepare the price index before the first batch while preserving valid rows during smart indexing.
         if ($cursor == 0 && !$smart) {
             $this->rebuildPriceIndexTable();
+        } elseif ($cursor == 0) {
+            $this->getDatabase()->execute(
+                'DELETE psi FROM `' . _DB_PREFIX_ . 'layered_price_index` psi ' .
+                'LEFT JOIN `' . _DB_PREFIX_ . 'product_shop` ps ON (ps.`id_product` = psi.`id_product` AND ps.`active` = 1 AND ps.`visibility` IN ("both", "catalog")) ' .
+                'WHERE ps.`id_product` IS NULL'
+            );
         }
 
         return $this->indexPrices($cursor, true, $ajax, $smart);
@@ -395,211 +392,12 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
      */
     public function indexProductPrices($idProduct, $smart = true)
     {
-        static $groups = null;
-
-        if ($groups === null) {
-            $groups = $this->getDatabase()->executeS('SELECT id_group FROM `' . _DB_PREFIX_ . 'group_reduction`');
-            if (!$groups) {
-                $groups = [];
-            }
+        // Reuse one indexer instance so its shop dimension caches survive the complete indexing process.
+        if ($this->priceIndexer === null) {
+            $this->priceIndexer = new PriceIndexer();
         }
 
-        $shopList = Shop::getShops(false, null, true);
-
-        foreach ($shopList as $idShop) {
-            $currencyList = Currency::getCurrencies(false, true, true);
-
-            $minPrice = [];
-            $maxPrice = [];
-
-            if ($smart) {
-                $this->getDatabase()->execute('DELETE FROM `' . _DB_PREFIX_ . 'layered_price_index` WHERE `id_product` = ' . (int) $idProduct . ' AND `id_shop` = ' . (int) $idShop);
-            }
-
-            $taxRatesByCountry = $this->getDatabase()->executeS(
-                'SELECT t.rate rate, tr.id_country, c.iso_code ' .
-                'FROM `' . _DB_PREFIX_ . 'product_shop` p ' .
-                'LEFT JOIN `' . _DB_PREFIX_ . 'tax_rules_group` trg ON  ' .
-                '(trg.id_tax_rules_group = p.id_tax_rules_group AND p.id_shop = ' . (int) $idShop . ') ' .
-                'LEFT JOIN `' . _DB_PREFIX_ . 'tax_rule` tr ON (tr.id_tax_rules_group = trg.id_tax_rules_group) ' .
-                'LEFT JOIN `' . _DB_PREFIX_ . 'tax` t ON (t.id_tax = tr.id_tax AND t.active = 1) ' .
-                'JOIN `' . _DB_PREFIX_ . 'country` c ON (tr.id_country=c.id_country AND c.active = 1) ' .
-                'WHERE id_product = ' . (int) $idProduct . ' ' .
-                'GROUP BY id_product, tr.id_country'
-            );
-
-            // When tax is not applied to indexed prices, drop the per-country tax rates entirely.
-            if (!Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX')) {
-                $taxRatesByCountry = [];
-            }
-
-            // Always index every active country of the shop. Countries that have no specific tax
-            // rule for this product (or when the "use tax" option is off) are indexed with a 0% rate.
-            // Without this, the price sort - an INNER JOIN on layered_price_index.id_country - returns
-            // no products at all for customers whose country was not indexed. This makes the
-            // with-tax-rules path consistent with the path already used for products without any tax
-            // rule. See https://github.com/PrestaShop/ps_facetedsearch/issues/1206
-            $indexedCountryIds = array_column($taxRatesByCountry, 'id_country');
-            $shopCountries = Country::getCountriesByIdShop($idShop, $this->getContext()->language->id);
-            foreach ($shopCountries as $country) {
-                if (!empty($country['active']) && !in_array($country['id_country'], $indexedCountryIds)) {
-                    $taxRatesByCountry[] = [
-                        'rate' => 0,
-                        'id_country' => $country['id_country'],
-                        'iso_code' => $country['iso_code'],
-                    ];
-                }
-            }
-
-            $productMinPrices = $this->getDatabase()->executeS(
-                'SELECT id_shop, id_currency, id_country, id_group, from_quantity
-                FROM `' . _DB_PREFIX_ . 'specific_price`
-                WHERE id_product = ' . (int) $idProduct . ' AND id_shop IN (0,' . (int) $idShop . ')'
-            );
-
-            $countries = Country::getCountries($this->getContext()->language->id, true, false, false);
-            foreach ($countries as $country) {
-                $idCountry = $country['id_country'];
-
-                // Get price by currency & country, without reduction!
-                foreach ($currencyList as $currency) {
-                    $price = Product::priceCalculation(
-                        $idShop,
-                        (int) $idProduct,
-                        null,
-                        $idCountry,
-                        0,
-                        '',
-                        $currency['id_currency'],
-                        0,
-                        0,
-                        false,
-                        6, // Decimals
-                        false,
-                        false,
-                        true,
-                        $specificPriceOutput,
-                        true
-                    );
-
-                    $minPrice[$idCountry][$currency['id_currency']] = $price;
-                    $maxPrice[$idCountry][$currency['id_currency']] = $price;
-                }
-
-                foreach ($productMinPrices as $specificPrice) {
-                    foreach ($currencyList as $currency) {
-                        if ($specificPrice['id_currency'] &&
-                            $specificPrice['id_currency'] != $currency['id_currency']
-                        ) {
-                            continue;
-                        }
-
-                        $price = Product::priceCalculation(
-                            $idShop,
-                            (int) $idProduct,
-                            null,
-                            $idCountry,
-                            0,
-                            '',
-                            $currency['id_currency'],
-                            (int) $specificPrice['id_group'],
-                            $specificPrice['from_quantity'],
-                            false,
-                            6,
-                            false,
-                            true,
-                            true,
-                            $specificPriceOutput,
-                            true
-                        );
-
-                        if ($price > $maxPrice[$idCountry][$currency['id_currency']]) {
-                            $maxPrice[$idCountry][$currency['id_currency']] = $price;
-                        }
-
-                        if ($price == 0) {
-                            continue;
-                        }
-
-                        if (null === $minPrice[$idCountry][$currency['id_currency']] || $price < $minPrice[$idCountry][$currency['id_currency']]) {
-                            $minPrice[$idCountry][$currency['id_currency']] = $price;
-                        }
-                    }
-                }
-
-                foreach ($groups as $group) {
-                    foreach ($currencyList as $currency) {
-                        $price = Product::priceCalculation(
-                            $idShop,
-                            (int) $idProduct,
-                            null,
-                            (int) $idCountry,
-                            0,
-                            '',
-                            (int) $currency['id_currency'],
-                            (int) $group['id_group'],
-                            0,
-                            false,
-                            6,
-                            false,
-                            true,
-                            true,
-                            $specificPriceOutput,
-                            true
-                        );
-
-                        if (!isset($maxPrice[$idCountry][$currency['id_currency']])) {
-                            $maxPrice[$idCountry][$currency['id_currency']] = 0;
-                        }
-
-                        if (!isset($minPrice[$idCountry][$currency['id_currency']])) {
-                            $minPrice[$idCountry][$currency['id_currency']] = null;
-                        }
-
-                        if ($price == 0) {
-                            continue;
-                        }
-
-                        if (null === $minPrice[$idCountry][$currency['id_currency']] || $price < $minPrice[$idCountry][$currency['id_currency']]) {
-                            $minPrice[$idCountry][$currency['id_currency']] = $price;
-                        }
-
-                        if ($price > $maxPrice[$idCountry][$currency['id_currency']]) {
-                            $maxPrice[$idCountry][$currency['id_currency']] = $price;
-                        }
-                    }
-                }
-            }
-
-            $values = [];
-            foreach ($taxRatesByCountry as $taxRateByCountry) {
-                $taxRate = $taxRateByCountry['rate'];
-                $idCountry = $taxRateByCountry['id_country'];
-                foreach ($currencyList as $currency) {
-                    $minPriceValue = array_key_exists($idCountry, $minPrice) ? $minPrice[$idCountry][$currency['id_currency']] : 0;
-                    $maxPriceValue = array_key_exists($idCountry, $maxPrice) ? $maxPrice[$idCountry][$currency['id_currency']] : 0;
-                    if (!in_array($taxRateByCountry['iso_code'], self::ISO_CODE_TAX_FREE)) {
-                        $minPriceValue = Tools::ps_round($minPriceValue * (100 + $taxRate) / 100, self::DECIMAL_DIGITS);
-                        $maxPriceValue = Tools::ps_round($maxPriceValue * (100 + $taxRate) / 100, self::DECIMAL_DIGITS);
-                    }
-
-                    $values[] = '(' . (int) $idProduct . ',
-                        ' . (int) $currency['id_currency'] . ',
-                        ' . $idShop . ',
-                        ' . (float) $minPriceValue . ',
-                        ' . (float) $maxPriceValue . ',
-                        ' . (int) $idCountry . ')';
-                }
-            }
-
-            if (!empty($values)) {
-                $this->getDatabase()->execute(
-                    'INSERT INTO `' . _DB_PREFIX_ . 'layered_price_index` (id_product, id_currency, id_shop, price_min, price_max, id_country)
-                     VALUES ' . implode(',', $values) . '
-                     ON DUPLICATE KEY UPDATE id_product = id_product' // Avoid duplicate keys
-                );
-            }
-        }
+        $this->priceIndexer->indexProductPrices($idProduct, $smart);
     }
 
     /**
@@ -1454,7 +1252,8 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
             `price_min` DECIMAL(20, 6) NOT NULL,
             `price_max` DECIMAL(20, 6) NOT NULL,
             `id_country` INT NOT NULL,
-            PRIMARY KEY (`id_product`, `id_currency`, `id_shop`, `id_country`),
+            `id_group` INT NOT NULL,
+            PRIMARY KEY (`id_product`, `id_currency`, `id_shop`, `id_country`, `id_group`),
             INDEX `id_currency` (`id_currency`),
             INDEX `price_min` (`price_min`),
             INDEX `price_max` (`price_max`)

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -24,6 +24,7 @@ use Configuration;
 use Context;
 use Db;
 use Doctrine\Common\Collections\ArrayCollection;
+use Group;
 use PrestaShop\Module\FacetedSearch\CombinationFeature;
 use Product;
 use StockAvailable;
@@ -169,6 +170,15 @@ class MySQL extends AbstractAdapter
             null,
             'sa'
         );
+
+        // Resolve the effective customer group for the current shop using the same fallback as the core.
+        $idGroup = (int) Group::getCurrent()->id;
+
+        // Match the compact price row for the current shop, converted currency, country and customer group.
+        $priceIndexJoinCondition = '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id
+            . ' AND psi.id_currency = ' . $this->getContext()->currency->id
+            . ' AND psi.id_country IN (0, ' . $this->getContext()->country->id . ')'
+            . ' AND psi.id_group IN (0, ' . $idGroup . '))';
 
         // Feature filters are resolved against the feature_product table by default. When combination
         // feature values are enabled (PrestaShop >= 9.3 + feature flag), we swap that table for a
@@ -328,29 +338,25 @@ class MySQL extends AbstractAdapter
             'price_min' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
-                'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                'joinCondition' => $priceIndexJoinCondition,
                 'joinType' => self::INNER_JOIN,
             ],
             'price_max' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
-                'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                'joinCondition' => $priceIndexJoinCondition,
                 'joinType' => self::INNER_JOIN,
             ],
             'range_start' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
-                'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                'joinCondition' => $priceIndexJoinCondition,
                 'joinType' => self::INNER_JOIN,
             ],
             'range_end' => [
                 'tableName' => 'layered_price_index',
                 'tableAlias' => 'psi',
-                'joinCondition' => '(psi.id_product = p.id_product AND psi.id_shop = ' . $this->getContext()->shop->id . ' AND psi.id_currency = ' .
-                $this->getContext()->currency->id . ' AND psi.id_country = ' . $this->getContext()->country->id . ')',
+                'joinCondition' => $priceIndexJoinCondition,
                 'joinType' => self::INNER_JOIN,
             ],
             'id_group' => [
@@ -376,7 +382,7 @@ class MySQL extends AbstractAdapter
                     sp.id_shop IN (0, ' . $this->getContext()->shop->id . ') AND 
                     sp.id_currency IN (0, ' . $this->getContext()->currency->id . ') AND 
                     sp.id_country IN (0, ' . $this->getContext()->country->id . ') AND 
-                    sp.id_group IN (0, ' . $this->getContext()->customer->id_default_group . ') AND 
+                    sp.id_group IN (0, ' . $idGroup . ') AND
                     sp.from_quantity = 1 AND
                     sp.reduction > 0 AND
                     sp.id_customer = 0 AND

--- a/src/Indexation/PriceIndexer.php
+++ b/src/Indexation/PriceIndexer.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Indexation;
+
+use Configuration;
+use Db;
+use Product;
+use Shop;
+
+class PriceIndexer
+{
+    /**
+     * @var array|null
+     */
+    private static $shops;
+
+    /**
+     * @var array
+     */
+    private static $countriesByShop = [];
+
+    /**
+     * @var array
+     */
+    private static $groupsByShop = [];
+
+    /**
+     * @var array
+     */
+    private static $currenciesByShop = [];
+
+    /**
+     * Index product prices using the smallest country and group matrix required by each shop and currency.
+     *
+     * @param int $idProduct
+     * @param bool $smart Delete existing rows before reindexing
+     */
+    public function indexProductPrices($idProduct, $smart = true)
+    {
+        // Index every shop independently so currency conversion and relevant customer dimensions never leak between shops.
+        foreach ($this->getShops() as $idShop) {
+            if ($smart) {
+                Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'layered_price_index` WHERE `id_product` = ' . (int) $idProduct . ' AND `id_shop` = ' . (int) $idShop);
+            }
+
+            // Load and cache the dimensions available in this shop.
+            $countries = $this->getCountriesByShop($idShop);
+            $groups = $this->getGroupsByShop($idShop);
+            $currencies = $this->getCurrenciesByShop($idShop);
+            if (empty($countries) || empty($groups) || empty($currencies)) {
+                continue;
+            }
+
+            // Load product-specific data and shop configuration once for every currency, country and group.
+            $specificPriceQuantities = $this->getSpecificPriceQuantities($idProduct, $idShop);
+            $useTax = (bool) Configuration::get('PS_LAYERED_FILTER_PRICE_USETAX', null, null, $idShop);
+            $values = [];
+
+            // Build and compact a separate country/group matrix for each converted currency.
+            foreach ($currencies as $currency) {
+                $prices = $this->getPriceMatrix(
+                    $idProduct,
+                    $idShop,
+                    (int) $currency['id_currency'],
+                    $countries,
+                    $groups,
+                    $specificPriceQuantities,
+                    $useTax
+                );
+
+                // Convert the matrix into rows using zero for every dimension that does not change the calculated range.
+                foreach ($this->compactPriceMatrix($prices) as $indexedPrice) {
+                    $values[] = '(' . (int) $idProduct . ', '
+                        . (int) $currency['id_currency'] . ', '
+                        . (int) $idShop . ', '
+                        . (float) $indexedPrice['price_min'] . ', '
+                        . (float) $indexedPrice['price_max'] . ', '
+                        . (int) $indexedPrice['id_country'] . ', '
+                        . (int) $indexedPrice['id_group'] . ')';
+                }
+            }
+
+            // Insert all compacted prices for the shop in one query.
+            if (!empty($values)) {
+                Db::getInstance()->execute(
+                    'INSERT INTO `' . _DB_PREFIX_ . 'layered_price_index` (id_product, id_currency, id_shop, price_min, price_max, id_country, id_group)
+                     VALUES ' . implode(',', $values) . '
+                     ON DUPLICATE KEY UPDATE id_product = id_product'
+                );
+            }
+        }
+    }
+
+    /**
+     * Return all shop identifiers and cache them for subsequent products.
+     *
+     * @return array
+     */
+    private function getShops()
+    {
+        if (self::$shops === null) {
+            self::$shops = Shop::getShops(false, null, true);
+        }
+
+        return self::$shops;
+    }
+
+    /**
+     * Return active countries associated with a shop.
+     *
+     * @param int $idShop
+     *
+     * @return array
+     */
+    private function getCountriesByShop($idShop)
+    {
+        if (!isset(self::$countriesByShop[$idShop])) {
+            // Load only active countries explicitly associated with the indexed shop.
+            self::$countriesByShop[$idShop] = Db::getInstance()->executeS(
+                'SELECT c.id_country
+                FROM `' . _DB_PREFIX_ . 'country` c
+                INNER JOIN `' . _DB_PREFIX_ . 'country_shop` cs ON (cs.id_country = c.id_country)
+                WHERE c.active = 1 AND cs.id_shop = ' . (int) $idShop
+            ) ?: [];
+        }
+
+        return self::$countriesByShop[$idShop];
+    }
+
+    /**
+     * Return customer groups associated with a shop.
+     *
+     * @param int $idShop
+     *
+     * @return array
+     */
+    private function getGroupsByShop($idShop)
+    {
+        if (!isset(self::$groupsByShop[$idShop])) {
+            // Load every group explicitly associated with the indexed shop because groups have no active flag.
+            self::$groupsByShop[$idShop] = Db::getInstance()->executeS(
+                'SELECT g.id_group
+                FROM `' . _DB_PREFIX_ . 'group` g
+                INNER JOIN `' . _DB_PREFIX_ . 'group_shop` gs ON (gs.id_group = g.id_group)
+                WHERE gs.id_shop = ' . (int) $idShop
+            ) ?: [];
+        }
+
+        return self::$groupsByShop[$idShop];
+    }
+
+    /**
+     * Return active, non-deleted currencies associated with a shop.
+     *
+     * @param int $idShop
+     *
+     * @return array
+     */
+    private function getCurrenciesByShop($idShop)
+    {
+        if (!isset(self::$currenciesByShop[$idShop])) {
+            // Load only active, non-deleted currencies explicitly associated with the indexed shop.
+            self::$currenciesByShop[$idShop] = Db::getInstance()->executeS(
+                'SELECT c.id_currency
+                FROM `' . _DB_PREFIX_ . 'currency` c
+                INNER JOIN `' . _DB_PREFIX_ . 'currency_shop` cs ON (cs.id_currency = c.id_currency)
+                WHERE c.active = 1 AND c.deleted = 0 AND cs.id_shop = ' . (int) $idShop
+            ) ?: [];
+        }
+
+        return self::$currenciesByShop[$idShop];
+    }
+
+    /**
+     * Return all specific-price quantity thresholds that can affect a product in a shop.
+     *
+     * @param int $idProduct
+     * @param int $idShop
+     *
+     * @return array
+     */
+    private function getSpecificPriceQuantities($idProduct, $idShop)
+    {
+        $specificPrices = Db::getInstance()->executeS(
+            'SELECT DISTINCT from_quantity
+            FROM `' . _DB_PREFIX_ . 'specific_price`
+            WHERE id_product = ' . (int) $idProduct . ' AND id_shop IN (0,' . (int) $idShop . ')'
+        );
+
+        // Return scalar quantities so the calculation loop remains independent of the query representation.
+        return array_map(function ($specificPrice) {
+            return (int) $specificPrice['from_quantity'];
+        }, $specificPrices ?: []);
+    }
+
+    /**
+     * Calculate the final price range for every country and group in one shop currency.
+     *
+     * @param int $idProduct
+     * @param int $idShop
+     * @param int $idCurrency
+     * @param array $countries
+     * @param array $groups
+     * @param array $specificPriceQuantities
+     * @param bool $useTax
+     *
+     * @return array
+     */
+    private function getPriceMatrix($idProduct, $idShop, $idCurrency, array $countries, array $groups, array $specificPriceQuantities, $useTax)
+    {
+        $prices = [];
+
+        // Calculate each country and group combination through the core pricing logic so taxes and hooks affect dependency detection.
+        foreach ($countries as $country) {
+            $idCountry = (int) $country['id_country'];
+            foreach ($groups as $group) {
+                $idGroup = (int) $group['id_group'];
+                $prices[$idCountry][$idGroup] = $this->calculatePriceRange($idProduct, $idShop, $idCurrency, $idCountry, $idGroup, $specificPriceQuantities, $useTax);
+            }
+        }
+
+        return $prices;
+    }
+
+    /**
+     * Calculate minimum and maximum converted prices for one country and group.
+     *
+     * @param int $idProduct
+     * @param int $idShop
+     * @param int $idCurrency
+     * @param int $idCountry
+     * @param int $idGroup
+     * @param array $quantities
+     * @param bool $useTax
+     *
+     * @return array
+     */
+    private function calculatePriceRange($idProduct, $idShop, $idCurrency, $idCountry, $idGroup, array $quantities, $useTax)
+    {
+        // Calculate the regular price without a specific-price reduction while retaining configured taxes, group reductions and hooks.
+        $specificPriceOutput = null;
+        $price = Product::priceCalculation(
+            $idShop,
+            $idProduct,
+            null,
+            $idCountry,
+            0,
+            '',
+            $idCurrency,
+            $idGroup,
+            0,
+            $useTax,
+            6,
+            false,
+            false,
+            true,
+            $specificPriceOutput,
+            true
+        );
+        $minPrice = $price;
+        $maxPrice = $price;
+
+        // Calculate every specific-price quantity candidate for the same country and group.
+        foreach ($quantities as $quantity) {
+            $price = Product::priceCalculation(
+                $idShop,
+                $idProduct,
+                null,
+                $idCountry,
+                0,
+                '',
+                $idCurrency,
+                $idGroup,
+                $quantity,
+                $useTax,
+                6,
+                false,
+                true,
+                true,
+                $specificPriceOutput,
+                true
+            );
+
+            if ($price > $maxPrice) {
+                $maxPrice = $price;
+            }
+
+            if ($price == 0) {
+                continue;
+            }
+
+            if ($minPrice === null || $price < $minPrice) {
+                $minPrice = $price;
+            }
+        }
+
+        return [
+            'price_min' => (float) $minPrice,
+            'price_max' => (float) $maxPrice,
+        ];
+    }
+
+    /**
+     * Replace country and group identifiers with zero when their values do not affect the price range.
+     *
+     * @param array $prices
+     *
+     * @return array
+     */
+    private function compactPriceMatrix(array $prices)
+    {
+        $firstCountryId = key($prices);
+        $firstGroupId = key($prices[$firstCountryId]);
+        $dependsOnCountry = false;
+        $dependsOnGroup = false;
+
+        // Compare each country with the first country while keeping the group fixed.
+        foreach ($prices as $idCountry => $groupPrices) {
+            foreach ($groupPrices as $idGroup => $price) {
+                if ($price['price_min'] != $prices[$firstCountryId][$idGroup]['price_min'] || $price['price_max'] != $prices[$firstCountryId][$idGroup]['price_max']) {
+                    $dependsOnCountry = true;
+                }
+
+                if ($price['price_min'] != $groupPrices[$firstGroupId]['price_min'] || $price['price_max'] != $groupPrices[$firstGroupId]['price_max']) {
+                    $dependsOnGroup = true;
+                }
+            }
+        }
+
+        // Store one representative value for every dimension that does not affect the calculated range.
+        $indexedPrices = [];
+        foreach ($prices as $idCountry => $groupPrices) {
+            foreach ($groupPrices as $idGroup => $price) {
+                $indexCountryId = $dependsOnCountry ? $idCountry : 0;
+                $indexGroupId = $dependsOnGroup ? $idGroup : 0;
+                $indexedPrices[$indexCountryId . '-' . $indexGroupId] = [
+                    'id_country' => $indexCountryId,
+                    'id_group' => $indexGroupId,
+                    'price_min' => $price['price_min'],
+                    'price_max' => $price['price_max'],
+                ];
+            }
+        }
+
+        return array_values($indexedPrices);
+    }
+}

--- a/src/Indexation/index.php
+++ b/src/Indexation/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Product/SearchProvider.php
+++ b/src/Product/SearchProvider.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\FacetedSearch\Product;
 
 use Configuration;
+use Group;
 use Hook;
 use PrestaShop\Module\FacetedSearch\Filters;
 use PrestaShop\Module\FacetedSearch\URLSerializer;
@@ -270,14 +271,16 @@ class SearchProvider implements FacetsRendererInterface, ProductSearchProviderIn
             ]
         );
 
+        // Separate cached filter blocks by every context dimension that can change their contents.
         $filterHash = md5(
             sprintf(
-                '%d-%d-%d-%s-%d-%s',
+                '%d-%d-%d-%s-%d-%d-%s',
                 (int) $context->shop->id,
                 (int) $context->currency->id,
                 (int) $context->language->id,
                 $filterKey,
                 (int) $context->country->id,
+                (int) Group::getCurrent()->id,
                 serialize($facetedSearchFilters)
             )
         );

--- a/tests/php/FacetedSearch/Adapter/MySQLTest.php
+++ b/tests/php/FacetedSearch/Adapter/MySQLTest.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\FacetedSearch\Tests\Adapter;
 use Configuration;
 use Context;
 use Db;
+use Group;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\FacetedSearch\Adapter\MySQL;
@@ -62,6 +63,14 @@ class MySQLTest extends MockeryTestCase
         $contextMock->shouldReceive('getContext')
             ->andReturn($stdClass);
         Context::setStaticExpectations($contextMock);
+
+        // Return the effective customer group used by the core for the current shop.
+        $currentGroup = new stdClass();
+        $currentGroup->id = 5;
+        $groupMock = Mockery::mock(Group::class);
+        $groupMock->shouldReceive('getCurrent')
+            ->andReturn($currentGroup);
+        Group::setStaticExpectations($groupMock);
 
         $configurationMock = Mockery::mock(Configuration::class);
         $configurationMock->shouldReceive('get')
@@ -225,7 +234,7 @@ class MySQLTest extends MockeryTestCase
         $dbInstanceMock = Mockery::mock(Db::class)->makePartial();
         $dbInstanceMock->shouldReceive('executeS')
             ->once()
-            ->with('SELECT psi.price_min, MIN(price_min) as min, MAX(price_max) as max FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3)')
+            ->with('SELECT psi.price_min, MIN(price_min) as min, MAX(price_max) as max FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5))')
             ->andReturn(
                 [
                     [
@@ -427,7 +436,7 @@ class MySQLTest extends MockeryTestCase
         );
 
         $this->assertEquals(
-            'SELECT p.id_product, pa.id_product_attribute, pac.id_attribute, a.id_attribute_group, fp.id_feature, ps.id_shop, p.id_feature_çvalue, cp.id_category, pl.name, c.nleft, c.nright, c.level_depth, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end, cg.id_group, m.name FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) INNER JOIN ps_attribute a ON (a.id_attribute = pac.id_attribute) INNER JOIN ps_feature_product fp ON (p.id_product = fp.id_product) INNER JOIN ps_product_shop ps ON (p.id_product = ps.id_product AND ps.id_shop = 1 AND ps.active = TRUE) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) INNER JOIN ps_product_lang pl ON (p.id_product = pl.id_product AND pl.id_shop = 1 AND pl.id_lang = 2) INNER JOIN ps_category c ON (cp.id_category = c.id_category AND c.active=1) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) LEFT JOIN ps_category_group cg ON (cg.id_category = c.id_category) LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer) ORDER BY p.id_product DESC',
+            'SELECT p.id_product, pa.id_product_attribute, pac.id_attribute, a.id_attribute_group, fp.id_feature, ps.id_shop, p.id_feature_çvalue, cp.id_category, pl.name, c.nleft, c.nright, c.level_depth, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end, cg.id_group, m.name FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) INNER JOIN ps_attribute a ON (a.id_attribute = pac.id_attribute) INNER JOIN ps_feature_product fp ON (p.id_product = fp.id_product) INNER JOIN ps_product_shop ps ON (p.id_product = ps.id_product AND ps.id_shop = 1 AND ps.active = TRUE) INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) INNER JOIN ps_product_lang pl ON (p.id_product = pl.id_product AND pl.id_shop = 1 AND pl.id_lang = 2) INNER JOIN ps_category c ON (cp.id_category = c.id_category AND c.active=1) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) LEFT JOIN ps_category_group cg ON (cg.id_category = c.id_category) LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer) ORDER BY p.id_product DESC',
             $this->adapter->getQuery()
         );
     }
@@ -453,7 +462,7 @@ class MySQLTest extends MockeryTestCase
         $this->adapter->addFilter('id_product', [2, 20, 200], '=');
 
         $this->assertEquals(
-            'SELECT p.id_product, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) WHERE p.condition IN (\'new\', \'used\') AND p.weight=\'10\' AND psi.price_min>=10 AND psi.price_min<=100 AND p.id_product IN (2, 20, 200) ORDER BY p.id_product DESC',
+            'SELECT p.id_product, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) WHERE p.condition IN (\'new\', \'used\') AND p.weight=\'10\' AND psi.price_min>=10 AND psi.price_min<=100 AND p.id_product IN (2, 20, 200) ORDER BY p.id_product DESC',
             $this->adapter->getQuery()
         );
     }
@@ -676,7 +685,7 @@ class MySQLTest extends MockeryTestCase
                         ['out_of_stock', [1], '='],
                     ],
                 ],
-                'expected' => 'SELECT p.id_product, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) LEFT JOIN ps_stock_available sa_1 ON (p.id_product = sa_1.id_product AND IFNULL(pac.id_product_attribute, 0) = sa_1.id_product_attribute) WHERE ((sa.quantity>=0 AND sa_1.out_of_stock IN (1, 3, 4)) OR (sa.quantity>0 AND sa_1.out_of_stock=1)) ORDER BY p.id_product DESC',
+                'expected' => 'SELECT p.id_product, sa.out_of_stock, SUM(sa.quantity) as quantity, psi.price_min, psi.price_max, psi.range_start, psi.range_end FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) LEFT JOIN ps_stock_available sa_1 ON (p.id_product = sa_1.id_product AND IFNULL(pac.id_product_attribute, 0) = sa_1.id_product_attribute) WHERE ((sa.quantity>=0 AND sa_1.out_of_stock IN (1, 3, 4)) OR (sa.quantity>0 AND sa_1.out_of_stock=1)) ORDER BY p.id_product DESC',
             ],
             [
                 'fields' => [
@@ -734,10 +743,10 @@ class MySQLTest extends MockeryTestCase
             ['level_depth', 'SELECT c.level_depth FROM ps_product p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) INNER JOIN ps_category c ON (cp.id_category = c.id_category AND c.active=1) ORDER BY p.id_product DESC'],
             ['out_of_stock', 'SELECT sa.out_of_stock FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) ORDER BY p.id_product DESC'],
             ['quantity', 'SELECT SUM(sa.quantity) as quantity FROM ps_product p LEFT JOIN ps_product_attribute pa ON (p.id_product = pa.id_product) LEFT JOIN ps_product_attribute_combination pac ON (pa.id_product_attribute = pac.id_product_attribute) LEFT JOIN ps_stock_available sa ON (p.id_product = sa.id_product AND IFNULL(pac.id_product_attribute, 0) = sa.id_product_attribute) ORDER BY p.id_product DESC'],
-            ['price_min', 'SELECT psi.price_min FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) ORDER BY p.id_product DESC'],
-            ['price_max', 'SELECT psi.price_max FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) ORDER BY p.id_product DESC'],
-            ['range_start', 'SELECT psi.range_start FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) ORDER BY p.id_product DESC'],
-            ['range_end', 'SELECT psi.range_end FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country = 3) ORDER BY p.id_product DESC'],
+            ['price_min', 'SELECT psi.price_min FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) ORDER BY p.id_product DESC'],
+            ['price_max', 'SELECT psi.price_max FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) ORDER BY p.id_product DESC'],
+            ['range_start', 'SELECT psi.range_start FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) ORDER BY p.id_product DESC'],
+            ['range_end', 'SELECT psi.range_end FROM ps_product p INNER JOIN ps_layered_price_index psi ON (psi.id_product = p.id_product AND psi.id_shop = 1 AND psi.id_currency = 4 AND psi.id_country IN (0, 3) AND psi.id_group IN (0, 5)) ORDER BY p.id_product DESC'],
             ['id_group', 'SELECT cg.id_group FROM ps_product p INNER JOIN ps_category_product cp ON (p.id_product = cp.id_product) INNER JOIN ps_category c ON (cp.id_category = c.id_category AND c.active=1) LEFT JOIN ps_category_group cg ON (cg.id_category = c.id_category) ORDER BY p.id_product DESC'],
             ['manufacturer_name', 'SELECT m.name FROM ps_product p LEFT JOIN ps_manufacturer m ON (p.id_manufacturer = m.id_manufacturer) ORDER BY p.id_product DESC'],
         ];

--- a/tests/php/FacetedSearch/Filters/BlockTest.php
+++ b/tests/php/FacetedSearch/Filters/BlockTest.php
@@ -104,6 +104,14 @@ class BlockTest extends MockeryTestCase
             ->andReturn($this->contextMock);
         Context::setStaticExpectations($this->contextMock);
 
+        // Return the effective customer group used by the adapter for the current shop.
+        $currentGroup = new stdClass();
+        $currentGroup->id = 5;
+        $groupMock = Mockery::mock(Group::class);
+        $groupMock->shouldReceive('getCurrent')
+            ->andReturn($currentGroup);
+        Group::setStaticExpectations($groupMock);
+
         $this->dbMock = Mockery::mock(Db::class);
         $dbMock = Mockery::mock(Db::class)->makePartial();
         $dbMock->shouldReceive('getInstance')
@@ -156,6 +164,7 @@ class BlockTest extends MockeryTestCase
     public function testGetFiltersBlockWithPriceDeactivated()
     {
         $group = new stdClass();
+        $group->id = 5;
         $group->show_prices = false;
 
         $groupMock = Mockery::mock(Group::class);
@@ -187,6 +196,7 @@ class BlockTest extends MockeryTestCase
     public function testGetFiltersBlockWithPrice()
     {
         $group = new stdClass();
+        $group->id = 5;
         $group->show_prices = true;
 
         $groupMock = Mockery::mock(Group::class);

--- a/upgrade/upgrade-5.1.0.php
+++ b/upgrade/upgrade-5.1.0.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_5_1_0(Ps_Facetedsearch $module)
+{
+    // Extend the price index key while preserving existing rows as group-neutral prices.
+    $schemaUpdated = Db::getInstance()->execute(
+        'ALTER TABLE `' . _DB_PREFIX_ . 'layered_price_index`
+        ADD `id_group` INT NOT NULL DEFAULT 0 AFTER `id_country`,
+        DROP PRIMARY KEY,
+        ADD PRIMARY KEY (`id_product`, `id_currency`, `id_shop`, `id_country`, `id_group`)'
+    );
+    if (!$schemaUpdated) {
+        return false;
+    }
+
+    // Mark the preserved index as stale so a normal full rebuild can compact it with group-aware prices.
+    return Configuration::updateGlobalValue('PS_LAYERED_INDEXED', 0);
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Completely refactors the price indexation part. Fixes databases inflated to insane numbers for nothing, fixes sorting and filtering in most cases. More info below.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.

### What this changes and improves
- Moves price indexation into a dedicated `PriceIndexer` class.
- Adds customer group support to the price index.
- **Reduces the price index size automatically without requiring configuration.** Detects whether the calculated min/max price actually depends on country or group and stores only the the required combinations:
  - 0 / 0 when neither dimension affects the price.
  - country / 0 when only country affects the price.
  - 0 / group when only group affects the price.
  - country / group when both dimensions affect the price.
- Uses IN (0, current_id) when selecting prices for the current country and group.
- Caches shop-specific countries, groups, and currencies during indexation.

### A shop where there all world countries:
- Current index size: 2 621 862 rows
- Module upgrade OK, database modified, price index still works.
- New index size: 10 638 rows