### PR TITLE
Stop one bad filter template from wiping every shop's facets

### DIFF
--- a/ps_facetedsearch.php
+++ b/ps_facetedsearch.php
@@ -1290,12 +1290,35 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
         // Clear cache
         $this->invalidateLayeredFilterBlockCache();
 
-        // Remove all previous data from layered_category
-        $this->getDatabase()->execute('TRUNCATE ' . _DB_PREFIX_ . 'layered_category');
-
-        // If no filter templates are defined, nothing else to do here
+        // If no filter templates are defined, nothing else to do here. WHY this check moved ahead of any
+        // delete: with zero templates there's nothing to rebuild, so previously-built data (however it got
+        // there) is left as-is rather than wiped for no replacement.
         if (!count($templates)) {
             return true;
+        }
+
+        // WHY per-shop, not one global TRUNCATE: a shop's filters table only gets cleared once we know we
+        // have a template we can actually read for it. A single corrupt `filters` blob on ANY template used
+        // to wipe every shop's facets via one unconditional TRUNCATE, then silently fail to repopulate the
+        // rest of the loop for that template - on a multi-shop install, one bad template took every shop's
+        // navigation down at once, and each affected shop had to wait for the next full, valid rebuild
+        // before facets came back. Shops whose own template still unserializes correctly now keep working
+        // regardless of what happens to someone else's.
+        $shopIdsWithValidTemplate = [];
+        foreach ($templates as $filterTemplate) {
+            $data = Tools::unSerialize($filterTemplate['filters']);
+            if (!is_array($data) || !isset($data['shop_list']) || !is_array($data['shop_list'])) {
+                continue;
+            }
+            foreach ($data['shop_list'] as $idShop) {
+                $shopIdsWithValidTemplate[(int) $idShop] = true;
+            }
+        }
+
+        if (!empty($shopIdsWithValidTemplate)) {
+            $this->getDatabase()->execute(
+                'DELETE FROM ' . _DB_PREFIX_ . 'layered_category WHERE id_shop IN (' . implode(',', array_keys($shopIdsWithValidTemplate)) . ')'
+            );
         }
 
         // We will insert our queries by batches of hundred queries
