### PR TITLE
Address a facet by its URL slug only when it has one

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -411,7 +411,17 @@ class Converter
                             continue;
                         }
 
-                        if (isset($receivedFilters[$feature['url_name']])) {
+                        /*
+                         * WHY: a facet that has an explicit URL slug answers to that slug only. Keeping the
+                         * plain name as a fallback is what lets two facets sharing a name - a feature and an
+                         * attribute group both called "Color" - activate from the same URL segment and AND
+                         * each other down to zero results, with no way for the merchant to separate them.
+                         * The slug is already what serialization emits, so it is the whole address.
+                         */
+                        if ($feature['url_name'] !== null) {
+                            if (!isset($receivedFilters[$feature['url_name']])) {
+                                continue;
+                            }
                             $featureValueLabels = $receivedFilters[$feature['url_name']];
                         } elseif (isset($receivedFilters[$feature['name']])) {
                             $featureValueLabels = $receivedFilters[$feature['name']];
@@ -443,7 +453,11 @@ class Converter
                             continue;
                         }
 
-                        if (isset($receivedFilters[$attributeGroup['url_name']])) {
+                        // Same rule as for features above: an explicit slug is the whole address.
+                        if ($attributeGroup['url_name'] !== null) {
+                            if (!isset($receivedFilters[$attributeGroup['url_name']])) {
+                                continue;
+                            }
                             $attributeLabels = $receivedFilters[$attributeGroup['url_name']];
                         } elseif (isset($receivedFilters[$attributeGroup['attribute_group_name']])) {
                             $attributeLabels = $receivedFilters[$attributeGroup['attribute_group_name']];

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -154,6 +154,88 @@ class ConverterTest extends MockeryTestCase
     }
 
     /**
+     * A feature and an attribute group may carry the same name. The URL segment holds one label, so
+     * without a distinguishing slug both facets answer to it and their conditions AND each other down
+     * to an empty result page. A facet that has an explicit URL slug must therefore answer to that
+     * slug alone, leaving the plain label to the facet that has none. See issue #15635.
+     */
+    public function testFacetWithAnUrlNameIsNotActivatedByItsPlainName()
+    {
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')->andReturn(1);
+        $query->shouldReceive('getEncodedFacets')->andReturn('encoded-facets');
+
+        $provider = Mockery::mock(Provider::class);
+        $provider->shouldReceive('getFiltersForQuery')->with($query, 1)->andReturn([
+            ['type' => Converter::TYPE_FEATURE, 'id_value' => 5, 'filter_type' => 0],
+            ['type' => Converter::TYPE_ATTRIBUTE_GROUP, 'id_value' => 7, 'filter_type' => 0],
+        ]);
+
+        // The visitor followed the attribute group's link, which carries its plain name.
+        $urlSerializer = Mockery::mock(URLSerializer::class);
+        $urlSerializer->shouldReceive('unserialize')->with('encoded-facets')->andReturn([
+            'Color' => ['White'],
+        ]);
+
+        $dataAccessor = Mockery::mock(DataAccessor::class);
+        $dataAccessor->shouldReceive('getFeatures')->with(2)->andReturn([
+            5 => ['id_feature' => 5, 'name' => 'Color', 'url_name' => 'feature-color'],
+        ]);
+        $dataAccessor->shouldReceive('getFeatureValues')->with(5, 2)->andReturn([
+            ['id_feature_value' => 10, 'value' => 'White', 'url_name' => 'White'],
+        ]);
+        $dataAccessor->shouldReceive('getAttributesGroups')->with(2)->andReturn([
+            7 => ['id_attribute_group' => 7, 'attribute_group_name' => 'Color', 'url_name' => null],
+        ]);
+        $dataAccessor->shouldReceive('getAttributes')->with(2, 7)->andReturn([
+            ['id_attribute' => 20, 'name' => 'White', 'url_name' => 'White'],
+        ]);
+
+        $converter = new Converter($this->contextMock, $this->dbMock, $urlSerializer, $dataAccessor, $provider);
+
+        $this->assertEquals(
+            ['id_attribute_group' => [7 => [20]]],
+            $converter->createFacetedSearchFiltersFromQuery($query)
+        );
+    }
+
+    /**
+     * The counterpart of the test above: a facet with no slug of its own keeps answering to its plain
+     * name, so URLs already indexed for every shop that never configured one keep working.
+     */
+    public function testFacetWithoutAnUrlNameStillMatchesItsPlainName()
+    {
+        $query = Mockery::mock(ProductSearchQuery::class);
+        $query->shouldReceive('getIdCategory')->andReturn(1);
+        $query->shouldReceive('getEncodedFacets')->andReturn('encoded-facets');
+
+        $provider = Mockery::mock(Provider::class);
+        $provider->shouldReceive('getFiltersForQuery')->with($query, 1)->andReturn([
+            ['type' => Converter::TYPE_FEATURE, 'id_value' => 5, 'filter_type' => 0],
+        ]);
+
+        $urlSerializer = Mockery::mock(URLSerializer::class);
+        $urlSerializer->shouldReceive('unserialize')->with('encoded-facets')->andReturn([
+            'Composition' => ['Cotton'],
+        ]);
+
+        $dataAccessor = Mockery::mock(DataAccessor::class);
+        $dataAccessor->shouldReceive('getFeatures')->with(2)->andReturn([
+            5 => ['id_feature' => 5, 'name' => 'Composition', 'url_name' => null],
+        ]);
+        $dataAccessor->shouldReceive('getFeatureValues')->with(5, 2)->andReturn([
+            ['id_feature_value' => 10, 'value' => 'Cotton', 'url_name' => null],
+        ]);
+
+        $converter = new Converter($this->contextMock, $this->dbMock, $urlSerializer, $dataAccessor, $provider);
+
+        $this->assertEquals(
+            ['id_feature' => [5 => [10]]],
+            $converter->createFacetedSearchFiltersFromQuery($query)
+        );
+    }
+
+    /**
      * Test different scenario for facets filter
      *
      * @dataProvider facetsProvider


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | When an attribute group and a feature share a display name, `Converter::getFiltersFromUrlSegment()` could read the wrong one out of the URL. The received filters are keyed by the facet's `url_name` when it has one and by its `name` otherwise, but the lookup fell back to `name` even for a facet that does have a `url_name`. Two facets with the same `name` therefore collided, and the values of one were applied to the other.<br><br>A facet with a `url_name` is now addressed by that slug only, and the `name` fallback applies solely to facets that have no slug. Both `TYPE_FEATURE` and `TYPE_ATTRIBUTE_GROUP` are handled the same way.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#15635.
| How to test?      | Create an attribute group and a feature with the same display name, give one of them a distinct URL slug in its SEO settings, and enable both as filters. Select a value of the slugged one on the category page. Before this change the other facet's values are matched; after it, only the intended facet is.<br><br>The two cases added to `tests/php/FacetedSearch/Filters/ConverterTest.php` cover the collision and the no-slug fallback, and fail on `dev`.
| Sponsor company   |
