### PR TITLE
Fix: broader filter template silently overrides narrower templates' filters on shared categories

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1283,9 +1283,15 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         // Get data for all filter templates in the database
         $templates = $this->getDatabase()->executeS('SELECT * FROM ' . _DB_PREFIX_ . 'layered_filter ORDER BY date_add DESC');
 
-        // We will keep track of pages categories where filter was already set, so we don't have multiple
-        // filters for the same category and shop.
+        // We will keep track of which (shop, controller, category, filter) combinations were already
+        // set by a more recently created template, so several templates covering the same category
+        // contribute their distinct filters together (union) instead of one template silently
+        // replacing every other template's filters for that category.
         $alreadyAssigned = [];
+
+        // Running filter position per shop/controller/category, shared across every template that
+        // contributes filters to it (so positions stay sequential instead of restarting per template).
+        $positions = [];
 
         // Clear cache
         $this->invalidateLayeredFilterBlockCache();
@@ -1319,15 +1325,10 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                     $categories = ($controller == 'category' ? $data['categories'] : [0]);
 
                     foreach ($categories as $idCategory) {
-                        $n = 0;
-
-                        // Make unique job name and check if already generated something for this scenario
-                        // If yes, skip it, otherwise note this info for next time
-                        $jobName = $controller . '-' . $idCategory;
-                        if (in_array($jobName, $alreadyAssigned[$idShop])) {
-                            continue;
+                        $categoryJob = $controller . '-' . $idCategory;
+                        if (!isset($positions[$idShop][$categoryJob])) {
+                            $positions[$idShop][$categoryJob] = 0;
                         }
-                        $alreadyAssigned[$idShop][] = $jobName;
 
                         foreach ($data as $key => $value) {
                             // The template contains some other data than filters, so we clean it up a bit
@@ -1336,9 +1337,21 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
                                 continue;
                             }
 
+                            // Each individual filter on a given shop/controller/category is owned by
+                            // exactly one template - the most recently created one that enables it - so
+                            // a same-filter clash still resolves deterministically. Different filters
+                            // contributed by different templates for the same category are all kept,
+                            // instead of the first template processed excluding every other template's
+                            // filters for the whole category.
+                            $jobName = $categoryJob . '-' . $key;
+                            if (isset($alreadyAssigned[$idShop][$jobName])) {
+                                continue;
+                            }
+                            $alreadyAssigned[$idShop][$jobName] = true;
+
                             $type = $value['filter_type'];
                             $limit = $value['filter_show_limit'];
-                            ++$n;
+                            $n = ++$positions[$idShop][$categoryJob];
 
                             if ($key == 'layered_selection_stock') {
                                 $sqlInsert .= '(' . (int) $idCategory . ', \'' . $controller . '\', ' . (int) $idShop . ', NULL,\'availability\',' . (int) $n . ', ' . (int) $limit . ', ' . (int) $type . '),';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `buildLayeredCategories()` rebuilds the `layered_category` table from every filter template, but it deduplicated per `(shop, controller, category)`: whichever template was processed first (most recently *created*, per `date_add DESC`) claimed the whole category, and any other template covering that same category was skipped entirely for it - no merge, no confirmation, nothing surfaced in the admin UI. In practice, re-saving a broadly-scoped template (e.g. the default one, which commonly spans many/all categories) silently wipes out a more specific template's filters for every category they both cover, with only a generic "was updated successfully" message. This PR changes the dedup key from `(shop, controller, category)` to `(shop, controller, category, filter)`, so templates that cover the same category now contribute their *distinct* filters together (union) instead of one excluding the other. A genuine clash on the exact same filter (e.g. two templates both enabling the price slider for the same category) still resolves deterministically to the most recently created template - same tie-break as before, just scoped to that one filter instead of the whole category. Filter position numbering is now tracked per `(shop, controller, category)` across all contributing templates so positions stay sequential instead of restarting at each template.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A (found during manual testing, no existing issue)
| How to test?      | 1. Create template A scoped to category "Shoes" with only a Size (attribute group) filter enabled. 2. Create/edit template B (e.g. the "Default" template) scoped to include "Shoes" among its categories, with only the Manufacturer filter enabled. 3. Save B. 4. Visit the "Shoes" category page. Before this fix: only template B's filters show (Manufacturer), template A's Size filter silently disappears. After this fix: both the Size and Manufacturer filters show on the category page.
| Sponsor company   | N/A

Discovered while investigating why editing and re-saving a broad template (without even changing its scope) could make more specific templates stop having any visible effect on their categories.