### PR TITLE
Carry the merchant's facet meta titles onto the facets

### DIFF
--- a/src/Filters/Converter.php
+++ b/src/Filters/Converter.php
@@ -50,6 +50,7 @@ class Converter
     const TYPE_WEIGHT = 'weight';
     const TYPE_EXTRAS = 'extras';
 
+    const PROPERTY_META_TITLE = 'meta_title';
     const PROPERTY_URL_NAME = 'url_name';
     const PROPERTY_COLOR = 'color';
     const PROPERTY_TEXTURE = 'texture';
@@ -130,11 +131,17 @@ class Converter
                         if (isset($filterBlock['url_name'])) {
                             $facet->setProperty(self::PROPERTY_URL_NAME, $filterBlock['url_name']);
                         }
+                        if (isset($filterBlock['meta_title'])) {
+                            $facet->setProperty(self::PROPERTY_META_TITLE, $filterBlock['meta_title']);
+                        }
                     } elseif ($filterBlock['type'] == self::TYPE_FEATURE) {
                         $type = 'feature';
                         $facet->setProperty(self::TYPE_FEATURE, $filterBlock['id_key']);
                         if (isset($filterBlock['url_name'])) {
                             $facet->setProperty(self::PROPERTY_URL_NAME, $filterBlock['url_name']);
+                        }
+                        if (isset($filterBlock['meta_title'])) {
+                            $facet->setProperty(self::PROPERTY_META_TITLE, $filterBlock['meta_title']);
                         }
                     }
 
@@ -154,6 +161,10 @@ class Converter
 
                         if (isset($filterArray['url_name'])) {
                             $filter->setProperty(self::PROPERTY_URL_NAME, $filterArray['url_name']);
+                        }
+
+                        if (isset($filterArray['meta_title'])) {
+                            $filter->setProperty(self::PROPERTY_META_TITLE, $filterArray['meta_title']);
                         }
 
                         if (array_key_exists('checked', $filterArray)) {

--- a/tests/php/FacetedSearch/Filters/ConverterTest.php
+++ b/tests/php/FacetedSearch/Filters/ConverterTest.php
@@ -154,6 +154,46 @@ class ConverterTest extends MockeryTestCase
     }
 
     /**
+     * The "Meta title" a merchant fills in on an attribute, an attribute group, a feature or a feature
+     * value is indexed and read back on every listing render, but the facets never carried it, so no
+     * theme or module could reach it.
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/23799
+     */
+    public function testGetFacetsFromFilterBlocksCarriesMetaTitles()
+    {
+        $facets = $this->converter->getFacetsFromFilterBlocks(
+            [
+                [
+                    'type_lite' => 'id_feature',
+                    'type' => Converter::TYPE_FEATURE,
+                    'id_key' => 5,
+                    'name' => 'Material',
+                    'url_name' => 'material',
+                    'meta_title' => 'Made of',
+                    'values' => [
+                        10 => ['name' => 'Steel', 'nbr' => '2', 'url_name' => 'steel', 'meta_title' => 'Stainless steel'],
+                        20 => ['name' => 'Glass', 'nbr' => '1', 'url_name' => 'glass', 'meta_title' => null],
+                    ],
+                    'filter_show_limit' => 0,
+                    'filter_type' => Converter::WIDGET_TYPE_CHECKBOX,
+                ],
+            ]
+        );
+
+        $this->assertSame('Made of', $facets[0]->getProperty(Converter::PROPERTY_META_TITLE));
+
+        $metaTitlesByLabel = [];
+        foreach ($facets[0]->getFilters() as $filter) {
+            $metaTitlesByLabel[$filter->getLabel()] = $filter->getProperty(Converter::PROPERTY_META_TITLE);
+        }
+
+        $this->assertSame('Stainless steel', $metaTitlesByLabel['Steel']);
+        // A value the merchant left empty must not shadow its label with an empty meta title.
+        $this->assertNull($metaTitlesByLabel['Glass']);
+    }
+
+    /**
      * Test different scenario for facets filter
      *
      * @dataProvider facetsProvider


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Attributes, attribute groups, features and feature values each carry a "Meta title" field whose help text promises "more detailed page titles". The value is saved, indexed and selected on every listing render, but `Converter` copied only `url_name` onto the `Facet` / `Filter` objects, so the meta title stopped there and no theme or module could reach it. It is now exposed as a facet property alongside `url_name`.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Refs PrestaShop/PrestaShop#23799
| How to test?      | See below.
| Sponsor company   |

### Why

`Catalog > Attributes` and `Catalog > Features` show a per-value "Meta title" input whose help text reads
"When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word
that best represents this attribute. By default, PrestaShop uses the attribute's name, but you can change
that setting using this field."

Nothing in the module produces a page title from it. The value round-trips through
`src/Hook/{Attribute,AttributeGroup,Feature,FeatureValue}.php`, is selected by
`src/Filters/DataAccessor.php` on every listing render, reaches the filter blocks in
`src/Filters/Block.php`, and is then dropped by `src/Filters/Converter.php`, which sets
`PROPERTY_URL_NAME` on the facets but has no equivalent for the meta title.

The behaviour existed in 1.6: `blocklayered.php` built `$meta_values` / `$title_values` from
`meta_title` and composed the category page title from them. The 1.7 rewrite kept the form field, the
help text and the storage, and lost the consumer.

### What it does

Adds `Converter::PROPERTY_META_TITLE` and sets it on the `Facet` (attribute groups and features) and on
each `Filter` (attribute values and feature values), mirroring how `PROPERTY_URL_NAME` is already
handled. `DataAccessor` already normalises an empty meta title to `NULL`, so the property appears only
when the merchant actually filled it in.

Nothing rendered changes by default. The point is that `{$listing.facets}` now carries the value, so a
theme or a module can compose the title the merchant was promised. Composing it in the module is the
remaining half and needs a product decision - see the issue.

### How to test

```
composer install
php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/php/phpunit.xml --filter ConverterTest
```

`testGetFacetsFromFilterBlocksCarriesMetaTitles` asserts the group-level and value-level properties and
that a value left empty stays absent rather than carrying a null. Removing just the three `setProperty`
calls (keeping the constant) fails it with "Failed asserting that null is identical to 'Made of'".

On a shop: set a Meta title on an attribute value, open a category, and read
`facets[].properties.meta_title` / `facets[].filters[].properties.meta_title` out of the listing
variables.
