### PR TITLE
Let the product extras filter be turned off again

### DIFF
--- a/tests/php/FacetedSearch/AdminFilterFormInputNamesTest.php
+++ b/tests/php/FacetedSearch/AdminFilterFormInputNamesTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ps_Facetedsearch::getContent() decides which filters a template keeps by looking at which
+ * layered_selection_* keys are PRESENT in $_POST, never at their value. A checkbox that is off
+ * submits nothing, which is what makes that work - so any other input sharing a checkbox's name
+ * pins that filter permanently on, and no value can express "off".
+ */
+class AdminFilterFormInputNamesTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private $templates = [
+        'add.tpl',
+        'view.tpl',
+    ];
+
+    public function testNoInputShadowsAFilterCheckbox()
+    {
+        foreach ($this->templates as $template) {
+            $markup = file_get_contents(__DIR__ . '/../../../views/templates/admin/' . $template);
+            $this->assertNotFalse($markup, sprintf('Could not read %s', $template));
+
+            $checkboxes = $this->inputNamesOfType($markup, 'checkbox');
+            // Without this the intersection below is trivially empty whenever the markup changes
+            // shape enough to stop matching, and the test would pass while checking nothing.
+            $this->assertNotEmpty(
+                $checkboxes,
+                sprintf('No checkbox found in %s - the parsing needs updating.', $template)
+            );
+
+            $shadowed = array_values(array_intersect(
+                $checkboxes,
+                $this->inputNamesExcludingType($markup, 'checkbox')
+            ));
+
+            $this->assertSame(
+                [],
+                $shadowed,
+                sprintf(
+                    'In %s these names belong to a filter checkbox and to another input as well, so the '
+                    . 'filter is always submitted and can never be turned off: %s',
+                    $template,
+                    implode(', ', $shadowed)
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $markup
+     * @param string $type
+     *
+     * @return string[]
+     */
+    private function inputNamesOfType($markup, $type)
+    {
+        return $this->collectNames($markup, $type, true);
+    }
+
+    /**
+     * @param string $markup
+     * @param string $type
+     *
+     * @return string[]
+     */
+    private function inputNamesExcludingType($markup, $type)
+    {
+        return $this->collectNames($markup, $type, false);
+    }
+
+    /**
+     * Attribute order differs between the hand-written rows and the generated ones, so `name` and
+     * `type` are read independently of each other rather than with one combined pattern.
+     *
+     * @param string $markup
+     * @param string $type
+     * @param bool $keepMatchingType
+     *
+     * @return string[]
+     */
+    private function collectNames($markup, $type, $keepMatchingType)
+    {
+        if (!preg_match_all('#<input\b[^>]*>#i', $markup, $tags)) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($tags[0] as $tag) {
+            if (!preg_match('#\bname="([^"]+)"#i', $tag, $name)) {
+                continue;
+            }
+            preg_match('#\btype="([^"]+)"#i', $tag, $found);
+            $isType = isset($found[1]) && strtolower($found[1]) === $type;
+            if ($isType === $keepMatchingType) {
+                $names[] = $name[1];
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+}

--- a/views/templates/admin/add.tpl
+++ b/views/templates/admin/add.tpl
@@ -135,7 +135,7 @@
                 <div class="col-lg-3 pull-right">
                   <label class="control-label col-lg-6">{l s='Filter style:' d='Modules.Facetedsearch.Admin'}</label>
                   <div class="col-lg-6">
-                    <input type="hidden" name="layered_selection_extras" value="0">
+                    <input type="hidden" name="layered_selection_extras_filter_type" value="0">
                     <p class="form-control-static">{l s='Checkbox' d='Modules.Facetedsearch.Admin'}</p>
                   </div>
                 </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `Ps_Facetedsearch::getContent()` decides which filters a template keeps from the `layered_selection_*` keys **present** in `$_POST`, never from their values - an unchecked checkbox submits nothing, which is what makes that work. `views/templates/admin/add.tpl:138` gave a hidden input the same `name` as the extras checkbox at `:118`, so the key was in every submission and the "Product extras" filter was stored as enabled even with the switch off, on every newly created filter template. The two sliders in the same file already spell it correctly (`..._weight_slider_filter_type`, `..._price_slider_filter_type`); the `_filter_type` suffix is simply missing here.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Found while investigating PrestaShop/PrestaShop#35165.
| How to test?      | Create a new filter template with every switch off and save it. Before this change the stored template still contains `layered_selection_extras` and the extras filter shows as enabled; after it the template is empty. `tests/php/FacetedSearch/AdminFilterFormInputNamesTest.php` fails on the base branch.
| Sponsor company   |

## Root cause

`ps_facetedsearch.php:655-661`:

```php
foreach (array_keys($_POST) as $key) {
    if (!preg_match('~^(?P<key>layered_selection_.*)(?<!_filter_)(?<!type)(?<!show_limit)$~', $key, $matches)) {
        continue;
    }
    $filterValues[$matches['key']] = [
        'filter_type' => (int) Tools::getValue($matches['key'] . '_filter_type', 0),
        'filter_show_limit' => (int) Tools::getValue($matches['key'] . '_filter_show_limit', 0),
    ];
}
```

Presence is the whole signal. `add.tpl` then renders, inside the same `<form>` (lines 25-376):

```html
<input name="layered_selection_extras" id="layered_selection_extras" type="checkbox" />   <!-- :118 -->
...
<input type="hidden" name="layered_selection_extras" value="0">                            <!-- :138 -->
```

The `value="0"` never reaches the decision, so no state of the switch can express "off".

The intent is unambiguous from the two sibling rows, which do the same job correctly:

```html
<input type="hidden" name="layered_selection_weight_slider_filter_type" value="1">   <!-- :225 -->
<input type="hidden" name="layered_selection_price_slider_filter_type" value="1">    <!-- :249 -->
```

`0` is `Converter::WIDGET_TYPE_CHECKBOX`, which is also what the save defaults to when the field is
absent, so restoring the suffix changes nothing except removing the collision.

`view.tpl` - the template used when editing an existing filter template
(`ps_facetedsearch.php:890-892`) - is unaffected: it builds its rows from `getDefaultFilters()` and emits
the style as `<select name="{$filterId}_filter_type">`, with nothing at all for sliders.

## Measured

PrestaShop 9.2.0, module at `dev` (5.0.0). The save handler was replayed with the `$_POST` a browser sends
when **every switch is off** - no `layered_selection_*` checkbox at all, only the three hidden inputs
`add.tpl` emits - and the stored `ps_layered_filter.filters` was read back:

```
add.tpl as shipped   filters persisted with every switch OFF: layered_selection_extras
with this change     filters persisted with every switch OFF: (none)
```

## Test

`tests/php/FacetedSearch/AdminFilterFormInputNamesTest.php` parses `add.tpl` and `view.tpl` and asserts
that no input name belongs both to a filter checkbox and to some other input in the same file, which is
the invariant the presence-based save depends on. It asserts the checkbox list is non-empty first, so it
cannot pass by matching nothing.

RED on the base branch, with the failure naming the filter:

```
In add.tpl these names belong to a filter checkbox and to another input as well, so the filter is
always submitted and can never be turned off: layered_selection_extras
```

Full suite after the change: `OK (124 tests, 1084 assertions)` on PHPUnit 5.7 / PHP 7.4, php-cs-fixer clean.

## Deliberately not done

`add.tpl` hard-codes the seven built-in filter rows while `view.tpl` generates the same list from
`getDefaultFilters()`, and that duplication is what let the two drift apart. Collapsing `add.tpl` onto the
same loop would remove the class, but it is a refactor with visible consequences - the two lists are in a
different order, and the loop would give the extras row a style select it does not have today - so it does
not belong in a bug fix. Worth a separate PR if the maintainers want it.

One harmless divergence found while checking that: `add.tpl` submits `filter_type = 1` for the two sliders
while `view.tpl` submits nothing, so re-saving a template from the edit form rewrites those to `0`. It has
no effect - `src/Filters/Block.php:238` and `:326` hard-code `filter_type => Converter::WIDGET_TYPE_SLIDER`
for price and weight and ignore the stored value.
