### PR TITLE
Reject invalid values for the category filter depth

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -703,6 +703,18 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 );
             }
         } elseif (Tools::isSubmit('submitLayeredSettings')) {
+            // The depth is a plain (int) cast below, which silently turns "LLOI" into 0, "1,5" into 1 and
+            // accepts negatives - so anything that is not a whole number of zero or more is rejected here
+            // rather than stored as something the merchant did not type.
+            $categoryDepth = Tools::getValue('ps_layered_filter_category_depth');
+            if (!is_numeric($categoryDepth) || (string) (int) $categoryDepth !== trim((string) $categoryDepth) || (int) $categoryDepth < 0) {
+                $this->context->smarty->assign('message', $this->displayError(
+                    $this->trans('The category filter depth must be a whole number, zero or more.', [], 'Modules.Facetedsearch.Admin')
+                ));
+
+                return;
+            }
+
             Configuration::updateValue('PS_LAYERED_CACHE_ENABLED', (int) Tools::getValue('ps_layered_cache_enabled'));
             Configuration::updateValue('PS_LAYERED_SHOW_QTIES', (int) Tools::getValue('ps_layered_show_qties'));
             Configuration::updateValue('PS_LAYERED_FULL_TREE', (int) Tools::getValue('ps_layered_full_tree'));

--- a/views/templates/admin/manage.tpl
+++ b/views/templates/admin/manage.tpl
@@ -202,7 +202,7 @@
 	<div class="form-group">
 	  <label class="col-lg-3 control-label">{l s='Category filter depth' d='Modules.Facetedsearch.Admin'}</label>
 	  <div class="col-lg-9">
-		<input type="text" name="ps_layered_filter_category_depth" value="{if $category_depth !== false}{$category_depth}{else}1{/if}" class="fixed-width-sm" />
+		<input type="number" min="0" step="1" name="ps_layered_filter_category_depth" value="{if $category_depth !== false}{$category_depth}{else}1{/if}" class="fixed-width-sm" />
 	  </div>
 		<div class="col-lg-9 col-lg-offset-3">
 		<div class="help-block">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | "Category filter depth" was a plain `<input type="text">` saved with a bare `(int)` cast, so nothing was ever rejected: `LLOI` became `0`, `1,5` became `1`, `1 500` became `1`, and `-2` was stored as a negative depth. The merchant ended up with a value they had not typed and no indication anything was wrong. This follows @jolelievre's direction on the issue - the input becomes `type="number"` with `min="0"` and `step="1"` so the browser validates inline, and the save path refuses anything that is not a whole number of zero or more instead of coercing it. Zero stays valid, since the field's own help text documents it as unlimited depth.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes PrestaShop/PrestaShop#36438
| How to test?    | Module Manager > ps_facetedsearch > Configure. Type `-2`, `LLOI`, `1,5` or `1 500` in "Category filter depth" and save: the browser refuses the input, and a request that bypasses it is answered with "The category filter depth must be a whole number, zero or more." and nothing is stored. `0`, `1`, `2`, `3` still save normally.
| Sponsor company |

### Checked against every value in the report

```
'-2'                   rejected      '0'    accepted
'LLOI'                 rejected      '1'    accepted
'1,5'                  rejected      '2'    accepted
'1 500'                rejected      '3'    accepted
''                     rejected      ' 4 '  accepted (trimmed)
'1.0'  '007'  '1e3'    rejected
```

The module's PHPUnit suite passes with the change: **100 tests, 929 assertions, OK** (PHPUnit 5.7 on PHP 7.4, `tests/php/phpunit.xml`).

### One value the report lists that this does not reject

`9223372036854775807` is accepted, because it *is* a whole number of zero or more and the direction on the issue set no upper bound. Two things worth deciding rather than me inventing them: whether a maximum is wanted at all, and that without one the behaviour is platform dependent - on 64-bit PHP that string round-trips through `(int)` unchanged and passes, on 32-bit it does not and would be refused. If a bound is wanted, say which and I will add it.