### PR TITLE
CI: pin phpVersion on the three remaining 9.x PHPStan configurations

### DIFF
--- a/tests/php/phpstan/phpstan-9.0.3.neon
+++ b/tests/php/phpstan/phpstan-9.0.3.neon
@@ -1,2 +1,12 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
+
+parameters:
+	# PHPStan takes the PHP syntax level it parses with from the platform declaration,
+	# config.platform.php in composer.json (7.2.5 here) plus platform-overrides in
+	# composer.lock. Under 7.x semantics it cannot parse the 9.x core class
+	# PrestaShop\PrestaShop\Core\Context\LegacyControllerContext, which uses constructor
+	# property promotion, readonly and union types, and reports it as an unknown class
+	# wherever Context::$controller is used. This matrix only ever runs on PHP 8.1 and
+	# above, so pin the analysed level to what the job actually executes.
+	phpVersion: 80100

--- a/tests/php/phpstan/phpstan-9.1.5.neon
+++ b/tests/php/phpstan/phpstan-9.1.5.neon
@@ -1,2 +1,12 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
+
+parameters:
+	# PHPStan takes the PHP syntax level it parses with from the platform declaration,
+	# config.platform.php in composer.json (7.2.5 here) plus platform-overrides in
+	# composer.lock. Under 7.x semantics it cannot parse the 9.x core class
+	# PrestaShop\PrestaShop\Core\Context\LegacyControllerContext, which uses constructor
+	# property promotion, readonly and union types, and reports it as an unknown class
+	# wherever Context::$controller is used. This matrix only ever runs on PHP 8.1 and
+	# above, so pin the analysed level to what the job actually executes.
+	phpVersion: 80100

--- a/tests/php/phpstan/phpstan-9.2.x.neon
+++ b/tests/php/phpstan/phpstan-9.2.x.neon
@@ -1,2 +1,12 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
+
+parameters:
+	# PHPStan takes the PHP syntax level it parses with from the platform declaration,
+	# config.platform.php in composer.json (7.2.5 here) plus platform-overrides in
+	# composer.lock. Under 7.x semantics it cannot parse the 9.x core class
+	# PrestaShop\PrestaShop\Core\Context\LegacyControllerContext, which uses constructor
+	# property promotion, readonly and union types, and reports it as an unknown class
+	# wherever Context::$controller is used. This matrix only ever runs on PHP 8.1 and
+	# above, so pin the analysed level to what the job actually executes.
+	phpVersion: 80100

--- a/tests/php/phpstan/phpstan.neon
+++ b/tests/php/phpstan/phpstan.neon
@@ -1,2 +1,2 @@
-  # Base PHPStan configuration for the moduleExpand commentComment on line R2ResolvedCode has comments. Press enter to view.
-  # This file is included by version-specific configs 
+# Base PHPStan configuration for the module
+# This file is included by version-specific configs


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Pin `phpVersion: 80100` on the three PrestaShop 9.x PHPStan configurations that still lack it, matching what `phpstan-develop.neon` already does, and clean the GitHub UI text pasted into the base `phpstan.neon`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of #1331
| How to test?      | Every PHPStan job must stay green, the four 9.x ones and the two `8.2.x` ones which are deliberately untouched. No PHP file changes, so no functional testing is required.
| Sponsor company   | @PrestaShopCorp

### Why

`phpstan-develop.neon` pins `phpVersion: 80100`, added in #1327. The `9.0.3`, `9.1.5` and `9.2.x` configurations do not, so PHPStan analyses the 9.x core with the syntax level taken from the composer platform declaration, `7.2.5`.

Under 7.x semantics it cannot parse `PrestaShop\PrestaShop\Core\Context\LegacyControllerContext`, which uses constructor property promotion, `readonly` and union types, and reports it as an unknown class wherever `Context::$controller` is used:

```
Call to method getLanguages() on an unknown class
PrestaShop\PrestaShop\Core\Context\LegacyControllerContext.
```

That is the error `getAdminController()` in `src/Hook/AbstractHook.php` was working around, which only became visible when the same helper, carrying a native `: AdminController` return type instead of a phpdoc, threw a `TypeError` on the configuration page of `ps_wirepayment` on PrestaShop 9.x. See PrestaShop/ps_wirepayment#103. This module is not affected by that crash, PHP does not enforce a phpdoc.

The 9.x matrix only ever runs on PHP 8.1 and above, so pinning the analysed level to what the job actually executes is simply stating the truth.

### Why the helper stays for now

Its four call sites read `default_form_language`, a property declared on `AdminController` (`classes/controller/AdminController.php:51`) that does not exist on `LegacyControllerContext` at all. Removing the cast is not a mechanical substitution: it needs a decision on what that value should be on a page rendered by Symfony, where no equivalent is exposed. That is step 2 of #1331.

Worth noting that level 5 stays silent about it either way. Partially compatible unions are level 7 and nullable access is level 8. The same code at level 7 says it plainly:

```
Access to an undefined property AdminController|FrontController|
PrestaShop\PrestaShop\Core\Context\LegacyControllerContext::$default_form_language.
```

No user impact today: those four call sites are reached only through `displayAttributeGroupForm`, `displayAttributeForm`, `displayFeatureForm` and `displayFeatureValueForm`, legacy hooks no longer dispatched anywhere on 9.2 since the legacy Attributes and Features controllers were removed. On 8.2 the controller really is an `AdminController` and the property really is there.

### Measured

Locally against a PrestaShop 9.2.0 core, PHPStan 1.12.12, level 5, using the same `vendor/prestashop/php-dev-tools/phpstan/ps-module-extension.neon` merge the shared CI action performs. With this PR applied, `9.0.3`, `9.1.5`, `9.2.x` and `develop` all report no errors.

### Not in this PR

`tests/php/phpstan/phpstan-8.2.x.neon` is untouched. `LegacyControllerContext` does not exist on 8.2, where the union is `AdminController|FrontController|LegacyControllerBridgeInterface|null`, and that job runs on PHP 7.2, so pinning a PHP 8 syntax level there would be wrong.
