### PR TITLE
Fix PHPStan 2 findings on the develop matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2.5",
         "doctrine/collections": "^1.4"
     },
     "require-dev": {
@@ -20,7 +20,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.1.0"
+            "php": "7.2.5"
         },
         "preferred-install": "dist",
         "prepend-autoloader": false

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1a85a1b48d3d265b9c0561187c98e62",
+    "content-hash": "10a2ae192a165875b4d2c496dd7606b9",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -3124,11 +3124,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.2.5"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.1.0"
+        "php": "7.2.5"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1213,7 +1213,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 }
 
                 // Attribute filter
-                if (is_array($attributeGroupsById) && count($attributeGroupsById) > 0) {
+                if (count($attributeGroupsById) > 0) {
                     foreach (array_keys($a) as $kAttribute) {
                         if (!isset($doneCategories[(int) $idCategory]['a' . (int) $attributeGroupsById[(int) $kAttribute]])) {
                             $filterData['layered_selection_ag_' . (int) $attributeGroupsById[(int) $kAttribute]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];
@@ -1224,7 +1224,7 @@ class Ps_Facetedsearch extends Module implements WidgetInterface
                 }
 
                 // Features filter
-                if (is_array($featuresById) && count($featuresById) > 0) {
+                if (count($featuresById) > 0) {
                     foreach (array_keys($f) as $kFeature) {
                         if (!isset($doneCategories[(int) $idCategory]['f' . (int) $featuresById[(int) $kFeature]])) {
                             $filterData['layered_selection_feat_' . (int) $featuresById[(int) $kFeature]] = ['filter_type' => Converter::WIDGET_TYPE_CHECKBOX, 'filter_show_limit' => 0];

--- a/src/Adapter/MySQL.php
+++ b/src/Adapter/MySQL.php
@@ -533,7 +533,7 @@ class MySQL extends AbstractAdapter
         // query: products with zero or less quantity and not available to order go to the end
         $byOOPS = str_replace(
             [':byOutOfStockLast', ':field', ':value', ':direction'],
-            [$byOutOfStockLast, $computedField, $computedValue, $computedDirection],
+            [$byOutOfStockLast, $computedField, (string) $computedValue, $computedDirection],
             ':byOutOfStockLast AND FIELD(:field, :value) :direction'
         );
 

--- a/src/Product/CoreSearchBackport.php
+++ b/src/Product/CoreSearchBackport.php
@@ -390,7 +390,7 @@ class CoreSearchBackport
         }
 
         $sqlScore = '';
-        if (!empty($scoreArray) && is_array($scoreArray)) {
+        if (!empty($scoreArray)) {
             $sqlScore = ',( ' .
                 'SELECT SUM(weight) ' .
                 'FROM ' . _DB_PREFIX_ . 'search_word sw ' .

--- a/tests/php/phpstan/phpstan-develop.neon
+++ b/tests/php/phpstan/phpstan-develop.neon
@@ -1,2 +1,9 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
+
+parameters:
+	# PHPStan 2 derives the analysed language level from composer.json ("php": ">=7.1").
+	# Under PHP 7.1 semantics, the native "mixed" type used by Symfony 7 is parsed as a
+	# class name, which reports Symfony\Component\Validator\mixed instead of mixed.
+	# The develop matrix only ever runs on PHP 8.1 and 8.5, so pin the level accordingly.
+	phpVersion: 80100

--- a/tests/php/phpstan/phpstan-develop.neon
+++ b/tests/php/phpstan/phpstan-develop.neon
@@ -2,8 +2,12 @@ includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
 
 parameters:
-	# PHPStan 2 derives the analysed language level from composer.json ("php": ">=7.1").
-	# Under PHP 7.1 semantics, the native "mixed" type used by Symfony 7 is parsed as a
-	# class name, which reports Symfony\Component\Validator\mixed instead of mixed.
-	# The develop matrix only ever runs on PHP 8.1 and 8.5, so pin the level accordingly.
+	# PHPStan takes the PHP syntax level it parses with from the platform declaration,
+	# config.platform.php in composer.json (7.1.0 here) plus platform-overrides in
+	# composer.lock. Under 7.x semantics the native "mixed" type used by Symfony 7 is
+	# parsed as a class name, which reports Symfony\Component\Validator\mixed instead
+	# of mixed. "mixed" only became a type in PHP 8.0, so raising the platform floor
+	# within 7.x does not help, and 8.0 is not reachable while phpunit ~5.7 caps the
+	# dev dependencies below PHP 8. The develop matrix only ever runs on PHP 8.1 and
+	# 8.5, so pin the analysed level to what the job actually executes.
 	phpVersion: 80100

--- a/tests/php/phpstan/phpstan-develop.neon
+++ b/tests/php/phpstan/phpstan-develop.neon
@@ -3,11 +3,11 @@ includes:
 
 parameters:
 	# PHPStan takes the PHP syntax level it parses with from the platform declaration,
-	# config.platform.php in composer.json (7.1.0 here) plus platform-overrides in
+	# config.platform.php in composer.json (7.2.5 here) plus platform-overrides in
 	# composer.lock. Under 7.x semantics the native "mixed" type used by Symfony 7 is
 	# parsed as a class name, which reports Symfony\Component\Validator\mixed instead
-	# of mixed. "mixed" only became a type in PHP 8.0, so raising the platform floor
-	# within 7.x does not help, and 8.0 is not reachable while phpunit ~5.7 caps the
-	# dev dependencies below PHP 8. The develop matrix only ever runs on PHP 8.1 and
-	# 8.5, so pin the analysed level to what the job actually executes.
+	# of mixed. "mixed" only became a type in PHP 8.0, so no 7.x floor removes the
+	# findings, and 8.0 is not reachable while phpunit ~5.7 caps the dev dependencies
+	# below PHP 8. The develop matrix only ever runs on PHP 8.1 and 8.5, so pin the
+	# analysed level to what the job actually executes.
 	phpVersion: 80100


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Fix the PHPStan findings that appeared on the `develop` matrix after PrestaShop moved from PHPStan 1.x to 2.x, and align the module's composer PHP floor on the oldest PrestaShop it supports.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | The two `PHPStan (develop, 8.1)` and `(develop, 8.5)` jobs must turn green, and every other PHPStan job plus PHPUnit must stay green.
| Sponsor company   | @PrestaShopCorp

### Why the CI turned red without the module changing

The workflow runs `../../vendor/bin/phpstan`, so the binary comes from the analysed PrestaShop branch. `develop` moved from PHPStan 1.x to 2.2 with PrestaShop/PrestaShop#42252, merged on 2026-09-04, and gained `phpstan/phpstan-symfony`.

Same module commit `1bc7c00`, two runs: green on 2026-08-29 with phpstan 1.12.12, red on 2026-09-08 with phpstan 2.2.12. The `9.2.x` matrix runs on the same PHP versions and stays green, since PrestaShop 9.2 still ships phpstan `^1.9.3`.

### Three real findings

- `ps_facetedsearch.php` lines 1216 and 1227, and `src/Product/CoreSearchBackport.php` line 393: `is_array()` on a value PHPStan 2 now infers as an array, so the condition is always true and is dropped.
- `src/Adapter/MySQL.php` line 536: `str_replace()` received an `int` inside an `array<string>`, now cast.

### Five findings that are an artefact, fixed by configuration

The remaining errors expected a type called `Symfony\Component\Validator\mixed`, which does not exist: it is the native `mixed` parsed as a class name, which only happens when the analysis assumes PHP below 8.0.

PHPStan takes the syntax level it parses with from the **platform** declaration, `config.platform.php` in `composer.json` plus `platform-overrides` in `composer.lock`. `require.php` is not read. The `develop` matrix only ever runs on PHP 8.1 and 8.5, so `phpVersion` is pinned in `tests/php/phpstan/phpstan-develop.neon` rather than rewriting the `UrlSegment` constraint and its four callers for a cause that is not in the module.

Raising the platform floor is **not** an alternative fix, and this was measured rather than assumed. On a branch carrying this PR without the `phpVersion` line and with the floor at `7.2.5`, the two `develop` jobs still fail with the same five findings while every other job stays green. `mixed` only became a native type in PHP 8.0, so no 7.x value removes them, and 8.0 is not reachable: `composer update --lock` refuses it because `phpunit/phpunit ~5.7` caps the dev dependencies below PHP 8.

### Composer PHP floor aligned on 7.2.5

Separately, `require.php` and `config.platform.php` both declared `>=7.1`, below the PHP floor of the oldest PrestaShop the module supports: `ps_versions_compliancy` min is `8.2.0` and PrestaShop 8.2 requires `>=7.2.5`. Nothing exercised 7.1 either, the syntax checker starts at 7.2 and PHPUnit runs on 7.4.

So `7.2.5` is simply the truthful value, it is the `PHP 7.2 to 8.5` target of PrestaShop/PrestaShop#41648, and it changes nothing for shops. The `composer.lock` diff is limited to `content-hash` and the two platform values.

### Note

`tests/php/phpstan/phpstan.neon` carries text accidentally pasted from the GitHub review UI on its first comment line. Harmless, not touched here to keep the diff focused.