@@ -1305,8 +1328,13 @@ VALUES(' . $last_id . ', ' . (int) $idShop . ')');
 
         // Now we will loop through each filter template
         foreach ($templates as $filterTemplate) {
-            // We will get it's data and convert it into array
+            // We will get it's data and convert it into array. WHY re-decoded here rather than reusing the
+            // pass above: that pass only needed shop_list to decide what's safe to delete: this one needs
+            // the full structure, and a template that fails the same way is skipped the same way.
             $data = Tools::unSerialize($filterTemplate['filters']);
+            if (!is_array($data) || !isset($data['shop_list'], $data['controllers']) || !is_array($data['shop_list']) || !is_array($data['controllers'])) {
+                continue;
+            }
             foreach ($data['shop_list'] as $idShop) {
                 if (!isset($alreadyAssigned[$idShop])) {
                     $alreadyAssigned[$idShop] = [];

--- a/tests/php/FacetedSearch/BuildLayeredCategoriesTest.php
+++ b/tests/php/FacetedSearch/BuildLayeredCategoriesTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\FacetedSearch\Tests;
+
+use Db;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Ps_Facetedsearch;
+use Tools;
+
+/**
+ * WHY this test exists: buildLayeredCategories() used to TRUNCATE the whole layered_category table
+ * unconditionally, then loop through every filter template to repopulate it. On a multi-shop install, one
+ * template with a `filters` blob that fails to unserialize left every OTHER shop's facets wiped with
+ * nothing to replace them, until the next fully-successful rebuild. These tests pin the fixed behaviour:
+ * a shop is only cleared once we've confirmed we can read a template that covers it.
+ */
+class BuildLayeredCategoriesTest extends MockeryTestCase
+{
+    private $module;
+    private $dbMock;
+
+    protected function setUp()
+    {
+        $this->dbMock = Mockery::mock(Db::class);
+        $this->module = Mockery::mock(Ps_Facetedsearch::class)->makePartial();
+        $this->module->shouldReceive('getDatabase')->andReturn($this->dbMock);
+        $this->module->shouldReceive('invalidateLayeredFilterBlockCache')->andReturn(true);
+
+        // WHY: Tools is proxied to a mock in this test suite (see MockProxy.php) rather than being the real
+        // PrestaShop\Tools class, so Tools::unSerialize must be told what to return per test.
+        $toolsMock = Mockery::mock();
+        $toolsMock->shouldReceive('unSerialize')
+            ->andReturnUsing(function ($value) {
+                return @unserialize($value);
+            });
+        Tools::setStaticExpectations($toolsMock);
+    }
+
+    private function validTemplateRow(array $shopList, int $idCategory = 42)
+    {
+        return [
+            'filters' => serialize([
+                'shop_list' => $shopList,
+                'controllers' => ['category'],
+                'categories' => [$idCategory],
+                'layered_selection_manufacturer' => [
+                    'filter_type' => 0,
+                    'filter_show_limit' => 0,
+                ],
+            ]),
+        ];
+    }
+
+    public function testAllValidTemplatesClearOnlyTheShopsTheyCover()
+    {
+        $templates = [
+            $this->validTemplateRow([1]),
+            $this->validTemplateRow([13]),
+        ];
+
+        $this->dbMock->shouldReceive('executeS')
+            ->once()
+            ->andReturn($templates);
+
+        // The only DELETE issued must be scoped to exactly the shops covered by valid templates (1 and 13),
+        // and must NOT be an unscoped TRUNCATE.
+        $this->dbMock->shouldReceive('execute')
+            ->once()
+            ->with(Mockery::on(function ($sql) {
+                return strpos($sql, 'DELETE FROM') !== false
+                    && strpos($sql, 'TRUNCATE') === false
+                    && strpos($sql, 'id_shop IN (1,13)') !== false;
+            }))
+            ->andReturn(true);
+
+        // The INSERT batch (both templates are valid, so both get repopulated).
+        $this->dbMock->shouldReceive('execute')
+            ->once()
+            ->with(Mockery::on(function ($sql) {
+                return strpos($sql, 'INSERT INTO') !== false;
+            }))
+            ->andReturn(true);
+
+        $this->module->buildLayeredCategories();
+    }
+
+    public function testOneCorruptTemplateDoesNotTouchOtherShopsData()
+    {
+        $corruptRow = ['filters' => 'this is not valid serialized php'];
+        $validRow = $this->validTemplateRow([13]);
+
+        $this->dbMock->shouldReceive('executeS')
+            ->once()
+            ->andReturn([$corruptRow, $validRow]);
+
+        // Only shop 13 (the shop covered by the VALID template) may be cleared. Shop 1, or any other shop
+        // that might have been named inside the corrupt blob had it parsed, must never appear here, and
+        // there must be no unscoped TRUNCATE.
+        $this->dbMock->shouldReceive('execute')
+            ->once()
+            ->with(Mockery::on(function ($sql) {
+                return strpos($sql, 'DELETE FROM') !== false
+                    && strpos($sql, 'TRUNCATE') === false
+                    && strpos($sql, 'id_shop IN (13)') !== false;
+            }))
+            ->andReturn(true);
+
+        // Repopulation still happens for the one template that IS readable.
+        $this->dbMock->shouldReceive('execute')
+            ->once()
+            ->with(Mockery::on(function ($sql) {
+                return strpos($sql, 'INSERT INTO') !== false;
+            }))
+            ->andReturn(true);
+
+        $this->module->buildLayeredCategories();
+    }
+
+    public function testEveryTemplateCorruptDeletesNothing()
+    {
+        $this->dbMock->shouldReceive('executeS')
+            ->once()
+            ->andReturn([
+                ['filters' => 'garbage'],
+                ['filters' => 'also garbage'],
+            ]);
+
+        // No shop's template could be read, so nothing is deleted and nothing is inserted: whatever was
+        // already in layered_category for every shop is left exactly as it was.
+        $this->dbMock->shouldNotReceive('execute');
+
+        $this->module->buildLayeredCategories();
+    }
+
+    public function testNoTemplatesAtAllDeletesNothing()
+    {
+        $this->dbMock->shouldReceive('executeS')
+            ->once()
+            ->andReturn([]);
+
+        $this->dbMock->shouldNotReceive('execute');
+
+        $this->assertTrue($this->module->buildLayeredCategories());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `buildLayeredCategories()` clears `layered_category` with one unconditional `TRUNCATE` before rebuilding it from the saved filter templates. If any single template's serialized `filters` blob does not decode into the expected shape, the rebuild fails or produces nothing for that template, but the truncate has already removed every other shop's rows. On a multi-shop install one unreadable template takes down faceted navigation for all shops until the next fully successful rebuild. The delete is now scoped to the shops that actually have a readable template.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | See below.
| Sponsor company   |

### The bug

`ps_facetedsearch.php`, `buildLayeredCategories()`:

```php
// Remove all previous data from layered_category
$this->getDatabase()->execute('TRUNCATE ' . _DB_PREFIX_ . 'layered_category');
```

The truncate is unconditional and global, and it happens before anything is known about whether the
templates can be read. The loop that repopulates the table then does `foreach ($data['shop_list'] ...)`
on the result of `Tools::unSerialize()` without checking it, so a template whose blob does not decode
into the expected array shape either raises an error mid-loop or contributes no rows. Either way the
rows for every other shop are already gone.

### The change

A first pass decodes every template and collects the shop ids from the ones that decode into the
expected shape. Only those shops are deleted, with `DELETE ... WHERE id_shop IN (...)`. If no template
decodes, or there are none at all, nothing is deleted, so existing data is left in place rather than
removed with no replacement. The rebuild loop skips a template it cannot read instead of iterating it.

The empty-templates early return moved above the delete for the same reason: with nothing to rebuild
from, wiping the table leaves the shop with no facets and no replacement.

### Tests

`tests/php/FacetedSearch/BuildLayeredCategoriesTest.php`, 4 cases:

| Case | Asserts |
|---|---|
| `testAllValidTemplatesClearOnlyTheShopsTheyCover` | scoped delete plus repopulation, normal path |
| `testOneCorruptTemplateDoesNotTouchOtherShopsData` | one corrupt and one valid template, only the valid template's shop is touched |
| `testEveryTemplateCorruptDeletesNothing` | no template decodes, nothing is deleted |
| `testNoTemplatesAtAllDeletesNothing` | no templates, nothing is deleted |

All four fail against the current code and pass with this change. The existing suite is unchanged at
127 tests, 1099 assertions.

### How to test

```
composer install
./vendor/bin/phpunit -c tests/php/phpunit.xml --filter BuildLayeredCategories
```

On a multi-shop install: save a filter template for shop A and one for shop B, confirm both front
offices show facets, then corrupt shop B's `filters` value in `ps_layered_filter` and trigger a rebuild
by saving any filter template. Before this change shop A's facets disappear as well; after it, shop A
is unaffected.

### CI

The two red `PHPStan (develop)` jobs are pre-existing on `dev` and are already being fixed by #1327.

The same job on `dev` (run 34258994387) emits the identical ten errors, in `createDefaultTemplate()`,
`src/Adapter/MySQL.php`, `src/Product/CoreSearchBackport.php` and the `UrlSegment` constraint classes.
Sorting both error lists and diffing them gives an empty set for errors introduced by this branch: the
two errors that are in `ps_facetedsearch.php` are at lines 1216 and 1227, in `createDefaultTemplate()`,
while this change is at 1290 and 1305 in `buildLayeredCategories()`.

#1327 is approved and its own `PHPStan (develop)` jobs pass, so this branch goes green once that lands
and this one is rebased. A `git merge` of #1327 into this branch reports no conflict, so the rebase is
clean. Not duplicating that fix here on purpose.
