### PR TITLE
Bump version to 5.1.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facetedsearch</name>
     <displayName><![CDATA[Faceted search]]></displayName>
-    <version><![CDATA[5.0.0]]></version>
+    <version><![CDATA[5.1.0]]></version>
     <description><![CDATA[Displays a block allowing multiple filters.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -97,7 +97,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
     {
         $this->name = 'ps_facetedsearch';
         $this->tab = 'front_office_features';
-        $this->version = '5.0.0';
+        $this->version = '5.1.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Bump the module version from 5.0.0 to 5.1.0 in `ps_facetedsearch.php` and `config.xml`, ahead of the 5.1.0 release.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Install or upgrade the module and check that Back Office > Modules lists Faceted search in 5.1.0.
| Sponsor company   | @PrestaShopCorp

Required before merging PrestaShop/ps_facetedsearch#1324, which brings `dev` into `master` for the release: both files are still on 5.0.0, so the release would otherwise ship the previous version number.

Only the version line changes, `ps_versions_compliancy` already declares 8.2.0 as the minimum since the 5.0.0 bump.
